### PR TITLE
Make DynamoDB.TransactWriteItem an enum

### DIFF
--- a/CodeGenerator/Sources/CodeGenerator/AWSService.swift
+++ b/CodeGenerator/Sources/CodeGenerator/AWSService.swift
@@ -226,6 +226,8 @@ extension AWSService {
         let payload: String?
         var payloadOptions: String?
         let namespace: String?
+        let isEncodable: Bool
+        let isDecodable: Bool
         let encoding: [EncodingPropertiesContext]
         let members: [MemberContext]
         let awsShapeMembers: [AWSShapeMemberContext]
@@ -830,6 +832,8 @@ extension AWSService {
             payload: shape.payload?.toSwiftLabelCase(),
             payloadOptions: shapePayloadOptions.count > 0 ? shapePayloadOptions.map { ".\($0)" }.joined(separator: ", ") : nil,
             namespace: shape.xmlNamespace?.uri,
+            isEncodable: shape.usedInInput,
+            isDecodable: shape.usedInOutput,
             encoding: encodingContexts,
             members: memberContexts,
             awsShapeMembers: awsShapeMemberContexts,

--- a/CodeGenerator/Sources/CodeGenerator/patch.swift
+++ b/CodeGenerator/Sources/CodeGenerator/patch.swift
@@ -39,6 +39,7 @@ extension API {
         ],
         "DynamoDB": [
             ReplacePatch(PatchKeyPath3(\.shapes["AttributeValue"], \.type.structure, \.isEnum), value: true, originalValue: false),
+            ReplacePatch(PatchKeyPath3(\.shapes["TransactWriteItem"], \.type.structure, \.isEnum), value: true, originalValue: false),
         ],
         "EC2": [
             ReplacePatch(PatchKeyPath3(\.shapes["PlatformValues"], \.type.enum, \.cases[0]), value: "windows", originalValue: "Windows"),

--- a/CodeGenerator/Templates/enumWithValues.stencil
+++ b/CodeGenerator/Templates/enumWithValues.stencil
@@ -19,7 +19,8 @@
 {%endfor %}
         case {{member.variable}}({{member.type}})
 {%endfor %}
-        
+{%if enumWithValues.isDecodable %}
+
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             guard container.allKeys.count == 1, let key = container.allKeys.first else {
@@ -37,7 +38,9 @@
 {%endfor %}
             }
         }
-        
+{%endif %}
+{%if enumWithValues.isEncodable %}
+
         public func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
             switch self {
@@ -47,7 +50,8 @@
 {%endfor %}
             }
         }
-        
+{%endif %}
+
 {# validate() function #}
 {%if enumWithValues.validation.count > 0 %}
         public func validate(name: String) throws {
@@ -90,8 +94,10 @@
                 try validate(value, name: "{{v.name}}", parent: name, {{req}}: {{var}})
 {%endfor %}
 {%endfor %}
+{%if enumWithValues.validation.count != enumWithValues.members.count %}
             default:
                 break
+{%endif %}
             }
         }
 

--- a/CodeGenerator/Templates/shapes.stencil
+++ b/CodeGenerator/Templates/shapes.stencil
@@ -26,11 +26,3 @@ extension {{name}} {
 {%endif %}
 {%endfor %}
 }
-{%for shape in shapes%}
-{%if shape.enumWithValues %}
-
-extension {{name}}.{{shape.enumWithValues.name}}: Equatable {
-{%include "enumEquatableExtension.stencil" shape %}
-}
-{%endif %}
-{%endfor %}

--- a/Sources/Soto/Extensions/DynamoDB/DynamoDB+Codable.swift
+++ b/Sources/Soto/Extensions/DynamoDB/DynamoDB+Codable.swift
@@ -310,3 +310,32 @@ extension DynamoDB {
         public let scannedCount: Int?
     }
 }
+
+extension DynamoDB.AttributeValue: Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case (.b(let lhs), .b(let rhs)):
+            return lhs == rhs
+        case (.bool(let lhs), .bool(let rhs)):
+            return lhs == rhs
+        case (.bs(let lhs), .bs(let rhs)):
+            return lhs == rhs
+        case (.l(let lhs), .l(let rhs)):
+            return lhs == rhs
+        case (.m(let lhs), .m(let rhs)):
+            return lhs == rhs
+        case (.n(let lhs), .n(let rhs)):
+            return lhs == rhs
+        case (.ns(let lhs), .ns(let rhs)):
+            return lhs == rhs
+        case (.null(let lhs), .null(let rhs)):
+            return lhs == rhs
+        case (.s(let lhs), .s(let rhs)):
+            return lhs == rhs
+        case (.ss(let lhs), .ss(let rhs)):
+            return lhs == rhs
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/Soto/Services/DynamoDB/DynamoDB_Shapes.swift
+++ b/Sources/Soto/Services/DynamoDB/DynamoDB_Shapes.swift
@@ -350,6 +350,51 @@ extension DynamoDB {
         }
     }
 
