### PR TITLE
Add stub type to CodeGenerator

### DIFF
--- a/CodeGenerator/Sources/CodeGenerator/AWSService.swift
+++ b/CodeGenerator/Sources/CodeGenerator/AWSService.swift
@@ -951,6 +951,8 @@ extension Shape {
             return "TimeStamp"
         case .enum:
             return name.toSwiftClassCase()
+        case .stub:
+            return name.toSwiftClassCase()
         }
     }
 

--- a/CodeGenerator/Sources/CodeGenerator/Models/API.swift
+++ b/CodeGenerator/Sources/CodeGenerator/Models/API.swift
@@ -384,6 +384,7 @@ class Shape: Decodable {
         case boolean
         case timestamp(TimeStampFormat)
         case `enum`(EnumType)
+        case stub
 
         // added so we can access enum type through keypaths
         var `enum`: EnumType? {

--- a/CodeGenerator/Sources/CodeGenerator/String.swift
+++ b/CodeGenerator/Sources/CodeGenerator/String.swift
@@ -84,7 +84,6 @@ extension String {
         }
 
         return self.replacingOccurrences(of: "-", with: "_")
-            .replacingOccurrences(of: ".", with: "")
             .camelCased()
             .upperFirst()
     }

--- a/CodeGenerator/Sources/CodeGenerator/patch.swift
+++ b/CodeGenerator/Sources/CodeGenerator/patch.swift
@@ -63,6 +63,10 @@ extension API {
         "IAM": [
             AddPatch(PatchKeyPath3(\.shapes["PolicySourceType"], \.type.enum, \.cases), value: "IAM Policy"),
         ],
+        "Lambda": [
+            AddDictionaryPatch(PatchKeyPath1(\.shapes), key: "SotoCore.Region", value: Shape(type: .stub, name: "SotoCore.Region")),
+            ReplacePatch(PatchKeyPath4(\.shapes["ListFunctionsRequest"], \.type.structure, \.members["MasterRegion"], \.shapeName), value: "SotoCore.Region", originalValue: "MasterRegion"),
+        ],
         "Route53": [
             RemovePatch(PatchKeyPath3(\.shapes["ListHealthChecksResponse"], \.type.structure, \.required), value: "Marker"),
             RemovePatch(PatchKeyPath3(\.shapes["ListHostedZonesResponse"], \.type.structure, \.required), value: "Marker"),
@@ -185,6 +189,8 @@ extension Shape.ShapeType: Equatable {
             if case .boolean = rhs { return true }
         case .enum:
             if case .enum = rhs { return true }
+        case .stub:
+            return false
         }
         return false
     }

--- a/Sources/Soto/Services/Lambda/Lambda_Shapes.swift
+++ b/Sources/Soto/Services/Lambda/Lambda_Shapes.swift
@@ -2055,11 +2055,11 @@ extension Lambda {
         /// Specify the pagination token that's returned by a previous request to retrieve the next page of results.
         public let marker: String?
         /// For Lambda@Edge functions, the AWS Region of the master function. For example, us-east-1 filters the list of functions to only include Lambda@Edge functions replicated from a master function in US East (N. Virginia). If specified, you must set FunctionVersion to ALL.
-        public let masterRegion: String?
+        public let masterRegion: SotoCore.Region?
         /// The maximum number of functions to return.
         public let maxItems: Int?
 
-        public init(functionVersion: FunctionVersion? = nil, marker: String? = nil, masterRegion: String? = nil, maxItems: Int? = nil) {
+        public init(functionVersion: FunctionVersion? = nil, marker: String? = nil, masterRegion: SotoCore.Region? = nil, maxItems: Int? = nil) {
             self.functionVersion = functionVersion
             self.marker = marker
             self.masterRegion = masterRegion
@@ -2067,7 +2067,6 @@ extension Lambda {
         }
 
         public func validate(name: String) throws {
-            try self.validate(self.masterRegion, name: "masterRegion", parent: name, pattern: "ALL|[a-z]{2}(-gov)?-[a-z]+-\\d{1}")
             try self.validate(self.maxItems, name: "maxItems", parent: name, max: 10000)
             try self.validate(self.maxItems, name: "maxItems", parent: name, min: 1)
         }


### PR DESCRIPTION
Add stub type to CodeGenerator that references type outside of generated code. 

Patch Lambda.ListFunctions to use SotoCore.Region for the masterRegion variable