+    public enum TransactWriteItem: AWSEncodableShape {
+        /// A request to perform a check item operation.
+        case conditionCheck(ConditionCheck)
+        /// A request to perform a DeleteItem operation.
+        case delete(Delete)
+        /// A request to perform a PutItem operation.
+        case put(Put)
+        /// A request to perform an UpdateItem operation.
+        case update(Update)
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            switch self {
+            case .conditionCheck(let value):
+                try container.encode(value, forKey: .conditionCheck)
+            case .delete(let value):
+                try container.encode(value, forKey: .delete)
+            case .put(let value):
+                try container.encode(value, forKey: .put)
+            case .update(let value):
+                try container.encode(value, forKey: .update)
+            }
+        }
+
+        public func validate(name: String) throws {
+            switch self {
+            case .conditionCheck(let value):
+                try value.validate(name: "\(name).conditionCheck")
+            case .delete(let value):
+                try value.validate(name: "\(name).delete")
+            case .put(let value):
+                try value.validate(name: "\(name).put")
+            case .update(let value):
+                try value.validate(name: "\(name).update")
+            }
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case conditionCheck = "ConditionCheck"
+            case delete = "Delete"
+            case put = "Put"
+            case update = "Update"
+        }
+    }
+
     // MARK: Shapes
 
     public struct ArchivalSummary: AWSDecodableShape {
@@ -4120,38 +4165,6 @@ extension DynamoDB {
         }
     }
 
-    public struct TransactWriteItem: AWSEncodableShape {
-        /// A request to perform a check item operation.
-        public let conditionCheck: ConditionCheck?
-        /// A request to perform a DeleteItem operation.
-        public let delete: Delete?
-        /// A request to perform a PutItem operation.
-        public let put: Put?
-        /// A request to perform an UpdateItem operation.
-        public let update: Update?
-
-        public init(conditionCheck: ConditionCheck? = nil, delete: Delete? = nil, put: Put? = nil, update: Update? = nil) {
-            self.conditionCheck = conditionCheck
-            self.delete = delete
-            self.put = put
-            self.update = update
-        }
-
-        public func validate(name: String) throws {
-            try self.conditionCheck?.validate(name: "\(name).conditionCheck")
-            try self.delete?.validate(name: "\(name).delete")
-            try self.put?.validate(name: "\(name).put")
-            try self.update?.validate(name: "\(name).update")
-        }
-
-        private enum CodingKeys: String, CodingKey {
-            case conditionCheck = "ConditionCheck"
-            case delete = "Delete"
-            case put = "Put"
-            case update = "Update"
-        }
-    }
-
     public struct TransactWriteItemsInput: AWSEncodableShape {
         /// Providing a ClientRequestToken makes the call to TransactWriteItems idempotent, meaning that multiple identical calls have the same effect as one single call. Although multiple identical calls using the same client request token produce the same result on the server (no side effects), the responses to the calls might not be the same. If the ReturnConsumedCapacity&gt; parameter is set, then the initial TransactWriteItems call returns the amount of write capacity units consumed in making the changes. Subsequent TransactWriteItems calls with the same client token return the number of read capacity units consumed in reading the item. A client request token is valid for 10 minutes after the first request that uses it is completed. After 10 minutes, any request with the same client token is treated as a new request. Do not resubmit the same request with the same client token for more than 10 minutes, or the result might not be idempotent. If you submit a request with the same client token but a change in other parameters within the 10-minute idempotency window, DynamoDB returns an IdempotentParameterMismatch exception.
         public let clientRequestToken: String?
@@ -4810,35 +4823,6 @@ extension DynamoDB {
         private enum CodingKeys: String, CodingKey {
             case deleteRequest = "DeleteRequest"
             case putRequest = "PutRequest"
-        }
-    }
-}
-
-extension DynamoDB.AttributeValue: Equatable {
-    public static func == (lhs: Self, rhs: Self) -> Bool {
-        switch (lhs, rhs) {
-        case (.b(let lhs), .b(let rhs)):
-            return lhs == rhs
-        case (.bool(let lhs), .bool(let rhs)):
-            return lhs == rhs
-        case (.bs(let lhs), .bs(let rhs)):
-            return lhs == rhs
-        case (.l(let lhs), .l(let rhs)):
-            return lhs == rhs
-        case (.m(let lhs), .m(let rhs)):
-            return lhs == rhs
-        case (.n(let lhs), .n(let rhs)):
-            return lhs == rhs
-        case (.ns(let lhs), .ns(let rhs)):
-            return lhs == rhs
-        case (.null(let lhs), .null(let rhs)):
-            return lhs == rhs
-        case (.s(let lhs), .s(let rhs)):
-            return lhs == rhs
-        case (.ss(let lhs), .ss(let rhs)):
-            return lhs == rhs
-        default:
-            return false
         }
     }
 }

--- a/Tests/SotoTests/Services/DynamoDB/DynamoDBCodableTests.swift
+++ b/Tests/SotoTests/Services/DynamoDB/DynamoDBCodableTests.swift
@@ -99,7 +99,7 @@ final class DynamoDBCodableTests: XCTestCase {
                 return Self.dynamoDB.putItem(request)
             }
             .flatMap { _ -> EventLoopFuture<DynamoDB.GetItemCodableOutput<TestObject>> in
-                let request = DynamoDB.GetItemInput(key: ["id": .s(id)], tableName: tableName)
+                let request = DynamoDB.GetItemInput(consistentRead: true, key: ["id": .s(id)], tableName: tableName)
                 return Self.dynamoDB.getItem(request, type: TestObject.self)
             }
             .map { response -> Void in
@@ -141,7 +141,7 @@ final class DynamoDBCodableTests: XCTestCase {
                 return Self.dynamoDB.updateItem(request)
             }
             .flatMap { _ -> EventLoopFuture<DynamoDB.GetItemCodableOutput<TestObject>> in
-                let request = DynamoDB.GetItemInput(key: ["id": .s(id)], tableName: tableName)
+                let request = DynamoDB.GetItemInput(consistentRead: true, key: ["id": .s(id)], tableName: tableName)
                 return Self.dynamoDB.getItem(request, type: TestObject.self)
             }
             .map { response -> Void in
@@ -180,6 +180,7 @@ final class DynamoDBCodableTests: XCTestCase {
         }
         .flatMap { _ -> EventLoopFuture<DynamoDB.QueryCodableOutput<TestObject>> in
             let request = DynamoDB.QueryInput(
+                consistentRead: true,
                 expressionAttributeValues: [":id": .s("test"), ":version": .n("2")],
                 keyConditionExpression: "id = :id and version >= :version",
                 tableName: tableName
@@ -222,6 +223,7 @@ final class DynamoDBCodableTests: XCTestCase {
         }
         .flatMap { _ -> EventLoopFuture<Void> in
             let request = DynamoDB.QueryInput(
+                consistentRead: true,
                 expressionAttributeValues: [":id": .s("test"), ":version": .n("2")],
                 keyConditionExpression: "id = :id and version >= :version",
                 limit: 3,
@@ -266,7 +268,7 @@ final class DynamoDBCodableTests: XCTestCase {
             return EventLoopFuture.whenAllSucceed(futureResults, on: Self.dynamoDB.client.eventLoopGroup.next()).map { _ in }
         }
         .flatMap { _ -> EventLoopFuture<DynamoDB.ScanCodableOutput<TestObject>> in
-            let request = DynamoDB.ScanInput(expressionAttributeValues: [":message": .s("Message 2")], filterExpression: "message = :message", tableName: tableName)
+            let request = DynamoDB.ScanInput(consistentRead: true, expressionAttributeValues: [":message": .s("Message 2")], filterExpression: "message = :message", tableName: tableName)
             return Self.dynamoDB.scan(request, type: TestObject.self)
         }
         .map { response in

--- a/Tests/SotoTests/Services/DynamoDB/DynamoDBCodableTests.swift
+++ b/Tests/SotoTests/Services/DynamoDB/DynamoDBCodableTests.swift
@@ -36,7 +36,7 @@ final class DynamoDBCodableTests: XCTestCase {
             provisionedThroughput: .init(readCapacityUnits: 5, writeCapacityUnits: 5),
             tableName: name
         )
-        return Self.dynamoDB.createTable(input)
+        return Self.dynamoDB.createTable(input, logger: TestEnvironment.logger)
             .map { response in
                 XCTAssertEqual(response.tableDescription?.tableName, name)
                 return
@@ -59,7 +59,7 @@ final class DynamoDBCodableTests: XCTestCase {
         let promise = eventLoop.makePromise(of: Void.self)
         func waitForActiveTableInternal(waitTime: TimeAmount) {
             let scheduled = eventLoop.flatScheduleTask(in: waitTime) {
-                return Self.dynamoDB.describeTable(.init(tableName: name))
+                return Self.dynamoDB.describeTable(.init(tableName: name), logger: TestEnvironment.logger)
             }
             scheduled.futureResult.map { response in
                 if response.table?.tableStatus == .active {
@@ -75,7 +75,7 @@ final class DynamoDBCodableTests: XCTestCase {
 
     func deleteTable(name: String) -> EventLoopFuture<Void> {
         let input = DynamoDB.DeleteTableInput(tableName: name)
-        return Self.dynamoDB.deleteTable(input).map { _ in }
+        return Self.dynamoDB.deleteTable(input, logger: TestEnvironment.logger).map { _ in }
     }
 
     // MARK: Tests
@@ -96,11 +96,11 @@ final class DynamoDBCodableTests: XCTestCase {
         let response = self.createTable(name: tableName)
             .flatMap { _ -> EventLoopFuture<DynamoDB.PutItemOutput> in
                 let request = DynamoDB.PutItemCodableInput(item: test, tableName: tableName)
-                return Self.dynamoDB.putItem(request)
+                return Self.dynamoDB.putItem(request, logger: TestEnvironment.logger)
             }
             .flatMap { _ -> EventLoopFuture<DynamoDB.GetItemCodableOutput<TestObject>> in
                 let request = DynamoDB.GetItemInput(consistentRead: true, key: ["id": .s(id)], tableName: tableName)
-                return Self.dynamoDB.getItem(request, type: TestObject.self)
+                return Self.dynamoDB.getItem(request, type: TestObject.self, logger: TestEnvironment.logger)
             }
             .map { response -> Void in
                 XCTAssertEqual(test, response.item)
@@ -134,15 +134,15 @@ final class DynamoDBCodableTests: XCTestCase {
         let response = self.createTable(name: tableName)
             .flatMap { _ -> EventLoopFuture<DynamoDB.PutItemOutput> in
                 let request = DynamoDB.PutItemCodableInput(item: test, tableName: tableName)
-                return Self.dynamoDB.putItem(request)
+                return Self.dynamoDB.putItem(request, logger: TestEnvironment.logger)
             }
             .flatMap { _ -> EventLoopFuture<DynamoDB.UpdateItemOutput> in
                 let request = DynamoDB.UpdateItemCodableInput(key: ["id"], tableName: tableName, updateItem: nameUpdate)
-                return Self.dynamoDB.updateItem(request)
+                return Self.dynamoDB.updateItem(request, logger: TestEnvironment.logger)
             }
             .flatMap { _ -> EventLoopFuture<DynamoDB.GetItemCodableOutput<TestObject>> in
                 let request = DynamoDB.GetItemInput(consistentRead: true, key: ["id": .s(id)], tableName: tableName)
-                return Self.dynamoDB.getItem(request, type: TestObject.self)
+                return Self.dynamoDB.getItem(request, type: TestObject.self, logger: TestEnvironment.logger)
             }
             .map { response -> Void in
                 XCTAssertEqual("David", response.item?.name)
@@ -175,7 +175,7 @@ final class DynamoDBCodableTests: XCTestCase {
             attributeDefinitions: [.init(attributeName: "id", attributeType: .s), .init(attributeName: "version", attributeType: .n)],
             keySchema: [.init(attributeName: "id", keyType: .hash), .init(attributeName: "version", keyType: .range)]
         ).flatMap { _ -> EventLoopFuture<Void> in
-            let futureResults: [EventLoopFuture<DynamoDB.PutItemOutput>] = testItems.map { Self.dynamoDB.putItem(.init(item: $0, tableName: tableName)) }
+            let futureResults: [EventLoopFuture<DynamoDB.PutItemOutput>] = testItems.map { Self.dynamoDB.putItem(.init(item: $0, tableName: tableName), logger: TestEnvironment.logger) }
             return EventLoopFuture.whenAllSucceed(futureResults, on: Self.dynamoDB.client.eventLoopGroup.next()).map { _ in }
         }
         .flatMap { _ -> EventLoopFuture<DynamoDB.QueryCodableOutput<TestObject>> in
@@ -185,7 +185,7 @@ final class DynamoDBCodableTests: XCTestCase {
                 keyConditionExpression: "id = :id and version >= :version",
                 tableName: tableName
             )
-            return Self.dynamoDB.query(request, type: TestObject.self)
+            return Self.dynamoDB.query(request, type: TestObject.self, logger: TestEnvironment.logger)
         }
         .map { response in
             XCTAssertEqual(testItems[1], response.items?[0])
@@ -218,7 +218,7 @@ final class DynamoDBCodableTests: XCTestCase {
             attributeDefinitions: [.init(attributeName: "id", attributeType: .s), .init(attributeName: "version", attributeType: .n)],
             keySchema: [.init(attributeName: "id", keyType: .hash), .init(attributeName: "version", keyType: .range)]
         ).flatMap { _ -> EventLoopFuture<Void> in
-            let futureResults: [EventLoopFuture<DynamoDB.PutItemOutput>] = testItems.map { Self.dynamoDB.putItem(.init(item: $0, tableName: tableName)) }
+            let futureResults: [EventLoopFuture<DynamoDB.PutItemOutput>] = testItems.map { Self.dynamoDB.putItem(.init(item: $0, tableName: tableName), logger: TestEnvironment.logger) }
             return EventLoopFuture.whenAllSucceed(futureResults, on: Self.dynamoDB.client.eventLoopGroup.next()).map { _ in }
         }
         .flatMap { _ -> EventLoopFuture<Void> in
@@ -229,7 +229,7 @@ final class DynamoDBCodableTests: XCTestCase {
                 limit: 3,
                 tableName: tableName
             )
-            return Self.dynamoDB.queryPaginator(request, type: TestObject.self) { response, eventLoop in
+            return Self.dynamoDB.queryPaginator(request, type: TestObject.self, logger: TestEnvironment.logger) { response, eventLoop in
                 results.append(contentsOf: response.items ?? [])
                 return eventLoop.makeSucceededFuture(true)
             }
@@ -264,12 +264,12 @@ final class DynamoDBCodableTests: XCTestCase {
             attributeDefinitions: [.init(attributeName: "id", attributeType: .s), .init(attributeName: "version", attributeType: .n)],
             keySchema: [.init(attributeName: "id", keyType: .hash), .init(attributeName: "version", keyType: .range)]
         ).flatMap { _ -> EventLoopFuture<Void> in
-            let futureResults: [EventLoopFuture<DynamoDB.PutItemOutput>] = testItems.map { Self.dynamoDB.putItem(.init(item: $0, tableName: tableName)) }
+            let futureResults: [EventLoopFuture<DynamoDB.PutItemOutput>] = testItems.map { Self.dynamoDB.putItem(.init(item: $0, tableName: tableName), logger: TestEnvironment.logger) }
             return EventLoopFuture.whenAllSucceed(futureResults, on: Self.dynamoDB.client.eventLoopGroup.next()).map { _ in }
         }
         .flatMap { _ -> EventLoopFuture<DynamoDB.ScanCodableOutput<TestObject>> in
             let request = DynamoDB.ScanInput(consistentRead: true, expressionAttributeValues: [":message": .s("Message 2")], filterExpression: "message = :message", tableName: tableName)
-            return Self.dynamoDB.scan(request, type: TestObject.self)
+            return Self.dynamoDB.scan(request, type: TestObject.self, logger: TestEnvironment.logger)
         }
         .map { response in
             XCTAssertEqual(testItems[1], response.items?[0])

--- a/Tests/SotoTests/Services/DynamoDB/DynamoDBTests.swift
+++ b/Tests/SotoTests/Services/DynamoDB/DynamoDBTests.swift
@@ -97,7 +97,7 @@ class DynamoDBTests: XCTestCase {
     }
 
     func getItem(tableName: String, keys: [String: String]) -> EventLoopFuture<DynamoDB.GetItemOutput> {
-        let input = DynamoDB.GetItemInput(key: keys.mapValues { DynamoDB.AttributeValue.s($0) }, tableName: tableName)
+        let input = DynamoDB.GetItemInput(consistentRead: true, key: keys.mapValues { DynamoDB.AttributeValue.s($0) }, tableName: tableName)
         return Self.dynamoDB.getItem(input)
     }
 

--- a/Tests/SotoTests/test.swift
+++ b/Tests/SotoTests/test.swift
@@ -60,4 +60,15 @@ struct TestEnvironment {
         let prefix = Environment["AWS_TEST_RESOURCE_PREFIX"] ?? ""
         return "soto-" + (prefix + function).filter { $0.isLetter || $0.isNumber }.lowercased()
     }
+
+    public static var logger: Logger = {
+        if let loggingLevel = Environment["AWS_LOG_LEVEL"] {
+            if let logLevel = Logger.Level(rawValue: loggingLevel.lowercased()) {
+                var logger = Logger(label: "soto")
+                logger.logLevel = logLevel
+                return logger
+            }
+        }
+        return AWSClient.loggingDisabled
+    }()
 }


### PR DESCRIPTION
Also moved the AttributeValue equatable conformance to the DynamoDB extension code as equatable conformance is not a given for enums so I've stopped generating this automatically.