### PR TITLE
Create Error classes as structs with private enum

### DIFF
--- a/CodeGenerator/Templates/error.stencil
+++ b/CodeGenerator/Templates/error.stencil
@@ -3,35 +3,44 @@
 import SotoCore
 
 /// Error enum for {{name}}
-public enum {{errorName}}: AWSErrorType {
+public struct {{errorName}}: AWSErrorType {
+    enum Code: String {
 {%for error in errors %}
-    case {{error.enum}}(message: String?)
-{% endfor %}}
+        case {{error.enum}} = "{{error.string}}"
+{% endfor %}
+    }
+    
+    private var error: Code
+    public var message: String?
 
-extension {{errorName}} {
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+    
 {%for error in errors %}
-        case "{{error.string}}":
-            self = .{{error.enum}}(message: message)
+    public static var {{error.enum}}: Self { .init(.{{error.enum}}) }
 {% endfor %}
-        default:
-            return nil
-        }
+}
+
+extension {{errorName}}: Equatable {
+    public static func == (lhs: {{errorName}}, rhs: {{errorName}}) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension {{errorName}}: CustomStringConvertible {
     public var description: String {
-        switch self {
-{%for error in errors %}
-        case .{{error.enum}}(let message):
-            return "{{error.string}}: \(message ?? "")"
-{% endfor %}
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/ACM/ACM_Error.swift
+++ b/Sources/Soto/Services/ACM/ACM_Error.swift
@@ -17,85 +17,62 @@
 import SotoCore
 
 /// Error enum for ACM
-public enum ACMErrorType: AWSErrorType {
-    case invalidArgsException(message: String?)
-    case invalidArnException(message: String?)
-    case invalidDomainValidationOptionsException(message: String?)
-    case invalidParameterException(message: String?)
-    case invalidStateException(message: String?)
-    case invalidTagException(message: String?)
-    case limitExceededException(message: String?)
-    case requestInProgressException(message: String?)
-    case resourceInUseException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case tagPolicyException(message: String?)
-    case tooManyTagsException(message: String?)
-}
+public struct ACMErrorType: AWSErrorType {
+    enum Code: String {
+        case invalidArgsException = "InvalidArgsException"
+        case invalidArnException = "InvalidArnException"
+        case invalidDomainValidationOptionsException = "InvalidDomainValidationOptionsException"
+        case invalidParameterException = "InvalidParameterException"
+        case invalidStateException = "InvalidStateException"
+        case invalidTagException = "InvalidTagException"
+        case limitExceededException = "LimitExceededException"
+        case requestInProgressException = "RequestInProgressException"
+        case resourceInUseException = "ResourceInUseException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case tagPolicyException = "TagPolicyException"
+        case tooManyTagsException = "TooManyTagsException"
+    }
 
-extension ACMErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "InvalidArgsException":
-            self = .invalidArgsException(message: message)
-        case "InvalidArnException":
-            self = .invalidArnException(message: message)
-        case "InvalidDomainValidationOptionsException":
-            self = .invalidDomainValidationOptionsException(message: message)
-        case "InvalidParameterException":
-            self = .invalidParameterException(message: message)
-        case "InvalidStateException":
-            self = .invalidStateException(message: message)
-        case "InvalidTagException":
-            self = .invalidTagException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "RequestInProgressException":
-            self = .requestInProgressException(message: message)
-        case "ResourceInUseException":
-            self = .resourceInUseException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "TagPolicyException":
-            self = .tagPolicyException(message: message)
-        case "TooManyTagsException":
-            self = .tooManyTagsException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var invalidArgsException: Self { .init(.invalidArgsException) }
+    public static var invalidArnException: Self { .init(.invalidArnException) }
+    public static var invalidDomainValidationOptionsException: Self { .init(.invalidDomainValidationOptionsException) }
+    public static var invalidParameterException: Self { .init(.invalidParameterException) }
+    public static var invalidStateException: Self { .init(.invalidStateException) }
+    public static var invalidTagException: Self { .init(.invalidTagException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var requestInProgressException: Self { .init(.requestInProgressException) }
+    public static var resourceInUseException: Self { .init(.resourceInUseException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var tagPolicyException: Self { .init(.tagPolicyException) }
+    public static var tooManyTagsException: Self { .init(.tooManyTagsException) }
+}
+
+extension ACMErrorType: Equatable {
+    public static func == (lhs: ACMErrorType, rhs: ACMErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ACMErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .invalidArgsException(let message):
-            return "InvalidArgsException: \(message ?? "")"
-        case .invalidArnException(let message):
-            return "InvalidArnException: \(message ?? "")"
-        case .invalidDomainValidationOptionsException(let message):
-            return "InvalidDomainValidationOptionsException: \(message ?? "")"
-        case .invalidParameterException(let message):
-            return "InvalidParameterException: \(message ?? "")"
-        case .invalidStateException(let message):
-            return "InvalidStateException: \(message ?? "")"
-        case .invalidTagException(let message):
-            return "InvalidTagException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .requestInProgressException(let message):
-            return "RequestInProgressException: \(message ?? "")"
-        case .resourceInUseException(let message):
-            return "ResourceInUseException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .tagPolicyException(let message):
-            return "TagPolicyException: \(message ?? "")"
-        case .tooManyTagsException(let message):
-            return "TooManyTagsException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/ACMPCA/ACMPCA_Error.swift
+++ b/Sources/Soto/Services/ACMPCA/ACMPCA_Error.swift
@@ -17,120 +17,76 @@
 import SotoCore
 
 /// Error enum for ACMPCA
-public enum ACMPCAErrorType: AWSErrorType {
-    case certificateMismatchException(message: String?)
-    case concurrentModificationException(message: String?)
-    case invalidArgsException(message: String?)
-    case invalidArnException(message: String?)
-    case invalidNextTokenException(message: String?)
-    case invalidPolicyException(message: String?)
-    case invalidRequestException(message: String?)
-    case invalidStateException(message: String?)
-    case invalidTagException(message: String?)
-    case limitExceededException(message: String?)
-    case lockoutPreventedException(message: String?)
-    case malformedCSRException(message: String?)
-    case malformedCertificateException(message: String?)
-    case permissionAlreadyExistsException(message: String?)
-    case requestAlreadyProcessedException(message: String?)
-    case requestFailedException(message: String?)
-    case requestInProgressException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case tooManyTagsException(message: String?)
-}
+public struct ACMPCAErrorType: AWSErrorType {
+    enum Code: String {
+        case certificateMismatchException = "CertificateMismatchException"
+        case concurrentModificationException = "ConcurrentModificationException"
+        case invalidArgsException = "InvalidArgsException"
+        case invalidArnException = "InvalidArnException"
+        case invalidNextTokenException = "InvalidNextTokenException"
+        case invalidPolicyException = "InvalidPolicyException"
+        case invalidRequestException = "InvalidRequestException"
+        case invalidStateException = "InvalidStateException"
+        case invalidTagException = "InvalidTagException"
+        case limitExceededException = "LimitExceededException"
+        case lockoutPreventedException = "LockoutPreventedException"
+        case malformedCSRException = "MalformedCSRException"
+        case malformedCertificateException = "MalformedCertificateException"
+        case permissionAlreadyExistsException = "PermissionAlreadyExistsException"
+        case requestAlreadyProcessedException = "RequestAlreadyProcessedException"
+        case requestFailedException = "RequestFailedException"
+        case requestInProgressException = "RequestInProgressException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case tooManyTagsException = "TooManyTagsException"
+    }
 
-extension ACMPCAErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "CertificateMismatchException":
-            self = .certificateMismatchException(message: message)
-        case "ConcurrentModificationException":
-            self = .concurrentModificationException(message: message)
-        case "InvalidArgsException":
-            self = .invalidArgsException(message: message)
-        case "InvalidArnException":
-            self = .invalidArnException(message: message)
-        case "InvalidNextTokenException":
-            self = .invalidNextTokenException(message: message)
-        case "InvalidPolicyException":
-            self = .invalidPolicyException(message: message)
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        case "InvalidStateException":
-            self = .invalidStateException(message: message)
-        case "InvalidTagException":
-            self = .invalidTagException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "LockoutPreventedException":
-            self = .lockoutPreventedException(message: message)
-        case "MalformedCSRException":
-            self = .malformedCSRException(message: message)
-        case "MalformedCertificateException":
-            self = .malformedCertificateException(message: message)
-        case "PermissionAlreadyExistsException":
-            self = .permissionAlreadyExistsException(message: message)
-        case "RequestAlreadyProcessedException":
-            self = .requestAlreadyProcessedException(message: message)
-        case "RequestFailedException":
-            self = .requestFailedException(message: message)
-        case "RequestInProgressException":
-            self = .requestInProgressException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "TooManyTagsException":
-            self = .tooManyTagsException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var certificateMismatchException: Self { .init(.certificateMismatchException) }
+    public static var concurrentModificationException: Self { .init(.concurrentModificationException) }
+    public static var invalidArgsException: Self { .init(.invalidArgsException) }
+    public static var invalidArnException: Self { .init(.invalidArnException) }
+    public static var invalidNextTokenException: Self { .init(.invalidNextTokenException) }
+    public static var invalidPolicyException: Self { .init(.invalidPolicyException) }
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+    public static var invalidStateException: Self { .init(.invalidStateException) }
+    public static var invalidTagException: Self { .init(.invalidTagException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var lockoutPreventedException: Self { .init(.lockoutPreventedException) }
+    public static var malformedCSRException: Self { .init(.malformedCSRException) }
+    public static var malformedCertificateException: Self { .init(.malformedCertificateException) }
+    public static var permissionAlreadyExistsException: Self { .init(.permissionAlreadyExistsException) }
+    public static var requestAlreadyProcessedException: Self { .init(.requestAlreadyProcessedException) }
+    public static var requestFailedException: Self { .init(.requestFailedException) }
+    public static var requestInProgressException: Self { .init(.requestInProgressException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var tooManyTagsException: Self { .init(.tooManyTagsException) }
+}
+
+extension ACMPCAErrorType: Equatable {
+    public static func == (lhs: ACMPCAErrorType, rhs: ACMPCAErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ACMPCAErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .certificateMismatchException(let message):
-            return "CertificateMismatchException: \(message ?? "")"
-        case .concurrentModificationException(let message):
-            return "ConcurrentModificationException: \(message ?? "")"
-        case .invalidArgsException(let message):
-            return "InvalidArgsException: \(message ?? "")"
-        case .invalidArnException(let message):
-            return "InvalidArnException: \(message ?? "")"
-        case .invalidNextTokenException(let message):
-            return "InvalidNextTokenException: \(message ?? "")"
-        case .invalidPolicyException(let message):
-            return "InvalidPolicyException: \(message ?? "")"
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        case .invalidStateException(let message):
-            return "InvalidStateException: \(message ?? "")"
-        case .invalidTagException(let message):
-            return "InvalidTagException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .lockoutPreventedException(let message):
-            return "LockoutPreventedException: \(message ?? "")"
-        case .malformedCSRException(let message):
-            return "MalformedCSRException: \(message ?? "")"
-        case .malformedCertificateException(let message):
-            return "MalformedCertificateException: \(message ?? "")"
-        case .permissionAlreadyExistsException(let message):
-            return "PermissionAlreadyExistsException: \(message ?? "")"
-        case .requestAlreadyProcessedException(let message):
-            return "RequestAlreadyProcessedException: \(message ?? "")"
-        case .requestFailedException(let message):
-            return "RequestFailedException: \(message ?? "")"
-        case .requestInProgressException(let message):
-            return "RequestInProgressException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .tooManyTagsException(let message):
-            return "TooManyTagsException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/APIGateway/APIGateway_Error.swift
+++ b/Sources/Soto/Services/APIGateway/APIGateway_Error.swift
@@ -17,60 +17,52 @@
 import SotoCore
 
 /// Error enum for APIGateway
-public enum APIGatewayErrorType: AWSErrorType {
-    case badRequestException(message: String?)
-    case conflictException(message: String?)
-    case limitExceededException(message: String?)
-    case notFoundException(message: String?)
-    case serviceUnavailableException(message: String?)
-    case tooManyRequestsException(message: String?)
-    case unauthorizedException(message: String?)
-}
+public struct APIGatewayErrorType: AWSErrorType {
+    enum Code: String {
+        case badRequestException = "BadRequestException"
+        case conflictException = "ConflictException"
+        case limitExceededException = "LimitExceededException"
+        case notFoundException = "NotFoundException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+        case tooManyRequestsException = "TooManyRequestsException"
+        case unauthorizedException = "UnauthorizedException"
+    }
 
-extension APIGatewayErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        case "TooManyRequestsException":
-            self = .tooManyRequestsException(message: message)
-        case "UnauthorizedException":
-            self = .unauthorizedException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var badRequestException: Self { .init(.badRequestException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+    public static var tooManyRequestsException: Self { .init(.tooManyRequestsException) }
+    public static var unauthorizedException: Self { .init(.unauthorizedException) }
+}
+
+extension APIGatewayErrorType: Equatable {
+    public static func == (lhs: APIGatewayErrorType, rhs: APIGatewayErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension APIGatewayErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        case .tooManyRequestsException(let message):
-            return "TooManyRequestsException: \(message ?? "")"
-        case .unauthorizedException(let message):
-            return "UnauthorizedException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/AccessAnalyzer/AccessAnalyzer_Error.swift
+++ b/Sources/Soto/Services/AccessAnalyzer/AccessAnalyzer_Error.swift
@@ -17,60 +17,52 @@
 import SotoCore
 
 /// Error enum for AccessAnalyzer
-public enum AccessAnalyzerErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case conflictException(message: String?)
-    case internalServerException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceQuotaExceededException(message: String?)
-    case throttlingException(message: String?)
-    case validationException(message: String?)
-}
+public struct AccessAnalyzerErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case conflictException = "ConflictException"
+        case internalServerException = "InternalServerException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceQuotaExceededException = "ServiceQuotaExceededException"
+        case throttlingException = "ThrottlingException"
+        case validationException = "ValidationException"
+    }
 
-extension AccessAnalyzerErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceQuotaExceededException":
-            self = .serviceQuotaExceededException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceQuotaExceededException: Self { .init(.serviceQuotaExceededException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension AccessAnalyzerErrorType: Equatable {
+    public static func == (lhs: AccessAnalyzerErrorType, rhs: AccessAnalyzerErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension AccessAnalyzerErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceQuotaExceededException(let message):
-            return "ServiceQuotaExceededException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/AlexaForBusiness/AlexaForBusiness_Error.swift
+++ b/Sources/Soto/Services/AlexaForBusiness/AlexaForBusiness_Error.swift
@@ -17,100 +17,68 @@
 import SotoCore
 
 /// Error enum for AlexaForBusiness
-public enum AlexaForBusinessErrorType: AWSErrorType {
-    case alreadyExistsException(message: String?)
-    case concurrentModificationException(message: String?)
-    case deviceNotRegisteredException(message: String?)
-    case invalidCertificateAuthorityException(message: String?)
-    case invalidDeviceException(message: String?)
-    case invalidSecretsManagerResourceException(message: String?)
-    case invalidServiceLinkedRoleStateException(message: String?)
-    case invalidUserStatusException(message: String?)
-    case limitExceededException(message: String?)
-    case nameInUseException(message: String?)
-    case notFoundException(message: String?)
-    case resourceAssociatedException(message: String?)
-    case resourceInUseException(message: String?)
-    case skillNotLinkedException(message: String?)
-    case unauthorizedException(message: String?)
-}
+public struct AlexaForBusinessErrorType: AWSErrorType {
+    enum Code: String {
+        case alreadyExistsException = "AlreadyExistsException"
+        case concurrentModificationException = "ConcurrentModificationException"
+        case deviceNotRegisteredException = "DeviceNotRegisteredException"
+        case invalidCertificateAuthorityException = "InvalidCertificateAuthorityException"
+        case invalidDeviceException = "InvalidDeviceException"
+        case invalidSecretsManagerResourceException = "InvalidSecretsManagerResourceException"
+        case invalidServiceLinkedRoleStateException = "InvalidServiceLinkedRoleStateException"
+        case invalidUserStatusException = "InvalidUserStatusException"
+        case limitExceededException = "LimitExceededException"
+        case nameInUseException = "NameInUseException"
+        case notFoundException = "NotFoundException"
+        case resourceAssociatedException = "ResourceAssociatedException"
+        case resourceInUseException = "ResourceInUseException"
+        case skillNotLinkedException = "SkillNotLinkedException"
+        case unauthorizedException = "UnauthorizedException"
+    }
 
-extension AlexaForBusinessErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AlreadyExistsException":
-            self = .alreadyExistsException(message: message)
-        case "ConcurrentModificationException":
-            self = .concurrentModificationException(message: message)
-        case "DeviceNotRegisteredException":
-            self = .deviceNotRegisteredException(message: message)
-        case "InvalidCertificateAuthorityException":
-            self = .invalidCertificateAuthorityException(message: message)
-        case "InvalidDeviceException":
-            self = .invalidDeviceException(message: message)
-        case "InvalidSecretsManagerResourceException":
-            self = .invalidSecretsManagerResourceException(message: message)
-        case "InvalidServiceLinkedRoleStateException":
-            self = .invalidServiceLinkedRoleStateException(message: message)
-        case "InvalidUserStatusException":
-            self = .invalidUserStatusException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "NameInUseException":
-            self = .nameInUseException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "ResourceAssociatedException":
-            self = .resourceAssociatedException(message: message)
-        case "ResourceInUseException":
-            self = .resourceInUseException(message: message)
-        case "SkillNotLinkedException":
-            self = .skillNotLinkedException(message: message)
-        case "UnauthorizedException":
-            self = .unauthorizedException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var alreadyExistsException: Self { .init(.alreadyExistsException) }
+    public static var concurrentModificationException: Self { .init(.concurrentModificationException) }
+    public static var deviceNotRegisteredException: Self { .init(.deviceNotRegisteredException) }
+    public static var invalidCertificateAuthorityException: Self { .init(.invalidCertificateAuthorityException) }
+    public static var invalidDeviceException: Self { .init(.invalidDeviceException) }
+    public static var invalidSecretsManagerResourceException: Self { .init(.invalidSecretsManagerResourceException) }
+    public static var invalidServiceLinkedRoleStateException: Self { .init(.invalidServiceLinkedRoleStateException) }
+    public static var invalidUserStatusException: Self { .init(.invalidUserStatusException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var nameInUseException: Self { .init(.nameInUseException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var resourceAssociatedException: Self { .init(.resourceAssociatedException) }
+    public static var resourceInUseException: Self { .init(.resourceInUseException) }
+    public static var skillNotLinkedException: Self { .init(.skillNotLinkedException) }
+    public static var unauthorizedException: Self { .init(.unauthorizedException) }
+}
+
+extension AlexaForBusinessErrorType: Equatable {
+    public static func == (lhs: AlexaForBusinessErrorType, rhs: AlexaForBusinessErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension AlexaForBusinessErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .alreadyExistsException(let message):
-            return "AlreadyExistsException: \(message ?? "")"
-        case .concurrentModificationException(let message):
-            return "ConcurrentModificationException: \(message ?? "")"
-        case .deviceNotRegisteredException(let message):
-            return "DeviceNotRegisteredException: \(message ?? "")"
-        case .invalidCertificateAuthorityException(let message):
-            return "InvalidCertificateAuthorityException: \(message ?? "")"
-        case .invalidDeviceException(let message):
-            return "InvalidDeviceException: \(message ?? "")"
-        case .invalidSecretsManagerResourceException(let message):
-            return "InvalidSecretsManagerResourceException: \(message ?? "")"
-        case .invalidServiceLinkedRoleStateException(let message):
-            return "InvalidServiceLinkedRoleStateException: \(message ?? "")"
-        case .invalidUserStatusException(let message):
-            return "InvalidUserStatusException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .nameInUseException(let message):
-            return "NameInUseException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .resourceAssociatedException(let message):
-            return "ResourceAssociatedException: \(message ?? "")"
-        case .resourceInUseException(let message):
-            return "ResourceInUseException: \(message ?? "")"
-        case .skillNotLinkedException(let message):
-            return "SkillNotLinkedException: \(message ?? "")"
-        case .unauthorizedException(let message):
-            return "UnauthorizedException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Amplify/Amplify_Error.swift
+++ b/Sources/Soto/Services/Amplify/Amplify_Error.swift
@@ -17,60 +17,52 @@
 import SotoCore
 
 /// Error enum for Amplify
-public enum AmplifyErrorType: AWSErrorType {
-    case badRequestException(message: String?)
-    case dependentServiceFailureException(message: String?)
-    case internalFailureException(message: String?)
-    case limitExceededException(message: String?)
-    case notFoundException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case unauthorizedException(message: String?)
-}
+public struct AmplifyErrorType: AWSErrorType {
+    enum Code: String {
+        case badRequestException = "BadRequestException"
+        case dependentServiceFailureException = "DependentServiceFailureException"
+        case internalFailureException = "InternalFailureException"
+        case limitExceededException = "LimitExceededException"
+        case notFoundException = "NotFoundException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case unauthorizedException = "UnauthorizedException"
+    }
 
-extension AmplifyErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        case "DependentServiceFailureException":
-            self = .dependentServiceFailureException(message: message)
-        case "InternalFailureException":
-            self = .internalFailureException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "UnauthorizedException":
-            self = .unauthorizedException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var badRequestException: Self { .init(.badRequestException) }
+    public static var dependentServiceFailureException: Self { .init(.dependentServiceFailureException) }
+    public static var internalFailureException: Self { .init(.internalFailureException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var unauthorizedException: Self { .init(.unauthorizedException) }
+}
+
+extension AmplifyErrorType: Equatable {
+    public static func == (lhs: AmplifyErrorType, rhs: AmplifyErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension AmplifyErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        case .dependentServiceFailureException(let message):
-            return "DependentServiceFailureException: \(message ?? "")"
-        case .internalFailureException(let message):
-            return "InternalFailureException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .unauthorizedException(let message):
-            return "UnauthorizedException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/ApiGatewayManagementApi/ApiGatewayManagementApi_Error.swift
+++ b/Sources/Soto/Services/ApiGatewayManagementApi/ApiGatewayManagementApi_Error.swift
@@ -17,45 +17,46 @@
 import SotoCore
 
 /// Error enum for ApiGatewayManagementApi
-public enum ApiGatewayManagementApiErrorType: AWSErrorType {
-    case forbiddenException(message: String?)
-    case goneException(message: String?)
-    case limitExceededException(message: String?)
-    case payloadTooLargeException(message: String?)
-}
+public struct ApiGatewayManagementApiErrorType: AWSErrorType {
+    enum Code: String {
+        case forbiddenException = "ForbiddenException"
+        case goneException = "GoneException"
+        case limitExceededException = "LimitExceededException"
+        case payloadTooLargeException = "PayloadTooLargeException"
+    }
 
-extension ApiGatewayManagementApiErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ForbiddenException":
-            self = .forbiddenException(message: message)
-        case "GoneException":
-            self = .goneException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "PayloadTooLargeException":
-            self = .payloadTooLargeException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var forbiddenException: Self { .init(.forbiddenException) }
+    public static var goneException: Self { .init(.goneException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var payloadTooLargeException: Self { .init(.payloadTooLargeException) }
+}
+
+extension ApiGatewayManagementApiErrorType: Equatable {
+    public static func == (lhs: ApiGatewayManagementApiErrorType, rhs: ApiGatewayManagementApiErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ApiGatewayManagementApiErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .forbiddenException(let message):
-            return "ForbiddenException: \(message ?? "")"
-        case .goneException(let message):
-            return "GoneException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .payloadTooLargeException(let message):
-            return "PayloadTooLargeException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/ApiGatewayV2/ApiGatewayV2_Error.swift
+++ b/Sources/Soto/Services/ApiGatewayV2/ApiGatewayV2_Error.swift
@@ -17,50 +17,48 @@
 import SotoCore
 
 /// Error enum for ApiGatewayV2
-public enum ApiGatewayV2ErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case badRequestException(message: String?)
-    case conflictException(message: String?)
-    case notFoundException(message: String?)
-    case tooManyRequestsException(message: String?)
-}
+public struct ApiGatewayV2ErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case badRequestException = "BadRequestException"
+        case conflictException = "ConflictException"
+        case notFoundException = "NotFoundException"
+        case tooManyRequestsException = "TooManyRequestsException"
+    }
 
-extension ApiGatewayV2ErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "TooManyRequestsException":
-            self = .tooManyRequestsException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var badRequestException: Self { .init(.badRequestException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var tooManyRequestsException: Self { .init(.tooManyRequestsException) }
+}
+
+extension ApiGatewayV2ErrorType: Equatable {
+    public static func == (lhs: ApiGatewayV2ErrorType, rhs: ApiGatewayV2ErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ApiGatewayV2ErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .tooManyRequestsException(let message):
-            return "TooManyRequestsException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/AppConfig/AppConfig_Error.swift
+++ b/Sources/Soto/Services/AppConfig/AppConfig_Error.swift
@@ -17,55 +17,50 @@
 import SotoCore
 
 /// Error enum for AppConfig
-public enum AppConfigErrorType: AWSErrorType {
-    case badRequestException(message: String?)
-    case conflictException(message: String?)
-    case internalServerException(message: String?)
-    case payloadTooLargeException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceQuotaExceededException(message: String?)
-}
+public struct AppConfigErrorType: AWSErrorType {
+    enum Code: String {
+        case badRequestException = "BadRequestException"
+        case conflictException = "ConflictException"
+        case internalServerException = "InternalServerException"
+        case payloadTooLargeException = "PayloadTooLargeException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceQuotaExceededException = "ServiceQuotaExceededException"
+    }
 
-extension AppConfigErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "PayloadTooLargeException":
-            self = .payloadTooLargeException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceQuotaExceededException":
-            self = .serviceQuotaExceededException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var badRequestException: Self { .init(.badRequestException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var payloadTooLargeException: Self { .init(.payloadTooLargeException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceQuotaExceededException: Self { .init(.serviceQuotaExceededException) }
+}
+
+extension AppConfigErrorType: Equatable {
+    public static func == (lhs: AppConfigErrorType, rhs: AppConfigErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension AppConfigErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .payloadTooLargeException(let message):
-            return "PayloadTooLargeException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceQuotaExceededException(let message):
-            return "ServiceQuotaExceededException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/AppMesh/AppMesh_Error.swift
+++ b/Sources/Soto/Services/AppMesh/AppMesh_Error.swift
@@ -17,75 +17,58 @@
 import SotoCore
 
 /// Error enum for AppMesh
-public enum AppMeshErrorType: AWSErrorType {
-    case badRequestException(message: String?)
-    case conflictException(message: String?)
-    case forbiddenException(message: String?)
-    case internalServerErrorException(message: String?)
-    case limitExceededException(message: String?)
-    case notFoundException(message: String?)
-    case resourceInUseException(message: String?)
-    case serviceUnavailableException(message: String?)
-    case tooManyRequestsException(message: String?)
-    case tooManyTagsException(message: String?)
-}
+public struct AppMeshErrorType: AWSErrorType {
+    enum Code: String {
+        case badRequestException = "BadRequestException"
+        case conflictException = "ConflictException"
+        case forbiddenException = "ForbiddenException"
+        case internalServerErrorException = "InternalServerErrorException"
+        case limitExceededException = "LimitExceededException"
+        case notFoundException = "NotFoundException"
+        case resourceInUseException = "ResourceInUseException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+        case tooManyRequestsException = "TooManyRequestsException"
+        case tooManyTagsException = "TooManyTagsException"
+    }
 
-extension AppMeshErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "ForbiddenException":
-            self = .forbiddenException(message: message)
-        case "InternalServerErrorException":
-            self = .internalServerErrorException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "ResourceInUseException":
-            self = .resourceInUseException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        case "TooManyRequestsException":
-            self = .tooManyRequestsException(message: message)
-        case "TooManyTagsException":
-            self = .tooManyTagsException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var badRequestException: Self { .init(.badRequestException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var forbiddenException: Self { .init(.forbiddenException) }
+    public static var internalServerErrorException: Self { .init(.internalServerErrorException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var resourceInUseException: Self { .init(.resourceInUseException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+    public static var tooManyRequestsException: Self { .init(.tooManyRequestsException) }
+    public static var tooManyTagsException: Self { .init(.tooManyTagsException) }
+}
+
+extension AppMeshErrorType: Equatable {
+    public static func == (lhs: AppMeshErrorType, rhs: AppMeshErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension AppMeshErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .forbiddenException(let message):
-            return "ForbiddenException: \(message ?? "")"
-        case .internalServerErrorException(let message):
-            return "InternalServerErrorException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .resourceInUseException(let message):
-            return "ResourceInUseException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        case .tooManyRequestsException(let message):
-            return "TooManyRequestsException: \(message ?? "")"
-        case .tooManyTagsException(let message):
-            return "TooManyTagsException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/AppStream/AppStream_Error.swift
+++ b/Sources/Soto/Services/AppStream/AppStream_Error.swift
@@ -17,85 +17,62 @@
 import SotoCore
 
 /// Error enum for AppStream
-public enum AppStreamErrorType: AWSErrorType {
-    case concurrentModificationException(message: String?)
-    case incompatibleImageException(message: String?)
-    case invalidAccountStatusException(message: String?)
-    case invalidParameterCombinationException(message: String?)
-    case invalidRoleException(message: String?)
-    case limitExceededException(message: String?)
-    case operationNotPermittedException(message: String?)
-    case requestLimitExceededException(message: String?)
-    case resourceAlreadyExistsException(message: String?)
-    case resourceInUseException(message: String?)
-    case resourceNotAvailableException(message: String?)
-    case resourceNotFoundException(message: String?)
-}
+public struct AppStreamErrorType: AWSErrorType {
+    enum Code: String {
+        case concurrentModificationException = "ConcurrentModificationException"
+        case incompatibleImageException = "IncompatibleImageException"
+        case invalidAccountStatusException = "InvalidAccountStatusException"
+        case invalidParameterCombinationException = "InvalidParameterCombinationException"
+        case invalidRoleException = "InvalidRoleException"
+        case limitExceededException = "LimitExceededException"
+        case operationNotPermittedException = "OperationNotPermittedException"
+        case requestLimitExceededException = "RequestLimitExceededException"
+        case resourceAlreadyExistsException = "ResourceAlreadyExistsException"
+        case resourceInUseException = "ResourceInUseException"
+        case resourceNotAvailableException = "ResourceNotAvailableException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+    }
 
-extension AppStreamErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ConcurrentModificationException":
-            self = .concurrentModificationException(message: message)
-        case "IncompatibleImageException":
-            self = .incompatibleImageException(message: message)
-        case "InvalidAccountStatusException":
-            self = .invalidAccountStatusException(message: message)
-        case "InvalidParameterCombinationException":
-            self = .invalidParameterCombinationException(message: message)
-        case "InvalidRoleException":
-            self = .invalidRoleException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "OperationNotPermittedException":
-            self = .operationNotPermittedException(message: message)
-        case "RequestLimitExceededException":
-            self = .requestLimitExceededException(message: message)
-        case "ResourceAlreadyExistsException":
-            self = .resourceAlreadyExistsException(message: message)
-        case "ResourceInUseException":
-            self = .resourceInUseException(message: message)
-        case "ResourceNotAvailableException":
-            self = .resourceNotAvailableException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var concurrentModificationException: Self { .init(.concurrentModificationException) }
+    public static var incompatibleImageException: Self { .init(.incompatibleImageException) }
+    public static var invalidAccountStatusException: Self { .init(.invalidAccountStatusException) }
+    public static var invalidParameterCombinationException: Self { .init(.invalidParameterCombinationException) }
+    public static var invalidRoleException: Self { .init(.invalidRoleException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var operationNotPermittedException: Self { .init(.operationNotPermittedException) }
+    public static var requestLimitExceededException: Self { .init(.requestLimitExceededException) }
+    public static var resourceAlreadyExistsException: Self { .init(.resourceAlreadyExistsException) }
+    public static var resourceInUseException: Self { .init(.resourceInUseException) }
+    public static var resourceNotAvailableException: Self { .init(.resourceNotAvailableException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+}
+
+extension AppStreamErrorType: Equatable {
+    public static func == (lhs: AppStreamErrorType, rhs: AppStreamErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension AppStreamErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .concurrentModificationException(let message):
-            return "ConcurrentModificationException: \(message ?? "")"
-        case .incompatibleImageException(let message):
-            return "IncompatibleImageException: \(message ?? "")"
-        case .invalidAccountStatusException(let message):
-            return "InvalidAccountStatusException: \(message ?? "")"
-        case .invalidParameterCombinationException(let message):
-            return "InvalidParameterCombinationException: \(message ?? "")"
-        case .invalidRoleException(let message):
-            return "InvalidRoleException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .operationNotPermittedException(let message):
-            return "OperationNotPermittedException: \(message ?? "")"
-        case .requestLimitExceededException(let message):
-            return "RequestLimitExceededException: \(message ?? "")"
-        case .resourceAlreadyExistsException(let message):
-            return "ResourceAlreadyExistsException: \(message ?? "")"
-        case .resourceInUseException(let message):
-            return "ResourceInUseException: \(message ?? "")"
-        case .resourceNotAvailableException(let message):
-            return "ResourceNotAvailableException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/AppSync/AppSync_Error.swift
+++ b/Sources/Soto/Services/AppSync/AppSync_Error.swift
@@ -17,80 +17,60 @@
 import SotoCore
 
 /// Error enum for AppSync
-public enum AppSyncErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case apiKeyLimitExceededException(message: String?)
-    case apiKeyValidityOutOfBoundsException(message: String?)
-    case apiLimitExceededException(message: String?)
-    case badRequestException(message: String?)
-    case concurrentModificationException(message: String?)
-    case graphQLSchemaException(message: String?)
-    case internalFailureException(message: String?)
-    case limitExceededException(message: String?)
-    case notFoundException(message: String?)
-    case unauthorizedException(message: String?)
-}
+public struct AppSyncErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case apiKeyLimitExceededException = "ApiKeyLimitExceededException"
+        case apiKeyValidityOutOfBoundsException = "ApiKeyValidityOutOfBoundsException"
+        case apiLimitExceededException = "ApiLimitExceededException"
+        case badRequestException = "BadRequestException"
+        case concurrentModificationException = "ConcurrentModificationException"
+        case graphQLSchemaException = "GraphQLSchemaException"
+        case internalFailureException = "InternalFailureException"
+        case limitExceededException = "LimitExceededException"
+        case notFoundException = "NotFoundException"
+        case unauthorizedException = "UnauthorizedException"
+    }
 
-extension AppSyncErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "ApiKeyLimitExceededException":
-            self = .apiKeyLimitExceededException(message: message)
-        case "ApiKeyValidityOutOfBoundsException":
-            self = .apiKeyValidityOutOfBoundsException(message: message)
-        case "ApiLimitExceededException":
-            self = .apiLimitExceededException(message: message)
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        case "ConcurrentModificationException":
-            self = .concurrentModificationException(message: message)
-        case "GraphQLSchemaException":
-            self = .graphQLSchemaException(message: message)
-        case "InternalFailureException":
-            self = .internalFailureException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "UnauthorizedException":
-            self = .unauthorizedException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var apiKeyLimitExceededException: Self { .init(.apiKeyLimitExceededException) }
+    public static var apiKeyValidityOutOfBoundsException: Self { .init(.apiKeyValidityOutOfBoundsException) }
+    public static var apiLimitExceededException: Self { .init(.apiLimitExceededException) }
+    public static var badRequestException: Self { .init(.badRequestException) }
+    public static var concurrentModificationException: Self { .init(.concurrentModificationException) }
+    public static var graphQLSchemaException: Self { .init(.graphQLSchemaException) }
+    public static var internalFailureException: Self { .init(.internalFailureException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var unauthorizedException: Self { .init(.unauthorizedException) }
+}
+
+extension AppSyncErrorType: Equatable {
+    public static func == (lhs: AppSyncErrorType, rhs: AppSyncErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension AppSyncErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .apiKeyLimitExceededException(let message):
-            return "ApiKeyLimitExceededException: \(message ?? "")"
-        case .apiKeyValidityOutOfBoundsException(let message):
-            return "ApiKeyValidityOutOfBoundsException: \(message ?? "")"
-        case .apiLimitExceededException(let message):
-            return "ApiLimitExceededException: \(message ?? "")"
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        case .concurrentModificationException(let message):
-            return "ConcurrentModificationException: \(message ?? "")"
-        case .graphQLSchemaException(let message):
-            return "GraphQLSchemaException: \(message ?? "")"
-        case .internalFailureException(let message):
-            return "InternalFailureException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .unauthorizedException(let message):
-            return "UnauthorizedException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Appflow/Appflow_Error.swift
+++ b/Sources/Soto/Services/Appflow/Appflow_Error.swift
@@ -17,65 +17,54 @@
 import SotoCore
 
 /// Error enum for Appflow
-public enum AppflowErrorType: AWSErrorType {
-    case conflictException(message: String?)
-    case connectorAuthenticationException(message: String?)
-    case connectorServerException(message: String?)
-    case internalServerException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceQuotaExceededException(message: String?)
-    case unsupportedOperationException(message: String?)
-    case validationException(message: String?)
-}
+public struct AppflowErrorType: AWSErrorType {
+    enum Code: String {
+        case conflictException = "ConflictException"
+        case connectorAuthenticationException = "ConnectorAuthenticationException"
+        case connectorServerException = "ConnectorServerException"
+        case internalServerException = "InternalServerException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceQuotaExceededException = "ServiceQuotaExceededException"
+        case unsupportedOperationException = "UnsupportedOperationException"
+        case validationException = "ValidationException"
+    }
 
-extension AppflowErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "ConnectorAuthenticationException":
-            self = .connectorAuthenticationException(message: message)
-        case "ConnectorServerException":
-            self = .connectorServerException(message: message)
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceQuotaExceededException":
-            self = .serviceQuotaExceededException(message: message)
-        case "UnsupportedOperationException":
-            self = .unsupportedOperationException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var connectorAuthenticationException: Self { .init(.connectorAuthenticationException) }
+    public static var connectorServerException: Self { .init(.connectorServerException) }
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceQuotaExceededException: Self { .init(.serviceQuotaExceededException) }
+    public static var unsupportedOperationException: Self { .init(.unsupportedOperationException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension AppflowErrorType: Equatable {
+    public static func == (lhs: AppflowErrorType, rhs: AppflowErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension AppflowErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .connectorAuthenticationException(let message):
-            return "ConnectorAuthenticationException: \(message ?? "")"
-        case .connectorServerException(let message):
-            return "ConnectorServerException: \(message ?? "")"
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceQuotaExceededException(let message):
-            return "ServiceQuotaExceededException: \(message ?? "")"
-        case .unsupportedOperationException(let message):
-            return "UnsupportedOperationException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/ApplicationAutoScaling/ApplicationAutoScaling_Error.swift
+++ b/Sources/Soto/Services/ApplicationAutoScaling/ApplicationAutoScaling_Error.swift
@@ -17,60 +17,52 @@
 import SotoCore
 
 /// Error enum for ApplicationAutoScaling
-public enum ApplicationAutoScalingErrorType: AWSErrorType {
-    case concurrentUpdateException(message: String?)
-    case failedResourceAccessException(message: String?)
-    case internalServiceException(message: String?)
-    case invalidNextTokenException(message: String?)
-    case limitExceededException(message: String?)
-    case objectNotFoundException(message: String?)
-    case validationException(message: String?)
-}
+public struct ApplicationAutoScalingErrorType: AWSErrorType {
+    enum Code: String {
+        case concurrentUpdateException = "ConcurrentUpdateException"
+        case failedResourceAccessException = "FailedResourceAccessException"
+        case internalServiceException = "InternalServiceException"
+        case invalidNextTokenException = "InvalidNextTokenException"
+        case limitExceededException = "LimitExceededException"
+        case objectNotFoundException = "ObjectNotFoundException"
+        case validationException = "ValidationException"
+    }
 
-extension ApplicationAutoScalingErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ConcurrentUpdateException":
-            self = .concurrentUpdateException(message: message)
-        case "FailedResourceAccessException":
-            self = .failedResourceAccessException(message: message)
-        case "InternalServiceException":
-            self = .internalServiceException(message: message)
-        case "InvalidNextTokenException":
-            self = .invalidNextTokenException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ObjectNotFoundException":
-            self = .objectNotFoundException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var concurrentUpdateException: Self { .init(.concurrentUpdateException) }
+    public static var failedResourceAccessException: Self { .init(.failedResourceAccessException) }
+    public static var internalServiceException: Self { .init(.internalServiceException) }
+    public static var invalidNextTokenException: Self { .init(.invalidNextTokenException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var objectNotFoundException: Self { .init(.objectNotFoundException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension ApplicationAutoScalingErrorType: Equatable {
+    public static func == (lhs: ApplicationAutoScalingErrorType, rhs: ApplicationAutoScalingErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ApplicationAutoScalingErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .concurrentUpdateException(let message):
-            return "ConcurrentUpdateException: \(message ?? "")"
-        case .failedResourceAccessException(let message):
-            return "FailedResourceAccessException: \(message ?? "")"
-        case .internalServiceException(let message):
-            return "InternalServiceException: \(message ?? "")"
-        case .invalidNextTokenException(let message):
-            return "InvalidNextTokenException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .objectNotFoundException(let message):
-            return "ObjectNotFoundException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/ApplicationDiscoveryService/ApplicationDiscoveryService_Error.swift
+++ b/Sources/Soto/Services/ApplicationDiscoveryService/ApplicationDiscoveryService_Error.swift
@@ -17,70 +17,56 @@
 import SotoCore
 
 /// Error enum for ApplicationDiscoveryService
-public enum ApplicationDiscoveryServiceErrorType: AWSErrorType {
-    case authorizationErrorException(message: String?)
-    case conflictErrorException(message: String?)
-    case homeRegionNotSetException(message: String?)
-    case invalidParameterException(message: String?)
-    case invalidParameterValueException(message: String?)
-    case operationNotPermittedException(message: String?)
-    case resourceInUseException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serverInternalErrorException(message: String?)
-}
+public struct ApplicationDiscoveryServiceErrorType: AWSErrorType {
+    enum Code: String {
+        case authorizationErrorException = "AuthorizationErrorException"
+        case conflictErrorException = "ConflictErrorException"
+        case homeRegionNotSetException = "HomeRegionNotSetException"
+        case invalidParameterException = "InvalidParameterException"
+        case invalidParameterValueException = "InvalidParameterValueException"
+        case operationNotPermittedException = "OperationNotPermittedException"
+        case resourceInUseException = "ResourceInUseException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serverInternalErrorException = "ServerInternalErrorException"
+    }
 
-extension ApplicationDiscoveryServiceErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AuthorizationErrorException":
-            self = .authorizationErrorException(message: message)
-        case "ConflictErrorException":
-            self = .conflictErrorException(message: message)
-        case "HomeRegionNotSetException":
-            self = .homeRegionNotSetException(message: message)
-        case "InvalidParameterException":
-            self = .invalidParameterException(message: message)
-        case "InvalidParameterValueException":
-            self = .invalidParameterValueException(message: message)
-        case "OperationNotPermittedException":
-            self = .operationNotPermittedException(message: message)
-        case "ResourceInUseException":
-            self = .resourceInUseException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServerInternalErrorException":
-            self = .serverInternalErrorException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var authorizationErrorException: Self { .init(.authorizationErrorException) }
+    public static var conflictErrorException: Self { .init(.conflictErrorException) }
+    public static var homeRegionNotSetException: Self { .init(.homeRegionNotSetException) }
+    public static var invalidParameterException: Self { .init(.invalidParameterException) }
+    public static var invalidParameterValueException: Self { .init(.invalidParameterValueException) }
+    public static var operationNotPermittedException: Self { .init(.operationNotPermittedException) }
+    public static var resourceInUseException: Self { .init(.resourceInUseException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serverInternalErrorException: Self { .init(.serverInternalErrorException) }
+}
+
+extension ApplicationDiscoveryServiceErrorType: Equatable {
+    public static func == (lhs: ApplicationDiscoveryServiceErrorType, rhs: ApplicationDiscoveryServiceErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ApplicationDiscoveryServiceErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .authorizationErrorException(let message):
-            return "AuthorizationErrorException: \(message ?? "")"
-        case .conflictErrorException(let message):
-            return "ConflictErrorException: \(message ?? "")"
-        case .homeRegionNotSetException(let message):
-            return "HomeRegionNotSetException: \(message ?? "")"
-        case .invalidParameterException(let message):
-            return "InvalidParameterException: \(message ?? "")"
-        case .invalidParameterValueException(let message):
-            return "InvalidParameterValueException: \(message ?? "")"
-        case .operationNotPermittedException(let message):
-            return "OperationNotPermittedException: \(message ?? "")"
-        case .resourceInUseException(let message):
-            return "ResourceInUseException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serverInternalErrorException(let message):
-            return "ServerInternalErrorException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/ApplicationInsights/ApplicationInsights_Error.swift
+++ b/Sources/Soto/Services/ApplicationInsights/ApplicationInsights_Error.swift
@@ -17,60 +17,52 @@
 import SotoCore
 
 /// Error enum for ApplicationInsights
-public enum ApplicationInsightsErrorType: AWSErrorType {
-    case badRequestException(message: String?)
-    case internalServerException(message: String?)
-    case resourceInUseException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case tagsAlreadyExistException(message: String?)
-    case tooManyTagsException(message: String?)
-    case validationException(message: String?)
-}
+public struct ApplicationInsightsErrorType: AWSErrorType {
+    enum Code: String {
+        case badRequestException = "BadRequestException"
+        case internalServerException = "InternalServerException"
+        case resourceInUseException = "ResourceInUseException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case tagsAlreadyExistException = "TagsAlreadyExistException"
+        case tooManyTagsException = "TooManyTagsException"
+        case validationException = "ValidationException"
+    }
 
-extension ApplicationInsightsErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "ResourceInUseException":
-            self = .resourceInUseException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "TagsAlreadyExistException":
-            self = .tagsAlreadyExistException(message: message)
-        case "TooManyTagsException":
-            self = .tooManyTagsException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var badRequestException: Self { .init(.badRequestException) }
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var resourceInUseException: Self { .init(.resourceInUseException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var tagsAlreadyExistException: Self { .init(.tagsAlreadyExistException) }
+    public static var tooManyTagsException: Self { .init(.tooManyTagsException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension ApplicationInsightsErrorType: Equatable {
+    public static func == (lhs: ApplicationInsightsErrorType, rhs: ApplicationInsightsErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ApplicationInsightsErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .resourceInUseException(let message):
-            return "ResourceInUseException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .tagsAlreadyExistException(let message):
-            return "TagsAlreadyExistException: \(message ?? "")"
-        case .tooManyTagsException(let message):
-            return "TooManyTagsException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Athena/Athena_Error.swift
+++ b/Sources/Soto/Services/Athena/Athena_Error.swift
@@ -17,50 +17,48 @@
 import SotoCore
 
 /// Error enum for Athena
-public enum AthenaErrorType: AWSErrorType {
-    case internalServerException(message: String?)
-    case invalidRequestException(message: String?)
-    case metadataException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case tooManyRequestsException(message: String?)
-}
+public struct AthenaErrorType: AWSErrorType {
+    enum Code: String {
+        case internalServerException = "InternalServerException"
+        case invalidRequestException = "InvalidRequestException"
+        case metadataException = "MetadataException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case tooManyRequestsException = "TooManyRequestsException"
+    }
 
-extension AthenaErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        case "MetadataException":
-            self = .metadataException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "TooManyRequestsException":
-            self = .tooManyRequestsException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+    public static var metadataException: Self { .init(.metadataException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var tooManyRequestsException: Self { .init(.tooManyRequestsException) }
+}
+
+extension AthenaErrorType: Equatable {
+    public static func == (lhs: AthenaErrorType, rhs: AthenaErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension AthenaErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        case .metadataException(let message):
-            return "MetadataException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .tooManyRequestsException(let message):
-            return "TooManyRequestsException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/AugmentedAIRuntime/AugmentedAIRuntime_Error.swift
+++ b/Sources/Soto/Services/AugmentedAIRuntime/AugmentedAIRuntime_Error.swift
@@ -17,55 +17,50 @@
 import SotoCore
 
 /// Error enum for AugmentedAIRuntime
-public enum AugmentedAIRuntimeErrorType: AWSErrorType {
-    case conflictException(message: String?)
-    case internalServerException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceQuotaExceededException(message: String?)
-    case throttlingException(message: String?)
-    case validationException(message: String?)
-}
+public struct AugmentedAIRuntimeErrorType: AWSErrorType {
+    enum Code: String {
+        case conflictException = "ConflictException"
+        case internalServerException = "InternalServerException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceQuotaExceededException = "ServiceQuotaExceededException"
+        case throttlingException = "ThrottlingException"
+        case validationException = "ValidationException"
+    }
 
-extension AugmentedAIRuntimeErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceQuotaExceededException":
-            self = .serviceQuotaExceededException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceQuotaExceededException: Self { .init(.serviceQuotaExceededException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension AugmentedAIRuntimeErrorType: Equatable {
+    public static func == (lhs: AugmentedAIRuntimeErrorType, rhs: AugmentedAIRuntimeErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension AugmentedAIRuntimeErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceQuotaExceededException(let message):
-            return "ServiceQuotaExceededException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/AutoScaling/AutoScaling_Error.swift
+++ b/Sources/Soto/Services/AutoScaling/AutoScaling_Error.swift
@@ -17,70 +17,56 @@
 import SotoCore
 
 /// Error enum for AutoScaling
-public enum AutoScalingErrorType: AWSErrorType {
-    case activeInstanceRefreshNotFoundFault(message: String?)
-    case alreadyExistsFault(message: String?)
-    case instanceRefreshInProgressFault(message: String?)
-    case invalidNextToken(message: String?)
-    case limitExceededFault(message: String?)
-    case resourceContentionFault(message: String?)
-    case resourceInUseFault(message: String?)
-    case scalingActivityInProgressFault(message: String?)
-    case serviceLinkedRoleFailure(message: String?)
-}
+public struct AutoScalingErrorType: AWSErrorType {
+    enum Code: String {
+        case activeInstanceRefreshNotFoundFault = "ActiveInstanceRefreshNotFound"
+        case alreadyExistsFault = "AlreadyExists"
+        case instanceRefreshInProgressFault = "InstanceRefreshInProgress"
+        case invalidNextToken = "InvalidNextToken"
+        case limitExceededFault = "LimitExceeded"
+        case resourceContentionFault = "ResourceContention"
+        case resourceInUseFault = "ResourceInUse"
+        case scalingActivityInProgressFault = "ScalingActivityInProgress"
+        case serviceLinkedRoleFailure = "ServiceLinkedRoleFailure"
+    }
 
-extension AutoScalingErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ActiveInstanceRefreshNotFound":
-            self = .activeInstanceRefreshNotFoundFault(message: message)
-        case "AlreadyExists":
-            self = .alreadyExistsFault(message: message)
-        case "InstanceRefreshInProgress":
-            self = .instanceRefreshInProgressFault(message: message)
-        case "InvalidNextToken":
-            self = .invalidNextToken(message: message)
-        case "LimitExceeded":
-            self = .limitExceededFault(message: message)
-        case "ResourceContention":
-            self = .resourceContentionFault(message: message)
-        case "ResourceInUse":
-            self = .resourceInUseFault(message: message)
-        case "ScalingActivityInProgress":
-            self = .scalingActivityInProgressFault(message: message)
-        case "ServiceLinkedRoleFailure":
-            self = .serviceLinkedRoleFailure(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var activeInstanceRefreshNotFoundFault: Self { .init(.activeInstanceRefreshNotFoundFault) }
+    public static var alreadyExistsFault: Self { .init(.alreadyExistsFault) }
+    public static var instanceRefreshInProgressFault: Self { .init(.instanceRefreshInProgressFault) }
+    public static var invalidNextToken: Self { .init(.invalidNextToken) }
+    public static var limitExceededFault: Self { .init(.limitExceededFault) }
+    public static var resourceContentionFault: Self { .init(.resourceContentionFault) }
+    public static var resourceInUseFault: Self { .init(.resourceInUseFault) }
+    public static var scalingActivityInProgressFault: Self { .init(.scalingActivityInProgressFault) }
+    public static var serviceLinkedRoleFailure: Self { .init(.serviceLinkedRoleFailure) }
+}
+
+extension AutoScalingErrorType: Equatable {
+    public static func == (lhs: AutoScalingErrorType, rhs: AutoScalingErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension AutoScalingErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .activeInstanceRefreshNotFoundFault(let message):
-            return "ActiveInstanceRefreshNotFound: \(message ?? "")"
-        case .alreadyExistsFault(let message):
-            return "AlreadyExists: \(message ?? "")"
-        case .instanceRefreshInProgressFault(let message):
-            return "InstanceRefreshInProgress: \(message ?? "")"
-        case .invalidNextToken(let message):
-            return "InvalidNextToken: \(message ?? "")"
-        case .limitExceededFault(let message):
-            return "LimitExceeded: \(message ?? "")"
-        case .resourceContentionFault(let message):
-            return "ResourceContention: \(message ?? "")"
-        case .resourceInUseFault(let message):
-            return "ResourceInUse: \(message ?? "")"
-        case .scalingActivityInProgressFault(let message):
-            return "ScalingActivityInProgress: \(message ?? "")"
-        case .serviceLinkedRoleFailure(let message):
-            return "ServiceLinkedRoleFailure: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/AutoScalingPlans/AutoScalingPlans_Error.swift
+++ b/Sources/Soto/Services/AutoScalingPlans/AutoScalingPlans_Error.swift
@@ -17,55 +17,50 @@
 import SotoCore
 
 /// Error enum for AutoScalingPlans
-public enum AutoScalingPlansErrorType: AWSErrorType {
-    case concurrentUpdateException(message: String?)
-    case internalServiceException(message: String?)
-    case invalidNextTokenException(message: String?)
-    case limitExceededException(message: String?)
-    case objectNotFoundException(message: String?)
-    case validationException(message: String?)
-}
+public struct AutoScalingPlansErrorType: AWSErrorType {
+    enum Code: String {
+        case concurrentUpdateException = "ConcurrentUpdateException"
+        case internalServiceException = "InternalServiceException"
+        case invalidNextTokenException = "InvalidNextTokenException"
+        case limitExceededException = "LimitExceededException"
+        case objectNotFoundException = "ObjectNotFoundException"
+        case validationException = "ValidationException"
+    }
 
-extension AutoScalingPlansErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ConcurrentUpdateException":
-            self = .concurrentUpdateException(message: message)
-        case "InternalServiceException":
-            self = .internalServiceException(message: message)
-        case "InvalidNextTokenException":
-            self = .invalidNextTokenException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ObjectNotFoundException":
-            self = .objectNotFoundException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var concurrentUpdateException: Self { .init(.concurrentUpdateException) }
+    public static var internalServiceException: Self { .init(.internalServiceException) }
+    public static var invalidNextTokenException: Self { .init(.invalidNextTokenException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var objectNotFoundException: Self { .init(.objectNotFoundException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension AutoScalingPlansErrorType: Equatable {
+    public static func == (lhs: AutoScalingPlansErrorType, rhs: AutoScalingPlansErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension AutoScalingPlansErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .concurrentUpdateException(let message):
-            return "ConcurrentUpdateException: \(message ?? "")"
-        case .internalServiceException(let message):
-            return "InternalServiceException: \(message ?? "")"
-        case .invalidNextTokenException(let message):
-            return "InvalidNextTokenException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .objectNotFoundException(let message):
-            return "ObjectNotFoundException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Backup/Backup_Error.swift
+++ b/Sources/Soto/Services/Backup/Backup_Error.swift
@@ -17,65 +17,54 @@
 import SotoCore
 
 /// Error enum for Backup
-public enum BackupErrorType: AWSErrorType {
-    case alreadyExistsException(message: String?)
-    case dependencyFailureException(message: String?)
-    case invalidParameterValueException(message: String?)
-    case invalidRequestException(message: String?)
-    case limitExceededException(message: String?)
-    case missingParameterValueException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceUnavailableException(message: String?)
-}
+public struct BackupErrorType: AWSErrorType {
+    enum Code: String {
+        case alreadyExistsException = "AlreadyExistsException"
+        case dependencyFailureException = "DependencyFailureException"
+        case invalidParameterValueException = "InvalidParameterValueException"
+        case invalidRequestException = "InvalidRequestException"
+        case limitExceededException = "LimitExceededException"
+        case missingParameterValueException = "MissingParameterValueException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+    }
 
-extension BackupErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AlreadyExistsException":
-            self = .alreadyExistsException(message: message)
-        case "DependencyFailureException":
-            self = .dependencyFailureException(message: message)
-        case "InvalidParameterValueException":
-            self = .invalidParameterValueException(message: message)
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "MissingParameterValueException":
-            self = .missingParameterValueException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var alreadyExistsException: Self { .init(.alreadyExistsException) }
+    public static var dependencyFailureException: Self { .init(.dependencyFailureException) }
+    public static var invalidParameterValueException: Self { .init(.invalidParameterValueException) }
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var missingParameterValueException: Self { .init(.missingParameterValueException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+}
+
+extension BackupErrorType: Equatable {
+    public static func == (lhs: BackupErrorType, rhs: BackupErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension BackupErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .alreadyExistsException(let message):
-            return "AlreadyExistsException: \(message ?? "")"
-        case .dependencyFailureException(let message):
-            return "DependencyFailureException: \(message ?? "")"
-        case .invalidParameterValueException(let message):
-            return "InvalidParameterValueException: \(message ?? "")"
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .missingParameterValueException(let message):
-            return "MissingParameterValueException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Braket/Braket_Error.swift
+++ b/Sources/Soto/Services/Braket/Braket_Error.swift
@@ -17,65 +17,54 @@
 import SotoCore
 
 /// Error enum for Braket
-public enum BraketErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case conflictException(message: String?)
-    case deviceOfflineException(message: String?)
-    case internalServiceException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceQuotaExceededException(message: String?)
-    case throttlingException(message: String?)
-    case validationException(message: String?)
-}
+public struct BraketErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case conflictException = "ConflictException"
+        case deviceOfflineException = "DeviceOfflineException"
+        case internalServiceException = "InternalServiceException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceQuotaExceededException = "ServiceQuotaExceededException"
+        case throttlingException = "ThrottlingException"
+        case validationException = "ValidationException"
+    }
 
-extension BraketErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "DeviceOfflineException":
-            self = .deviceOfflineException(message: message)
-        case "InternalServiceException":
-            self = .internalServiceException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceQuotaExceededException":
-            self = .serviceQuotaExceededException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var deviceOfflineException: Self { .init(.deviceOfflineException) }
+    public static var internalServiceException: Self { .init(.internalServiceException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceQuotaExceededException: Self { .init(.serviceQuotaExceededException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension BraketErrorType: Equatable {
+    public static func == (lhs: BraketErrorType, rhs: BraketErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension BraketErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .deviceOfflineException(let message):
-            return "DeviceOfflineException: \(message ?? "")"
-        case .internalServiceException(let message):
-            return "InternalServiceException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceQuotaExceededException(let message):
-            return "ServiceQuotaExceededException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Budgets/Budgets_Error.swift
+++ b/Sources/Soto/Services/Budgets/Budgets_Error.swift
@@ -17,65 +17,54 @@
 import SotoCore
 
 /// Error enum for Budgets
-public enum BudgetsErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case creationLimitExceededException(message: String?)
-    case duplicateRecordException(message: String?)
-    case expiredNextTokenException(message: String?)
-    case internalErrorException(message: String?)
-    case invalidNextTokenException(message: String?)
-    case invalidParameterException(message: String?)
-    case notFoundException(message: String?)
-}
+public struct BudgetsErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case creationLimitExceededException = "CreationLimitExceededException"
+        case duplicateRecordException = "DuplicateRecordException"
+        case expiredNextTokenException = "ExpiredNextTokenException"
+        case internalErrorException = "InternalErrorException"
+        case invalidNextTokenException = "InvalidNextTokenException"
+        case invalidParameterException = "InvalidParameterException"
+        case notFoundException = "NotFoundException"
+    }
 
-extension BudgetsErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "CreationLimitExceededException":
-            self = .creationLimitExceededException(message: message)
-        case "DuplicateRecordException":
-            self = .duplicateRecordException(message: message)
-        case "ExpiredNextTokenException":
-            self = .expiredNextTokenException(message: message)
-        case "InternalErrorException":
-            self = .internalErrorException(message: message)
-        case "InvalidNextTokenException":
-            self = .invalidNextTokenException(message: message)
-        case "InvalidParameterException":
-            self = .invalidParameterException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var creationLimitExceededException: Self { .init(.creationLimitExceededException) }
+    public static var duplicateRecordException: Self { .init(.duplicateRecordException) }
+    public static var expiredNextTokenException: Self { .init(.expiredNextTokenException) }
+    public static var internalErrorException: Self { .init(.internalErrorException) }
+    public static var invalidNextTokenException: Self { .init(.invalidNextTokenException) }
+    public static var invalidParameterException: Self { .init(.invalidParameterException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+}
+
+extension BudgetsErrorType: Equatable {
+    public static func == (lhs: BudgetsErrorType, rhs: BudgetsErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension BudgetsErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .creationLimitExceededException(let message):
-            return "CreationLimitExceededException: \(message ?? "")"
-        case .duplicateRecordException(let message):
-            return "DuplicateRecordException: \(message ?? "")"
-        case .expiredNextTokenException(let message):
-            return "ExpiredNextTokenException: \(message ?? "")"
-        case .internalErrorException(let message):
-            return "InternalErrorException: \(message ?? "")"
-        case .invalidNextTokenException(let message):
-            return "InvalidNextTokenException: \(message ?? "")"
-        case .invalidParameterException(let message):
-            return "InvalidParameterException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Chime/Chime_Error.swift
+++ b/Sources/Soto/Services/Chime/Chime_Error.swift
@@ -17,80 +17,60 @@
 import SotoCore
 
 /// Error enum for Chime
-public enum ChimeErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case badRequestException(message: String?)
-    case conflictException(message: String?)
-    case forbiddenException(message: String?)
-    case notFoundException(message: String?)
-    case resourceLimitExceededException(message: String?)
-    case serviceFailureException(message: String?)
-    case serviceUnavailableException(message: String?)
-    case throttledClientException(message: String?)
-    case unauthorizedClientException(message: String?)
-    case unprocessableEntityException(message: String?)
-}
+public struct ChimeErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case badRequestException = "BadRequestException"
+        case conflictException = "ConflictException"
+        case forbiddenException = "ForbiddenException"
+        case notFoundException = "NotFoundException"
+        case resourceLimitExceededException = "ResourceLimitExceededException"
+        case serviceFailureException = "ServiceFailureException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+        case throttledClientException = "ThrottledClientException"
+        case unauthorizedClientException = "UnauthorizedClientException"
+        case unprocessableEntityException = "UnprocessableEntityException"
+    }
 
-extension ChimeErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "ForbiddenException":
-            self = .forbiddenException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "ResourceLimitExceededException":
-            self = .resourceLimitExceededException(message: message)
-        case "ServiceFailureException":
-            self = .serviceFailureException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        case "ThrottledClientException":
-            self = .throttledClientException(message: message)
-        case "UnauthorizedClientException":
-            self = .unauthorizedClientException(message: message)
-        case "UnprocessableEntityException":
-            self = .unprocessableEntityException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var badRequestException: Self { .init(.badRequestException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var forbiddenException: Self { .init(.forbiddenException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var resourceLimitExceededException: Self { .init(.resourceLimitExceededException) }
+    public static var serviceFailureException: Self { .init(.serviceFailureException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+    public static var throttledClientException: Self { .init(.throttledClientException) }
+    public static var unauthorizedClientException: Self { .init(.unauthorizedClientException) }
+    public static var unprocessableEntityException: Self { .init(.unprocessableEntityException) }
+}
+
+extension ChimeErrorType: Equatable {
+    public static func == (lhs: ChimeErrorType, rhs: ChimeErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ChimeErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .forbiddenException(let message):
-            return "ForbiddenException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .resourceLimitExceededException(let message):
-            return "ResourceLimitExceededException: \(message ?? "")"
-        case .serviceFailureException(let message):
-            return "ServiceFailureException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        case .throttledClientException(let message):
-            return "ThrottledClientException: \(message ?? "")"
-        case .unauthorizedClientException(let message):
-            return "UnauthorizedClientException: \(message ?? "")"
-        case .unprocessableEntityException(let message):
-            return "UnprocessableEntityException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Cloud9/Cloud9_Error.swift
+++ b/Sources/Soto/Services/Cloud9/Cloud9_Error.swift
@@ -17,65 +17,54 @@
 import SotoCore
 
 /// Error enum for Cloud9
-public enum Cloud9ErrorType: AWSErrorType {
-    case badRequestException(message: String?)
-    case concurrentAccessException(message: String?)
-    case conflictException(message: String?)
-    case forbiddenException(message: String?)
-    case internalServerErrorException(message: String?)
-    case limitExceededException(message: String?)
-    case notFoundException(message: String?)
-    case tooManyRequestsException(message: String?)
-}
+public struct Cloud9ErrorType: AWSErrorType {
+    enum Code: String {
+        case badRequestException = "BadRequestException"
+        case concurrentAccessException = "ConcurrentAccessException"
+        case conflictException = "ConflictException"
+        case forbiddenException = "ForbiddenException"
+        case internalServerErrorException = "InternalServerErrorException"
+        case limitExceededException = "LimitExceededException"
+        case notFoundException = "NotFoundException"
+        case tooManyRequestsException = "TooManyRequestsException"
+    }
 
-extension Cloud9ErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        case "ConcurrentAccessException":
-            self = .concurrentAccessException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "ForbiddenException":
-            self = .forbiddenException(message: message)
-        case "InternalServerErrorException":
-            self = .internalServerErrorException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "TooManyRequestsException":
-            self = .tooManyRequestsException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var badRequestException: Self { .init(.badRequestException) }
+    public static var concurrentAccessException: Self { .init(.concurrentAccessException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var forbiddenException: Self { .init(.forbiddenException) }
+    public static var internalServerErrorException: Self { .init(.internalServerErrorException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var tooManyRequestsException: Self { .init(.tooManyRequestsException) }
+}
+
+extension Cloud9ErrorType: Equatable {
+    public static func == (lhs: Cloud9ErrorType, rhs: Cloud9ErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension Cloud9ErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        case .concurrentAccessException(let message):
-            return "ConcurrentAccessException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .forbiddenException(let message):
-            return "ForbiddenException: \(message ?? "")"
-        case .internalServerErrorException(let message):
-            return "InternalServerErrorException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .tooManyRequestsException(let message):
-            return "TooManyRequestsException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/CloudDirectory/CloudDirectory_Error.swift
+++ b/Sources/Soto/Services/CloudDirectory/CloudDirectory_Error.swift
@@ -17,200 +17,108 @@
 import SotoCore
 
 /// Error enum for CloudDirectory
-public enum CloudDirectoryErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case batchWriteException(message: String?)
-    case cannotListParentOfRootException(message: String?)
-    case directoryAlreadyExistsException(message: String?)
-    case directoryDeletedException(message: String?)
-    case directoryNotDisabledException(message: String?)
-    case directoryNotEnabledException(message: String?)
-    case facetAlreadyExistsException(message: String?)
-    case facetInUseException(message: String?)
-    case facetNotFoundException(message: String?)
-    case facetValidationException(message: String?)
-    case incompatibleSchemaException(message: String?)
-    case indexedAttributeMissingException(message: String?)
-    case internalServiceException(message: String?)
-    case invalidArnException(message: String?)
-    case invalidAttachmentException(message: String?)
-    case invalidFacetUpdateException(message: String?)
-    case invalidNextTokenException(message: String?)
-    case invalidRuleException(message: String?)
-    case invalidSchemaDocException(message: String?)
-    case invalidTaggingRequestException(message: String?)
-    case limitExceededException(message: String?)
-    case linkNameAlreadyInUseException(message: String?)
-    case notIndexException(message: String?)
-    case notNodeException(message: String?)
-    case notPolicyException(message: String?)
-    case objectAlreadyDetachedException(message: String?)
-    case objectNotDetachedException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case retryableConflictException(message: String?)
-    case schemaAlreadyExistsException(message: String?)
-    case schemaAlreadyPublishedException(message: String?)
-    case stillContainsLinksException(message: String?)
-    case unsupportedIndexTypeException(message: String?)
-    case validationException(message: String?)
-}
+public struct CloudDirectoryErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case batchWriteException = "BatchWriteException"
+        case cannotListParentOfRootException = "CannotListParentOfRootException"
+        case directoryAlreadyExistsException = "DirectoryAlreadyExistsException"
+        case directoryDeletedException = "DirectoryDeletedException"
+        case directoryNotDisabledException = "DirectoryNotDisabledException"
+        case directoryNotEnabledException = "DirectoryNotEnabledException"
+        case facetAlreadyExistsException = "FacetAlreadyExistsException"
+        case facetInUseException = "FacetInUseException"
+        case facetNotFoundException = "FacetNotFoundException"
+        case facetValidationException = "FacetValidationException"
+        case incompatibleSchemaException = "IncompatibleSchemaException"
+        case indexedAttributeMissingException = "IndexedAttributeMissingException"
+        case internalServiceException = "InternalServiceException"
+        case invalidArnException = "InvalidArnException"
+        case invalidAttachmentException = "InvalidAttachmentException"
+        case invalidFacetUpdateException = "InvalidFacetUpdateException"
+        case invalidNextTokenException = "InvalidNextTokenException"
+        case invalidRuleException = "InvalidRuleException"
+        case invalidSchemaDocException = "InvalidSchemaDocException"
+        case invalidTaggingRequestException = "InvalidTaggingRequestException"
+        case limitExceededException = "LimitExceededException"
+        case linkNameAlreadyInUseException = "LinkNameAlreadyInUseException"
+        case notIndexException = "NotIndexException"
+        case notNodeException = "NotNodeException"
+        case notPolicyException = "NotPolicyException"
+        case objectAlreadyDetachedException = "ObjectAlreadyDetachedException"
+        case objectNotDetachedException = "ObjectNotDetachedException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case retryableConflictException = "RetryableConflictException"
+        case schemaAlreadyExistsException = "SchemaAlreadyExistsException"
+        case schemaAlreadyPublishedException = "SchemaAlreadyPublishedException"
+        case stillContainsLinksException = "StillContainsLinksException"
+        case unsupportedIndexTypeException = "UnsupportedIndexTypeException"
+        case validationException = "ValidationException"
+    }
 
-extension CloudDirectoryErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "BatchWriteException":
-            self = .batchWriteException(message: message)
-        case "CannotListParentOfRootException":
-            self = .cannotListParentOfRootException(message: message)
-        case "DirectoryAlreadyExistsException":
-            self = .directoryAlreadyExistsException(message: message)
-        case "DirectoryDeletedException":
-            self = .directoryDeletedException(message: message)
-        case "DirectoryNotDisabledException":
-            self = .directoryNotDisabledException(message: message)
-        case "DirectoryNotEnabledException":
-            self = .directoryNotEnabledException(message: message)
-        case "FacetAlreadyExistsException":
-            self = .facetAlreadyExistsException(message: message)
-        case "FacetInUseException":
-            self = .facetInUseException(message: message)
-        case "FacetNotFoundException":
-            self = .facetNotFoundException(message: message)
-        case "FacetValidationException":
-            self = .facetValidationException(message: message)
-        case "IncompatibleSchemaException":
-            self = .incompatibleSchemaException(message: message)
-        case "IndexedAttributeMissingException":
-            self = .indexedAttributeMissingException(message: message)
-        case "InternalServiceException":
-            self = .internalServiceException(message: message)
-        case "InvalidArnException":
-            self = .invalidArnException(message: message)
-        case "InvalidAttachmentException":
-            self = .invalidAttachmentException(message: message)
-        case "InvalidFacetUpdateException":
-            self = .invalidFacetUpdateException(message: message)
-        case "InvalidNextTokenException":
-            self = .invalidNextTokenException(message: message)
-        case "InvalidRuleException":
-            self = .invalidRuleException(message: message)
-        case "InvalidSchemaDocException":
-            self = .invalidSchemaDocException(message: message)
-        case "InvalidTaggingRequestException":
-            self = .invalidTaggingRequestException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "LinkNameAlreadyInUseException":
-            self = .linkNameAlreadyInUseException(message: message)
-        case "NotIndexException":
-            self = .notIndexException(message: message)
-        case "NotNodeException":
-            self = .notNodeException(message: message)
-        case "NotPolicyException":
-            self = .notPolicyException(message: message)
-        case "ObjectAlreadyDetachedException":
-            self = .objectAlreadyDetachedException(message: message)
-        case "ObjectNotDetachedException":
-            self = .objectNotDetachedException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "RetryableConflictException":
-            self = .retryableConflictException(message: message)
-        case "SchemaAlreadyExistsException":
-            self = .schemaAlreadyExistsException(message: message)
-        case "SchemaAlreadyPublishedException":
-            self = .schemaAlreadyPublishedException(message: message)
-        case "StillContainsLinksException":
-            self = .stillContainsLinksException(message: message)
-        case "UnsupportedIndexTypeException":
-            self = .unsupportedIndexTypeException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var batchWriteException: Self { .init(.batchWriteException) }
+    public static var cannotListParentOfRootException: Self { .init(.cannotListParentOfRootException) }
+    public static var directoryAlreadyExistsException: Self { .init(.directoryAlreadyExistsException) }
+    public static var directoryDeletedException: Self { .init(.directoryDeletedException) }
+    public static var directoryNotDisabledException: Self { .init(.directoryNotDisabledException) }
+    public static var directoryNotEnabledException: Self { .init(.directoryNotEnabledException) }
+    public static var facetAlreadyExistsException: Self { .init(.facetAlreadyExistsException) }
+    public static var facetInUseException: Self { .init(.facetInUseException) }
+    public static var facetNotFoundException: Self { .init(.facetNotFoundException) }
+    public static var facetValidationException: Self { .init(.facetValidationException) }
+    public static var incompatibleSchemaException: Self { .init(.incompatibleSchemaException) }
+    public static var indexedAttributeMissingException: Self { .init(.indexedAttributeMissingException) }
+    public static var internalServiceException: Self { .init(.internalServiceException) }
+    public static var invalidArnException: Self { .init(.invalidArnException) }
+    public static var invalidAttachmentException: Self { .init(.invalidAttachmentException) }
+    public static var invalidFacetUpdateException: Self { .init(.invalidFacetUpdateException) }
+    public static var invalidNextTokenException: Self { .init(.invalidNextTokenException) }
+    public static var invalidRuleException: Self { .init(.invalidRuleException) }
+    public static var invalidSchemaDocException: Self { .init(.invalidSchemaDocException) }
+    public static var invalidTaggingRequestException: Self { .init(.invalidTaggingRequestException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var linkNameAlreadyInUseException: Self { .init(.linkNameAlreadyInUseException) }
+    public static var notIndexException: Self { .init(.notIndexException) }
+    public static var notNodeException: Self { .init(.notNodeException) }
+    public static var notPolicyException: Self { .init(.notPolicyException) }
+    public static var objectAlreadyDetachedException: Self { .init(.objectAlreadyDetachedException) }
+    public static var objectNotDetachedException: Self { .init(.objectNotDetachedException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var retryableConflictException: Self { .init(.retryableConflictException) }
+    public static var schemaAlreadyExistsException: Self { .init(.schemaAlreadyExistsException) }
+    public static var schemaAlreadyPublishedException: Self { .init(.schemaAlreadyPublishedException) }
+    public static var stillContainsLinksException: Self { .init(.stillContainsLinksException) }
+    public static var unsupportedIndexTypeException: Self { .init(.unsupportedIndexTypeException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension CloudDirectoryErrorType: Equatable {
+    public static func == (lhs: CloudDirectoryErrorType, rhs: CloudDirectoryErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension CloudDirectoryErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .batchWriteException(let message):
-            return "BatchWriteException: \(message ?? "")"
-        case .cannotListParentOfRootException(let message):
-            return "CannotListParentOfRootException: \(message ?? "")"
-        case .directoryAlreadyExistsException(let message):
-            return "DirectoryAlreadyExistsException: \(message ?? "")"
-        case .directoryDeletedException(let message):
-            return "DirectoryDeletedException: \(message ?? "")"
-        case .directoryNotDisabledException(let message):
-            return "DirectoryNotDisabledException: \(message ?? "")"
-        case .directoryNotEnabledException(let message):
-            return "DirectoryNotEnabledException: \(message ?? "")"
-        case .facetAlreadyExistsException(let message):
-            return "FacetAlreadyExistsException: \(message ?? "")"
-        case .facetInUseException(let message):
-            return "FacetInUseException: \(message ?? "")"
-        case .facetNotFoundException(let message):
-            return "FacetNotFoundException: \(message ?? "")"
-        case .facetValidationException(let message):
-            return "FacetValidationException: \(message ?? "")"
-        case .incompatibleSchemaException(let message):
-            return "IncompatibleSchemaException: \(message ?? "")"
-        case .indexedAttributeMissingException(let message):
-            return "IndexedAttributeMissingException: \(message ?? "")"
-        case .internalServiceException(let message):
-            return "InternalServiceException: \(message ?? "")"
-        case .invalidArnException(let message):
-            return "InvalidArnException: \(message ?? "")"
-        case .invalidAttachmentException(let message):
-            return "InvalidAttachmentException: \(message ?? "")"
-        case .invalidFacetUpdateException(let message):
-            return "InvalidFacetUpdateException: \(message ?? "")"
-        case .invalidNextTokenException(let message):
-            return "InvalidNextTokenException: \(message ?? "")"
-        case .invalidRuleException(let message):
-            return "InvalidRuleException: \(message ?? "")"
-        case .invalidSchemaDocException(let message):
-            return "InvalidSchemaDocException: \(message ?? "")"
-        case .invalidTaggingRequestException(let message):
-            return "InvalidTaggingRequestException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .linkNameAlreadyInUseException(let message):
-            return "LinkNameAlreadyInUseException: \(message ?? "")"
-        case .notIndexException(let message):
-            return "NotIndexException: \(message ?? "")"
-        case .notNodeException(let message):
-            return "NotNodeException: \(message ?? "")"
-        case .notPolicyException(let message):
-            return "NotPolicyException: \(message ?? "")"
-        case .objectAlreadyDetachedException(let message):
-            return "ObjectAlreadyDetachedException: \(message ?? "")"
-        case .objectNotDetachedException(let message):
-            return "ObjectNotDetachedException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .retryableConflictException(let message):
-            return "RetryableConflictException: \(message ?? "")"
-        case .schemaAlreadyExistsException(let message):
-            return "SchemaAlreadyExistsException: \(message ?? "")"
-        case .schemaAlreadyPublishedException(let message):
-            return "SchemaAlreadyPublishedException: \(message ?? "")"
-        case .stillContainsLinksException(let message):
-            return "StillContainsLinksException: \(message ?? "")"
-        case .unsupportedIndexTypeException(let message):
-            return "UnsupportedIndexTypeException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/CloudFormation/CloudFormation_Error.swift
+++ b/Sources/Soto/Services/CloudFormation/CloudFormation_Error.swift
@@ -17,125 +17,78 @@
 import SotoCore
 
 /// Error enum for CloudFormation
-public enum CloudFormationErrorType: AWSErrorType {
-    case alreadyExistsException(message: String?)
-    case cFNRegistryException(message: String?)
-    case changeSetNotFoundException(message: String?)
-    case createdButModifiedException(message: String?)
-    case insufficientCapabilitiesException(message: String?)
-    case invalidChangeSetStatusException(message: String?)
-    case invalidOperationException(message: String?)
-    case invalidStateTransitionException(message: String?)
-    case limitExceededException(message: String?)
-    case nameAlreadyExistsException(message: String?)
-    case operationIdAlreadyExistsException(message: String?)
-    case operationInProgressException(message: String?)
-    case operationNotFoundException(message: String?)
-    case operationStatusCheckFailedException(message: String?)
-    case stackInstanceNotFoundException(message: String?)
-    case stackSetNotEmptyException(message: String?)
-    case stackSetNotFoundException(message: String?)
-    case staleRequestException(message: String?)
-    case tokenAlreadyExistsException(message: String?)
-    case typeNotFoundException(message: String?)
-}
+public struct CloudFormationErrorType: AWSErrorType {
+    enum Code: String {
+        case alreadyExistsException = "AlreadyExistsException"
+        case cFNRegistryException = "CFNRegistryException"
+        case changeSetNotFoundException = "ChangeSetNotFound"
+        case createdButModifiedException = "CreatedButModifiedException"
+        case insufficientCapabilitiesException = "InsufficientCapabilitiesException"
+        case invalidChangeSetStatusException = "InvalidChangeSetStatus"
+        case invalidOperationException = "InvalidOperationException"
+        case invalidStateTransitionException = "InvalidStateTransition"
+        case limitExceededException = "LimitExceededException"
+        case nameAlreadyExistsException = "NameAlreadyExistsException"
+        case operationIdAlreadyExistsException = "OperationIdAlreadyExistsException"
+        case operationInProgressException = "OperationInProgressException"
+        case operationNotFoundException = "OperationNotFoundException"
+        case operationStatusCheckFailedException = "ConditionalCheckFailed"
+        case stackInstanceNotFoundException = "StackInstanceNotFoundException"
+        case stackSetNotEmptyException = "StackSetNotEmptyException"
+        case stackSetNotFoundException = "StackSetNotFoundException"
+        case staleRequestException = "StaleRequestException"
+        case tokenAlreadyExistsException = "TokenAlreadyExistsException"
+        case typeNotFoundException = "TypeNotFoundException"
+    }
 
-extension CloudFormationErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AlreadyExistsException":
-            self = .alreadyExistsException(message: message)
-        case "CFNRegistryException":
-            self = .cFNRegistryException(message: message)
-        case "ChangeSetNotFound":
-            self = .changeSetNotFoundException(message: message)
-        case "CreatedButModifiedException":
-            self = .createdButModifiedException(message: message)
-        case "InsufficientCapabilitiesException":
-            self = .insufficientCapabilitiesException(message: message)
-        case "InvalidChangeSetStatus":
-            self = .invalidChangeSetStatusException(message: message)
-        case "InvalidOperationException":
-            self = .invalidOperationException(message: message)
-        case "InvalidStateTransition":
-            self = .invalidStateTransitionException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "NameAlreadyExistsException":
-            self = .nameAlreadyExistsException(message: message)
-        case "OperationIdAlreadyExistsException":
-            self = .operationIdAlreadyExistsException(message: message)
-        case "OperationInProgressException":
-            self = .operationInProgressException(message: message)
-        case "OperationNotFoundException":
-            self = .operationNotFoundException(message: message)
-        case "ConditionalCheckFailed":
-            self = .operationStatusCheckFailedException(message: message)
-        case "StackInstanceNotFoundException":
-            self = .stackInstanceNotFoundException(message: message)
-        case "StackSetNotEmptyException":
-            self = .stackSetNotEmptyException(message: message)
-        case "StackSetNotFoundException":
-            self = .stackSetNotFoundException(message: message)
-        case "StaleRequestException":
-            self = .staleRequestException(message: message)
-        case "TokenAlreadyExistsException":
-            self = .tokenAlreadyExistsException(message: message)
-        case "TypeNotFoundException":
-            self = .typeNotFoundException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var alreadyExistsException: Self { .init(.alreadyExistsException) }
+    public static var cFNRegistryException: Self { .init(.cFNRegistryException) }
+    public static var changeSetNotFoundException: Self { .init(.changeSetNotFoundException) }
+    public static var createdButModifiedException: Self { .init(.createdButModifiedException) }
+    public static var insufficientCapabilitiesException: Self { .init(.insufficientCapabilitiesException) }
+    public static var invalidChangeSetStatusException: Self { .init(.invalidChangeSetStatusException) }
+    public static var invalidOperationException: Self { .init(.invalidOperationException) }
+    public static var invalidStateTransitionException: Self { .init(.invalidStateTransitionException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var nameAlreadyExistsException: Self { .init(.nameAlreadyExistsException) }
+    public static var operationIdAlreadyExistsException: Self { .init(.operationIdAlreadyExistsException) }
+    public static var operationInProgressException: Self { .init(.operationInProgressException) }
+    public static var operationNotFoundException: Self { .init(.operationNotFoundException) }
+    public static var operationStatusCheckFailedException: Self { .init(.operationStatusCheckFailedException) }
+    public static var stackInstanceNotFoundException: Self { .init(.stackInstanceNotFoundException) }
+    public static var stackSetNotEmptyException: Self { .init(.stackSetNotEmptyException) }
+    public static var stackSetNotFoundException: Self { .init(.stackSetNotFoundException) }
+    public static var staleRequestException: Self { .init(.staleRequestException) }
+    public static var tokenAlreadyExistsException: Self { .init(.tokenAlreadyExistsException) }
+    public static var typeNotFoundException: Self { .init(.typeNotFoundException) }
+}
+
+extension CloudFormationErrorType: Equatable {
+    public static func == (lhs: CloudFormationErrorType, rhs: CloudFormationErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension CloudFormationErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .alreadyExistsException(let message):
-            return "AlreadyExistsException: \(message ?? "")"
-        case .cFNRegistryException(let message):
-            return "CFNRegistryException: \(message ?? "")"
-        case .changeSetNotFoundException(let message):
-            return "ChangeSetNotFound: \(message ?? "")"
-        case .createdButModifiedException(let message):
-            return "CreatedButModifiedException: \(message ?? "")"
-        case .insufficientCapabilitiesException(let message):
-            return "InsufficientCapabilitiesException: \(message ?? "")"
-        case .invalidChangeSetStatusException(let message):
-            return "InvalidChangeSetStatus: \(message ?? "")"
-        case .invalidOperationException(let message):
-            return "InvalidOperationException: \(message ?? "")"
-        case .invalidStateTransitionException(let message):
-            return "InvalidStateTransition: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .nameAlreadyExistsException(let message):
-            return "NameAlreadyExistsException: \(message ?? "")"
-        case .operationIdAlreadyExistsException(let message):
-            return "OperationIdAlreadyExistsException: \(message ?? "")"
-        case .operationInProgressException(let message):
-            return "OperationInProgressException: \(message ?? "")"
-        case .operationNotFoundException(let message):
-            return "OperationNotFoundException: \(message ?? "")"
-        case .operationStatusCheckFailedException(let message):
-            return "ConditionalCheckFailed: \(message ?? "")"
-        case .stackInstanceNotFoundException(let message):
-            return "StackInstanceNotFoundException: \(message ?? "")"
-        case .stackSetNotEmptyException(let message):
-            return "StackSetNotEmptyException: \(message ?? "")"
-        case .stackSetNotFoundException(let message):
-            return "StackSetNotFoundException: \(message ?? "")"
-        case .staleRequestException(let message):
-            return "StaleRequestException: \(message ?? "")"
-        case .tokenAlreadyExistsException(let message):
-            return "TokenAlreadyExistsException: \(message ?? "")"
-        case .typeNotFoundException(let message):
-            return "TypeNotFoundException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/CloudFront/CloudFront_Error.swift
+++ b/Sources/Soto/Services/CloudFront/CloudFront_Error.swift
@@ -17,540 +17,244 @@
 import SotoCore
 
 /// Error enum for CloudFront
-public enum CloudFrontErrorType: AWSErrorType {
-    case accessDenied(message: String?)
-    case batchTooLarge(message: String?)
-    case cNAMEAlreadyExists(message: String?)
-    case cachePolicyAlreadyExists(message: String?)
-    case cachePolicyInUse(message: String?)
-    case cannotChangeImmutablePublicKeyFields(message: String?)
-    case cloudFrontOriginAccessIdentityAlreadyExists(message: String?)
-    case cloudFrontOriginAccessIdentityInUse(message: String?)
-    case distributionAlreadyExists(message: String?)
-    case distributionNotDisabled(message: String?)
-    case fieldLevelEncryptionConfigAlreadyExists(message: String?)
-    case fieldLevelEncryptionConfigInUse(message: String?)
-    case fieldLevelEncryptionProfileAlreadyExists(message: String?)
-    case fieldLevelEncryptionProfileInUse(message: String?)
-    case fieldLevelEncryptionProfileSizeExceeded(message: String?)
-    case illegalDelete(message: String?)
-    case illegalFieldLevelEncryptionConfigAssociationWithCacheBehavior(message: String?)
-    case illegalUpdate(message: String?)
-    case inconsistentQuantities(message: String?)
-    case invalidArgument(message: String?)
-    case invalidDefaultRootObject(message: String?)
-    case invalidErrorCode(message: String?)
-    case invalidForwardCookies(message: String?)
-    case invalidGeoRestrictionParameter(message: String?)
-    case invalidHeadersForS3Origin(message: String?)
-    case invalidIfMatchVersion(message: String?)
-    case invalidLambdaFunctionAssociation(message: String?)
-    case invalidLocationCode(message: String?)
-    case invalidMinimumProtocolVersion(message: String?)
-    case invalidOrigin(message: String?)
-    case invalidOriginAccessIdentity(message: String?)
-    case invalidOriginKeepaliveTimeout(message: String?)
-    case invalidOriginReadTimeout(message: String?)
-    case invalidProtocolSettings(message: String?)
-    case invalidQueryStringParameters(message: String?)
-    case invalidRelativePath(message: String?)
-    case invalidRequiredProtocol(message: String?)
-    case invalidResponseCode(message: String?)
-    case invalidTTLOrder(message: String?)
-    case invalidTagging(message: String?)
-    case invalidViewerCertificate(message: String?)
-    case invalidWebACLId(message: String?)
-    case missingBody(message: String?)
-    case noSuchCachePolicy(message: String?)
-    case noSuchCloudFrontOriginAccessIdentity(message: String?)
-    case noSuchDistribution(message: String?)
-    case noSuchFieldLevelEncryptionConfig(message: String?)
-    case noSuchFieldLevelEncryptionProfile(message: String?)
-    case noSuchInvalidation(message: String?)
-    case noSuchOrigin(message: String?)
-    case noSuchOriginRequestPolicy(message: String?)
-    case noSuchPublicKey(message: String?)
-    case noSuchRealtimeLogConfig(message: String?)
-    case noSuchResource(message: String?)
-    case noSuchStreamingDistribution(message: String?)
-    case originRequestPolicyAlreadyExists(message: String?)
-    case originRequestPolicyInUse(message: String?)
-    case preconditionFailed(message: String?)
-    case publicKeyAlreadyExists(message: String?)
-    case publicKeyInUse(message: String?)
-    case queryArgProfileEmpty(message: String?)
-    case realtimeLogConfigAlreadyExists(message: String?)
-    case realtimeLogConfigInUse(message: String?)
-    case streamingDistributionAlreadyExists(message: String?)
-    case streamingDistributionNotDisabled(message: String?)
-    case tooManyCacheBehaviors(message: String?)
-    case tooManyCachePolicies(message: String?)
-    case tooManyCertificates(message: String?)
-    case tooManyCloudFrontOriginAccessIdentities(message: String?)
-    case tooManyCookieNamesInWhiteList(message: String?)
-    case tooManyCookiesInCachePolicy(message: String?)
-    case tooManyCookiesInOriginRequestPolicy(message: String?)
-    case tooManyDistributionCNAMEs(message: String?)
-    case tooManyDistributions(message: String?)
-    case tooManyDistributionsAssociatedToCachePolicy(message: String?)
-    case tooManyDistributionsAssociatedToFieldLevelEncryptionConfig(message: String?)
-    case tooManyDistributionsAssociatedToOriginRequestPolicy(message: String?)
-    case tooManyDistributionsWithLambdaAssociations(message: String?)
-    case tooManyDistributionsWithSingleFunctionARN(message: String?)
-    case tooManyFieldLevelEncryptionConfigs(message: String?)
-    case tooManyFieldLevelEncryptionContentTypeProfiles(message: String?)
-    case tooManyFieldLevelEncryptionEncryptionEntities(message: String?)
-    case tooManyFieldLevelEncryptionFieldPatterns(message: String?)
-    case tooManyFieldLevelEncryptionProfiles(message: String?)
-    case tooManyFieldLevelEncryptionQueryArgProfiles(message: String?)
-    case tooManyHeadersInCachePolicy(message: String?)
-    case tooManyHeadersInForwardedValues(message: String?)
-    case tooManyHeadersInOriginRequestPolicy(message: String?)
-    case tooManyInvalidationsInProgress(message: String?)
-    case tooManyLambdaFunctionAssociations(message: String?)
-    case tooManyOriginCustomHeaders(message: String?)
-    case tooManyOriginGroupsPerDistribution(message: String?)
-    case tooManyOriginRequestPolicies(message: String?)
-    case tooManyOrigins(message: String?)
-    case tooManyPublicKeys(message: String?)
-    case tooManyQueryStringParameters(message: String?)
-    case tooManyQueryStringsInCachePolicy(message: String?)
-    case tooManyQueryStringsInOriginRequestPolicy(message: String?)
-    case tooManyRealtimeLogConfigs(message: String?)
-    case tooManyStreamingDistributionCNAMEs(message: String?)
-    case tooManyStreamingDistributions(message: String?)
-    case tooManyTrustedSigners(message: String?)
-    case trustedSignerDoesNotExist(message: String?)
-}
+public struct CloudFrontErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDenied = "AccessDenied"
+        case batchTooLarge = "BatchTooLarge"
+        case cNAMEAlreadyExists = "CNAMEAlreadyExists"
+        case cachePolicyAlreadyExists = "CachePolicyAlreadyExists"
+        case cachePolicyInUse = "CachePolicyInUse"
+        case cannotChangeImmutablePublicKeyFields = "CannotChangeImmutablePublicKeyFields"
+        case cloudFrontOriginAccessIdentityAlreadyExists = "CloudFrontOriginAccessIdentityAlreadyExists"
+        case cloudFrontOriginAccessIdentityInUse = "CloudFrontOriginAccessIdentityInUse"
+        case distributionAlreadyExists = "DistributionAlreadyExists"
+        case distributionNotDisabled = "DistributionNotDisabled"
+        case fieldLevelEncryptionConfigAlreadyExists = "FieldLevelEncryptionConfigAlreadyExists"
+        case fieldLevelEncryptionConfigInUse = "FieldLevelEncryptionConfigInUse"
+        case fieldLevelEncryptionProfileAlreadyExists = "FieldLevelEncryptionProfileAlreadyExists"
+        case fieldLevelEncryptionProfileInUse = "FieldLevelEncryptionProfileInUse"
+        case fieldLevelEncryptionProfileSizeExceeded = "FieldLevelEncryptionProfileSizeExceeded"
+        case illegalDelete = "IllegalDelete"
+        case illegalFieldLevelEncryptionConfigAssociationWithCacheBehavior = "IllegalFieldLevelEncryptionConfigAssociationWithCacheBehavior"
+        case illegalUpdate = "IllegalUpdate"
+        case inconsistentQuantities = "InconsistentQuantities"
+        case invalidArgument = "InvalidArgument"
+        case invalidDefaultRootObject = "InvalidDefaultRootObject"
+        case invalidErrorCode = "InvalidErrorCode"
+        case invalidForwardCookies = "InvalidForwardCookies"
+        case invalidGeoRestrictionParameter = "InvalidGeoRestrictionParameter"
+        case invalidHeadersForS3Origin = "InvalidHeadersForS3Origin"
+        case invalidIfMatchVersion = "InvalidIfMatchVersion"
+        case invalidLambdaFunctionAssociation = "InvalidLambdaFunctionAssociation"
+        case invalidLocationCode = "InvalidLocationCode"
+        case invalidMinimumProtocolVersion = "InvalidMinimumProtocolVersion"
+        case invalidOrigin = "InvalidOrigin"
+        case invalidOriginAccessIdentity = "InvalidOriginAccessIdentity"
+        case invalidOriginKeepaliveTimeout = "InvalidOriginKeepaliveTimeout"
+        case invalidOriginReadTimeout = "InvalidOriginReadTimeout"
+        case invalidProtocolSettings = "InvalidProtocolSettings"
+        case invalidQueryStringParameters = "InvalidQueryStringParameters"
+        case invalidRelativePath = "InvalidRelativePath"
+        case invalidRequiredProtocol = "InvalidRequiredProtocol"
+        case invalidResponseCode = "InvalidResponseCode"
+        case invalidTTLOrder = "InvalidTTLOrder"
+        case invalidTagging = "InvalidTagging"
+        case invalidViewerCertificate = "InvalidViewerCertificate"
+        case invalidWebACLId = "InvalidWebACLId"
+        case missingBody = "MissingBody"
+        case noSuchCachePolicy = "NoSuchCachePolicy"
+        case noSuchCloudFrontOriginAccessIdentity = "NoSuchCloudFrontOriginAccessIdentity"
+        case noSuchDistribution = "NoSuchDistribution"
+        case noSuchFieldLevelEncryptionConfig = "NoSuchFieldLevelEncryptionConfig"
+        case noSuchFieldLevelEncryptionProfile = "NoSuchFieldLevelEncryptionProfile"
+        case noSuchInvalidation = "NoSuchInvalidation"
+        case noSuchOrigin = "NoSuchOrigin"
+        case noSuchOriginRequestPolicy = "NoSuchOriginRequestPolicy"
+        case noSuchPublicKey = "NoSuchPublicKey"
+        case noSuchRealtimeLogConfig = "NoSuchRealtimeLogConfig"
+        case noSuchResource = "NoSuchResource"
+        case noSuchStreamingDistribution = "NoSuchStreamingDistribution"
+        case originRequestPolicyAlreadyExists = "OriginRequestPolicyAlreadyExists"
+        case originRequestPolicyInUse = "OriginRequestPolicyInUse"
+        case preconditionFailed = "PreconditionFailed"
+        case publicKeyAlreadyExists = "PublicKeyAlreadyExists"
+        case publicKeyInUse = "PublicKeyInUse"
+        case queryArgProfileEmpty = "QueryArgProfileEmpty"
+        case realtimeLogConfigAlreadyExists = "RealtimeLogConfigAlreadyExists"
+        case realtimeLogConfigInUse = "RealtimeLogConfigInUse"
+        case streamingDistributionAlreadyExists = "StreamingDistributionAlreadyExists"
+        case streamingDistributionNotDisabled = "StreamingDistributionNotDisabled"
+        case tooManyCacheBehaviors = "TooManyCacheBehaviors"
+        case tooManyCachePolicies = "TooManyCachePolicies"
+        case tooManyCertificates = "TooManyCertificates"
+        case tooManyCloudFrontOriginAccessIdentities = "TooManyCloudFrontOriginAccessIdentities"
+        case tooManyCookieNamesInWhiteList = "TooManyCookieNamesInWhiteList"
+        case tooManyCookiesInCachePolicy = "TooManyCookiesInCachePolicy"
+        case tooManyCookiesInOriginRequestPolicy = "TooManyCookiesInOriginRequestPolicy"
+        case tooManyDistributionCNAMEs = "TooManyDistributionCNAMEs"
+        case tooManyDistributions = "TooManyDistributions"
+        case tooManyDistributionsAssociatedToCachePolicy = "TooManyDistributionsAssociatedToCachePolicy"
+        case tooManyDistributionsAssociatedToFieldLevelEncryptionConfig = "TooManyDistributionsAssociatedToFieldLevelEncryptionConfig"
+        case tooManyDistributionsAssociatedToOriginRequestPolicy = "TooManyDistributionsAssociatedToOriginRequestPolicy"
+        case tooManyDistributionsWithLambdaAssociations = "TooManyDistributionsWithLambdaAssociations"
+        case tooManyDistributionsWithSingleFunctionARN = "TooManyDistributionsWithSingleFunctionARN"
+        case tooManyFieldLevelEncryptionConfigs = "TooManyFieldLevelEncryptionConfigs"
+        case tooManyFieldLevelEncryptionContentTypeProfiles = "TooManyFieldLevelEncryptionContentTypeProfiles"
+        case tooManyFieldLevelEncryptionEncryptionEntities = "TooManyFieldLevelEncryptionEncryptionEntities"
+        case tooManyFieldLevelEncryptionFieldPatterns = "TooManyFieldLevelEncryptionFieldPatterns"
+        case tooManyFieldLevelEncryptionProfiles = "TooManyFieldLevelEncryptionProfiles"
+        case tooManyFieldLevelEncryptionQueryArgProfiles = "TooManyFieldLevelEncryptionQueryArgProfiles"
+        case tooManyHeadersInCachePolicy = "TooManyHeadersInCachePolicy"
+        case tooManyHeadersInForwardedValues = "TooManyHeadersInForwardedValues"
+        case tooManyHeadersInOriginRequestPolicy = "TooManyHeadersInOriginRequestPolicy"
+        case tooManyInvalidationsInProgress = "TooManyInvalidationsInProgress"
+        case tooManyLambdaFunctionAssociations = "TooManyLambdaFunctionAssociations"
+        case tooManyOriginCustomHeaders = "TooManyOriginCustomHeaders"
+        case tooManyOriginGroupsPerDistribution = "TooManyOriginGroupsPerDistribution"
+        case tooManyOriginRequestPolicies = "TooManyOriginRequestPolicies"
+        case tooManyOrigins = "TooManyOrigins"
+        case tooManyPublicKeys = "TooManyPublicKeys"
+        case tooManyQueryStringParameters = "TooManyQueryStringParameters"
+        case tooManyQueryStringsInCachePolicy = "TooManyQueryStringsInCachePolicy"
+        case tooManyQueryStringsInOriginRequestPolicy = "TooManyQueryStringsInOriginRequestPolicy"
+        case tooManyRealtimeLogConfigs = "TooManyRealtimeLogConfigs"
+        case tooManyStreamingDistributionCNAMEs = "TooManyStreamingDistributionCNAMEs"
+        case tooManyStreamingDistributions = "TooManyStreamingDistributions"
+        case tooManyTrustedSigners = "TooManyTrustedSigners"
+        case trustedSignerDoesNotExist = "TrustedSignerDoesNotExist"
+    }
 
-extension CloudFrontErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDenied":
-            self = .accessDenied(message: message)
-        case "BatchTooLarge":
-            self = .batchTooLarge(message: message)
-        case "CNAMEAlreadyExists":
-            self = .cNAMEAlreadyExists(message: message)
-        case "CachePolicyAlreadyExists":
-            self = .cachePolicyAlreadyExists(message: message)
-        case "CachePolicyInUse":
-            self = .cachePolicyInUse(message: message)
-        case "CannotChangeImmutablePublicKeyFields":
-            self = .cannotChangeImmutablePublicKeyFields(message: message)
-        case "CloudFrontOriginAccessIdentityAlreadyExists":
-            self = .cloudFrontOriginAccessIdentityAlreadyExists(message: message)
-        case "CloudFrontOriginAccessIdentityInUse":
-            self = .cloudFrontOriginAccessIdentityInUse(message: message)
-        case "DistributionAlreadyExists":
-            self = .distributionAlreadyExists(message: message)
-        case "DistributionNotDisabled":
-            self = .distributionNotDisabled(message: message)
-        case "FieldLevelEncryptionConfigAlreadyExists":
-            self = .fieldLevelEncryptionConfigAlreadyExists(message: message)
-        case "FieldLevelEncryptionConfigInUse":
-            self = .fieldLevelEncryptionConfigInUse(message: message)
-        case "FieldLevelEncryptionProfileAlreadyExists":
-            self = .fieldLevelEncryptionProfileAlreadyExists(message: message)
-        case "FieldLevelEncryptionProfileInUse":
-            self = .fieldLevelEncryptionProfileInUse(message: message)
-        case "FieldLevelEncryptionProfileSizeExceeded":
-            self = .fieldLevelEncryptionProfileSizeExceeded(message: message)
-        case "IllegalDelete":
-            self = .illegalDelete(message: message)
-        case "IllegalFieldLevelEncryptionConfigAssociationWithCacheBehavior":
-            self = .illegalFieldLevelEncryptionConfigAssociationWithCacheBehavior(message: message)
-        case "IllegalUpdate":
-            self = .illegalUpdate(message: message)
-        case "InconsistentQuantities":
-            self = .inconsistentQuantities(message: message)
-        case "InvalidArgument":
-            self = .invalidArgument(message: message)
-        case "InvalidDefaultRootObject":
-            self = .invalidDefaultRootObject(message: message)
-        case "InvalidErrorCode":
-            self = .invalidErrorCode(message: message)
-        case "InvalidForwardCookies":
-            self = .invalidForwardCookies(message: message)
-        case "InvalidGeoRestrictionParameter":
-            self = .invalidGeoRestrictionParameter(message: message)
-        case "InvalidHeadersForS3Origin":
-            self = .invalidHeadersForS3Origin(message: message)
-        case "InvalidIfMatchVersion":
-            self = .invalidIfMatchVersion(message: message)
-        case "InvalidLambdaFunctionAssociation":
-            self = .invalidLambdaFunctionAssociation(message: message)
-        case "InvalidLocationCode":
-            self = .invalidLocationCode(message: message)
-        case "InvalidMinimumProtocolVersion":
-            self = .invalidMinimumProtocolVersion(message: message)
-        case "InvalidOrigin":
-            self = .invalidOrigin(message: message)
-        case "InvalidOriginAccessIdentity":
-            self = .invalidOriginAccessIdentity(message: message)
-        case "InvalidOriginKeepaliveTimeout":
-            self = .invalidOriginKeepaliveTimeout(message: message)
-        case "InvalidOriginReadTimeout":
-            self = .invalidOriginReadTimeout(message: message)
-        case "InvalidProtocolSettings":
-            self = .invalidProtocolSettings(message: message)
-        case "InvalidQueryStringParameters":
-            self = .invalidQueryStringParameters(message: message)
-        case "InvalidRelativePath":
-            self = .invalidRelativePath(message: message)
-        case "InvalidRequiredProtocol":
-            self = .invalidRequiredProtocol(message: message)
-        case "InvalidResponseCode":
-            self = .invalidResponseCode(message: message)
-        case "InvalidTTLOrder":
-            self = .invalidTTLOrder(message: message)
-        case "InvalidTagging":
-            self = .invalidTagging(message: message)
-        case "InvalidViewerCertificate":
-            self = .invalidViewerCertificate(message: message)
-        case "InvalidWebACLId":
-            self = .invalidWebACLId(message: message)
-        case "MissingBody":
-            self = .missingBody(message: message)
-        case "NoSuchCachePolicy":
-            self = .noSuchCachePolicy(message: message)
-        case "NoSuchCloudFrontOriginAccessIdentity":
-            self = .noSuchCloudFrontOriginAccessIdentity(message: message)
-        case "NoSuchDistribution":
-            self = .noSuchDistribution(message: message)
-        case "NoSuchFieldLevelEncryptionConfig":
-            self = .noSuchFieldLevelEncryptionConfig(message: message)
-        case "NoSuchFieldLevelEncryptionProfile":
-            self = .noSuchFieldLevelEncryptionProfile(message: message)
-        case "NoSuchInvalidation":
-            self = .noSuchInvalidation(message: message)
-        case "NoSuchOrigin":
-            self = .noSuchOrigin(message: message)
-        case "NoSuchOriginRequestPolicy":
-            self = .noSuchOriginRequestPolicy(message: message)
-        case "NoSuchPublicKey":
-            self = .noSuchPublicKey(message: message)
-        case "NoSuchRealtimeLogConfig":
-            self = .noSuchRealtimeLogConfig(message: message)
-        case "NoSuchResource":
-            self = .noSuchResource(message: message)
-        case "NoSuchStreamingDistribution":
-            self = .noSuchStreamingDistribution(message: message)
-        case "OriginRequestPolicyAlreadyExists":
-            self = .originRequestPolicyAlreadyExists(message: message)
-        case "OriginRequestPolicyInUse":
-            self = .originRequestPolicyInUse(message: message)
-        case "PreconditionFailed":
-            self = .preconditionFailed(message: message)
-        case "PublicKeyAlreadyExists":
-            self = .publicKeyAlreadyExists(message: message)
-        case "PublicKeyInUse":
-            self = .publicKeyInUse(message: message)
-        case "QueryArgProfileEmpty":
-            self = .queryArgProfileEmpty(message: message)
-        case "RealtimeLogConfigAlreadyExists":
-            self = .realtimeLogConfigAlreadyExists(message: message)
-        case "RealtimeLogConfigInUse":
-            self = .realtimeLogConfigInUse(message: message)
-        case "StreamingDistributionAlreadyExists":
-            self = .streamingDistributionAlreadyExists(message: message)
-        case "StreamingDistributionNotDisabled":
-            self = .streamingDistributionNotDisabled(message: message)
-        case "TooManyCacheBehaviors":
-            self = .tooManyCacheBehaviors(message: message)
-        case "TooManyCachePolicies":
-            self = .tooManyCachePolicies(message: message)
-        case "TooManyCertificates":
-            self = .tooManyCertificates(message: message)
-        case "TooManyCloudFrontOriginAccessIdentities":
-            self = .tooManyCloudFrontOriginAccessIdentities(message: message)
-        case "TooManyCookieNamesInWhiteList":
-            self = .tooManyCookieNamesInWhiteList(message: message)
-        case "TooManyCookiesInCachePolicy":
-            self = .tooManyCookiesInCachePolicy(message: message)
-        case "TooManyCookiesInOriginRequestPolicy":
-            self = .tooManyCookiesInOriginRequestPolicy(message: message)
-        case "TooManyDistributionCNAMEs":
-            self = .tooManyDistributionCNAMEs(message: message)
-        case "TooManyDistributions":
-            self = .tooManyDistributions(message: message)
-        case "TooManyDistributionsAssociatedToCachePolicy":
-            self = .tooManyDistributionsAssociatedToCachePolicy(message: message)
-        case "TooManyDistributionsAssociatedToFieldLevelEncryptionConfig":
-            self = .tooManyDistributionsAssociatedToFieldLevelEncryptionConfig(message: message)
-        case "TooManyDistributionsAssociatedToOriginRequestPolicy":
-            self = .tooManyDistributionsAssociatedToOriginRequestPolicy(message: message)
-        case "TooManyDistributionsWithLambdaAssociations":
-            self = .tooManyDistributionsWithLambdaAssociations(message: message)
-        case "TooManyDistributionsWithSingleFunctionARN":
-            self = .tooManyDistributionsWithSingleFunctionARN(message: message)
-        case "TooManyFieldLevelEncryptionConfigs":
-            self = .tooManyFieldLevelEncryptionConfigs(message: message)
-        case "TooManyFieldLevelEncryptionContentTypeProfiles":
-            self = .tooManyFieldLevelEncryptionContentTypeProfiles(message: message)
-        case "TooManyFieldLevelEncryptionEncryptionEntities":
-            self = .tooManyFieldLevelEncryptionEncryptionEntities(message: message)
-        case "TooManyFieldLevelEncryptionFieldPatterns":
-            self = .tooManyFieldLevelEncryptionFieldPatterns(message: message)
-        case "TooManyFieldLevelEncryptionProfiles":
-            self = .tooManyFieldLevelEncryptionProfiles(message: message)
-        case "TooManyFieldLevelEncryptionQueryArgProfiles":
-            self = .tooManyFieldLevelEncryptionQueryArgProfiles(message: message)
-        case "TooManyHeadersInCachePolicy":
-            self = .tooManyHeadersInCachePolicy(message: message)
-        case "TooManyHeadersInForwardedValues":
-            self = .tooManyHeadersInForwardedValues(message: message)
-        case "TooManyHeadersInOriginRequestPolicy":
-            self = .tooManyHeadersInOriginRequestPolicy(message: message)
-        case "TooManyInvalidationsInProgress":
-            self = .tooManyInvalidationsInProgress(message: message)
-        case "TooManyLambdaFunctionAssociations":
-            self = .tooManyLambdaFunctionAssociations(message: message)
-        case "TooManyOriginCustomHeaders":
-            self = .tooManyOriginCustomHeaders(message: message)
-        case "TooManyOriginGroupsPerDistribution":
-            self = .tooManyOriginGroupsPerDistribution(message: message)
-        case "TooManyOriginRequestPolicies":
-            self = .tooManyOriginRequestPolicies(message: message)
-        case "TooManyOrigins":
-            self = .tooManyOrigins(message: message)
-        case "TooManyPublicKeys":
-            self = .tooManyPublicKeys(message: message)
-        case "TooManyQueryStringParameters":
-            self = .tooManyQueryStringParameters(message: message)
-        case "TooManyQueryStringsInCachePolicy":
-            self = .tooManyQueryStringsInCachePolicy(message: message)
-        case "TooManyQueryStringsInOriginRequestPolicy":
-            self = .tooManyQueryStringsInOriginRequestPolicy(message: message)
-        case "TooManyRealtimeLogConfigs":
-            self = .tooManyRealtimeLogConfigs(message: message)
-        case "TooManyStreamingDistributionCNAMEs":
-            self = .tooManyStreamingDistributionCNAMEs(message: message)
-        case "TooManyStreamingDistributions":
-            self = .tooManyStreamingDistributions(message: message)
-        case "TooManyTrustedSigners":
-            self = .tooManyTrustedSigners(message: message)
-        case "TrustedSignerDoesNotExist":
-            self = .trustedSignerDoesNotExist(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDenied: Self { .init(.accessDenied) }
+    public static var batchTooLarge: Self { .init(.batchTooLarge) }
+    public static var cNAMEAlreadyExists: Self { .init(.cNAMEAlreadyExists) }
+    public static var cachePolicyAlreadyExists: Self { .init(.cachePolicyAlreadyExists) }
+    public static var cachePolicyInUse: Self { .init(.cachePolicyInUse) }
+    public static var cannotChangeImmutablePublicKeyFields: Self { .init(.cannotChangeImmutablePublicKeyFields) }
+    public static var cloudFrontOriginAccessIdentityAlreadyExists: Self { .init(.cloudFrontOriginAccessIdentityAlreadyExists) }
+    public static var cloudFrontOriginAccessIdentityInUse: Self { .init(.cloudFrontOriginAccessIdentityInUse) }
+    public static var distributionAlreadyExists: Self { .init(.distributionAlreadyExists) }
+    public static var distributionNotDisabled: Self { .init(.distributionNotDisabled) }
+    public static var fieldLevelEncryptionConfigAlreadyExists: Self { .init(.fieldLevelEncryptionConfigAlreadyExists) }
+    public static var fieldLevelEncryptionConfigInUse: Self { .init(.fieldLevelEncryptionConfigInUse) }
+    public static var fieldLevelEncryptionProfileAlreadyExists: Self { .init(.fieldLevelEncryptionProfileAlreadyExists) }
+    public static var fieldLevelEncryptionProfileInUse: Self { .init(.fieldLevelEncryptionProfileInUse) }
+    public static var fieldLevelEncryptionProfileSizeExceeded: Self { .init(.fieldLevelEncryptionProfileSizeExceeded) }
+    public static var illegalDelete: Self { .init(.illegalDelete) }
+    public static var illegalFieldLevelEncryptionConfigAssociationWithCacheBehavior: Self { .init(.illegalFieldLevelEncryptionConfigAssociationWithCacheBehavior) }
+    public static var illegalUpdate: Self { .init(.illegalUpdate) }
+    public static var inconsistentQuantities: Self { .init(.inconsistentQuantities) }
+    public static var invalidArgument: Self { .init(.invalidArgument) }
+    public static var invalidDefaultRootObject: Self { .init(.invalidDefaultRootObject) }
+    public static var invalidErrorCode: Self { .init(.invalidErrorCode) }
+    public static var invalidForwardCookies: Self { .init(.invalidForwardCookies) }
+    public static var invalidGeoRestrictionParameter: Self { .init(.invalidGeoRestrictionParameter) }
+    public static var invalidHeadersForS3Origin: Self { .init(.invalidHeadersForS3Origin) }
+    public static var invalidIfMatchVersion: Self { .init(.invalidIfMatchVersion) }
+    public static var invalidLambdaFunctionAssociation: Self { .init(.invalidLambdaFunctionAssociation) }
+    public static var invalidLocationCode: Self { .init(.invalidLocationCode) }
+    public static var invalidMinimumProtocolVersion: Self { .init(.invalidMinimumProtocolVersion) }
+    public static var invalidOrigin: Self { .init(.invalidOrigin) }
+    public static var invalidOriginAccessIdentity: Self { .init(.invalidOriginAccessIdentity) }
+    public static var invalidOriginKeepaliveTimeout: Self { .init(.invalidOriginKeepaliveTimeout) }
+    public static var invalidOriginReadTimeout: Self { .init(.invalidOriginReadTimeout) }
+    public static var invalidProtocolSettings: Self { .init(.invalidProtocolSettings) }
+    public static var invalidQueryStringParameters: Self { .init(.invalidQueryStringParameters) }
+    public static var invalidRelativePath: Self { .init(.invalidRelativePath) }
+    public static var invalidRequiredProtocol: Self { .init(.invalidRequiredProtocol) }
+    public static var invalidResponseCode: Self { .init(.invalidResponseCode) }
+    public static var invalidTTLOrder: Self { .init(.invalidTTLOrder) }
+    public static var invalidTagging: Self { .init(.invalidTagging) }
+    public static var invalidViewerCertificate: Self { .init(.invalidViewerCertificate) }
+    public static var invalidWebACLId: Self { .init(.invalidWebACLId) }
+    public static var missingBody: Self { .init(.missingBody) }
+    public static var noSuchCachePolicy: Self { .init(.noSuchCachePolicy) }
+    public static var noSuchCloudFrontOriginAccessIdentity: Self { .init(.noSuchCloudFrontOriginAccessIdentity) }
+    public static var noSuchDistribution: Self { .init(.noSuchDistribution) }
+    public static var noSuchFieldLevelEncryptionConfig: Self { .init(.noSuchFieldLevelEncryptionConfig) }
+    public static var noSuchFieldLevelEncryptionProfile: Self { .init(.noSuchFieldLevelEncryptionProfile) }
+    public static var noSuchInvalidation: Self { .init(.noSuchInvalidation) }
+    public static var noSuchOrigin: Self { .init(.noSuchOrigin) }
+    public static var noSuchOriginRequestPolicy: Self { .init(.noSuchOriginRequestPolicy) }
+    public static var noSuchPublicKey: Self { .init(.noSuchPublicKey) }
+    public static var noSuchRealtimeLogConfig: Self { .init(.noSuchRealtimeLogConfig) }
+    public static var noSuchResource: Self { .init(.noSuchResource) }
+    public static var noSuchStreamingDistribution: Self { .init(.noSuchStreamingDistribution) }
+    public static var originRequestPolicyAlreadyExists: Self { .init(.originRequestPolicyAlreadyExists) }
+    public static var originRequestPolicyInUse: Self { .init(.originRequestPolicyInUse) }
+    public static var preconditionFailed: Self { .init(.preconditionFailed) }
+    public static var publicKeyAlreadyExists: Self { .init(.publicKeyAlreadyExists) }
+    public static var publicKeyInUse: Self { .init(.publicKeyInUse) }
+    public static var queryArgProfileEmpty: Self { .init(.queryArgProfileEmpty) }
+    public static var realtimeLogConfigAlreadyExists: Self { .init(.realtimeLogConfigAlreadyExists) }
+    public static var realtimeLogConfigInUse: Self { .init(.realtimeLogConfigInUse) }
+    public static var streamingDistributionAlreadyExists: Self { .init(.streamingDistributionAlreadyExists) }
+    public static var streamingDistributionNotDisabled: Self { .init(.streamingDistributionNotDisabled) }
+    public static var tooManyCacheBehaviors: Self { .init(.tooManyCacheBehaviors) }
+    public static var tooManyCachePolicies: Self { .init(.tooManyCachePolicies) }
+    public static var tooManyCertificates: Self { .init(.tooManyCertificates) }
+    public static var tooManyCloudFrontOriginAccessIdentities: Self { .init(.tooManyCloudFrontOriginAccessIdentities) }
+    public static var tooManyCookieNamesInWhiteList: Self { .init(.tooManyCookieNamesInWhiteList) }
+    public static var tooManyCookiesInCachePolicy: Self { .init(.tooManyCookiesInCachePolicy) }
+    public static var tooManyCookiesInOriginRequestPolicy: Self { .init(.tooManyCookiesInOriginRequestPolicy) }
+    public static var tooManyDistributionCNAMEs: Self { .init(.tooManyDistributionCNAMEs) }
+    public static var tooManyDistributions: Self { .init(.tooManyDistributions) }
+    public static var tooManyDistributionsAssociatedToCachePolicy: Self { .init(.tooManyDistributionsAssociatedToCachePolicy) }
+    public static var tooManyDistributionsAssociatedToFieldLevelEncryptionConfig: Self { .init(.tooManyDistributionsAssociatedToFieldLevelEncryptionConfig) }
+    public static var tooManyDistributionsAssociatedToOriginRequestPolicy: Self { .init(.tooManyDistributionsAssociatedToOriginRequestPolicy) }
+    public static var tooManyDistributionsWithLambdaAssociations: Self { .init(.tooManyDistributionsWithLambdaAssociations) }
+    public static var tooManyDistributionsWithSingleFunctionARN: Self { .init(.tooManyDistributionsWithSingleFunctionARN) }
+    public static var tooManyFieldLevelEncryptionConfigs: Self { .init(.tooManyFieldLevelEncryptionConfigs) }
+    public static var tooManyFieldLevelEncryptionContentTypeProfiles: Self { .init(.tooManyFieldLevelEncryptionContentTypeProfiles) }
+    public static var tooManyFieldLevelEncryptionEncryptionEntities: Self { .init(.tooManyFieldLevelEncryptionEncryptionEntities) }
+    public static var tooManyFieldLevelEncryptionFieldPatterns: Self { .init(.tooManyFieldLevelEncryptionFieldPatterns) }
+    public static var tooManyFieldLevelEncryptionProfiles: Self { .init(.tooManyFieldLevelEncryptionProfiles) }
+    public static var tooManyFieldLevelEncryptionQueryArgProfiles: Self { .init(.tooManyFieldLevelEncryptionQueryArgProfiles) }
+    public static var tooManyHeadersInCachePolicy: Self { .init(.tooManyHeadersInCachePolicy) }
+    public static var tooManyHeadersInForwardedValues: Self { .init(.tooManyHeadersInForwardedValues) }
+    public static var tooManyHeadersInOriginRequestPolicy: Self { .init(.tooManyHeadersInOriginRequestPolicy) }
+    public static var tooManyInvalidationsInProgress: Self { .init(.tooManyInvalidationsInProgress) }
+    public static var tooManyLambdaFunctionAssociations: Self { .init(.tooManyLambdaFunctionAssociations) }
+    public static var tooManyOriginCustomHeaders: Self { .init(.tooManyOriginCustomHeaders) }
+    public static var tooManyOriginGroupsPerDistribution: Self { .init(.tooManyOriginGroupsPerDistribution) }
+    public static var tooManyOriginRequestPolicies: Self { .init(.tooManyOriginRequestPolicies) }
+    public static var tooManyOrigins: Self { .init(.tooManyOrigins) }
+    public static var tooManyPublicKeys: Self { .init(.tooManyPublicKeys) }
+    public static var tooManyQueryStringParameters: Self { .init(.tooManyQueryStringParameters) }
+    public static var tooManyQueryStringsInCachePolicy: Self { .init(.tooManyQueryStringsInCachePolicy) }
+    public static var tooManyQueryStringsInOriginRequestPolicy: Self { .init(.tooManyQueryStringsInOriginRequestPolicy) }
+    public static var tooManyRealtimeLogConfigs: Self { .init(.tooManyRealtimeLogConfigs) }
+    public static var tooManyStreamingDistributionCNAMEs: Self { .init(.tooManyStreamingDistributionCNAMEs) }
+    public static var tooManyStreamingDistributions: Self { .init(.tooManyStreamingDistributions) }
+    public static var tooManyTrustedSigners: Self { .init(.tooManyTrustedSigners) }
+    public static var trustedSignerDoesNotExist: Self { .init(.trustedSignerDoesNotExist) }
+}
+
+extension CloudFrontErrorType: Equatable {
+    public static func == (lhs: CloudFrontErrorType, rhs: CloudFrontErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension CloudFrontErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDenied(let message):
-            return "AccessDenied: \(message ?? "")"
-        case .batchTooLarge(let message):
-            return "BatchTooLarge: \(message ?? "")"
-        case .cNAMEAlreadyExists(let message):
-            return "CNAMEAlreadyExists: \(message ?? "")"
-        case .cachePolicyAlreadyExists(let message):
-            return "CachePolicyAlreadyExists: \(message ?? "")"
-        case .cachePolicyInUse(let message):
-            return "CachePolicyInUse: \(message ?? "")"
-        case .cannotChangeImmutablePublicKeyFields(let message):
-            return "CannotChangeImmutablePublicKeyFields: \(message ?? "")"
-        case .cloudFrontOriginAccessIdentityAlreadyExists(let message):
-            return "CloudFrontOriginAccessIdentityAlreadyExists: \(message ?? "")"
-        case .cloudFrontOriginAccessIdentityInUse(let message):
-            return "CloudFrontOriginAccessIdentityInUse: \(message ?? "")"
-        case .distributionAlreadyExists(let message):
-            return "DistributionAlreadyExists: \(message ?? "")"
-        case .distributionNotDisabled(let message):
-            return "DistributionNotDisabled: \(message ?? "")"
-        case .fieldLevelEncryptionConfigAlreadyExists(let message):
-            return "FieldLevelEncryptionConfigAlreadyExists: \(message ?? "")"
-        case .fieldLevelEncryptionConfigInUse(let message):
-            return "FieldLevelEncryptionConfigInUse: \(message ?? "")"
-        case .fieldLevelEncryptionProfileAlreadyExists(let message):
-            return "FieldLevelEncryptionProfileAlreadyExists: \(message ?? "")"
-        case .fieldLevelEncryptionProfileInUse(let message):
-            return "FieldLevelEncryptionProfileInUse: \(message ?? "")"
-        case .fieldLevelEncryptionProfileSizeExceeded(let message):
-            return "FieldLevelEncryptionProfileSizeExceeded: \(message ?? "")"
-        case .illegalDelete(let message):
-            return "IllegalDelete: \(message ?? "")"
-        case .illegalFieldLevelEncryptionConfigAssociationWithCacheBehavior(let message):
-            return "IllegalFieldLevelEncryptionConfigAssociationWithCacheBehavior: \(message ?? "")"
-        case .illegalUpdate(let message):
-            return "IllegalUpdate: \(message ?? "")"
-        case .inconsistentQuantities(let message):
-            return "InconsistentQuantities: \(message ?? "")"
-        case .invalidArgument(let message):
-            return "InvalidArgument: \(message ?? "")"
-        case .invalidDefaultRootObject(let message):
-            return "InvalidDefaultRootObject: \(message ?? "")"
-        case .invalidErrorCode(let message):
-            return "InvalidErrorCode: \(message ?? "")"
-        case .invalidForwardCookies(let message):
-            return "InvalidForwardCookies: \(message ?? "")"
-        case .invalidGeoRestrictionParameter(let message):
-            return "InvalidGeoRestrictionParameter: \(message ?? "")"
-        case .invalidHeadersForS3Origin(let message):
-            return "InvalidHeadersForS3Origin: \(message ?? "")"
-        case .invalidIfMatchVersion(let message):
-            return "InvalidIfMatchVersion: \(message ?? "")"
-        case .invalidLambdaFunctionAssociation(let message):
-            return "InvalidLambdaFunctionAssociation: \(message ?? "")"
-        case .invalidLocationCode(let message):
-            return "InvalidLocationCode: \(message ?? "")"
-        case .invalidMinimumProtocolVersion(let message):
-            return "InvalidMinimumProtocolVersion: \(message ?? "")"
-        case .invalidOrigin(let message):
-            return "InvalidOrigin: \(message ?? "")"
-        case .invalidOriginAccessIdentity(let message):
-            return "InvalidOriginAccessIdentity: \(message ?? "")"
-        case .invalidOriginKeepaliveTimeout(let message):
-            return "InvalidOriginKeepaliveTimeout: \(message ?? "")"
-        case .invalidOriginReadTimeout(let message):
-            return "InvalidOriginReadTimeout: \(message ?? "")"
-        case .invalidProtocolSettings(let message):
-            return "InvalidProtocolSettings: \(message ?? "")"
-        case .invalidQueryStringParameters(let message):
-            return "InvalidQueryStringParameters: \(message ?? "")"
-        case .invalidRelativePath(let message):
-            return "InvalidRelativePath: \(message ?? "")"
-        case .invalidRequiredProtocol(let message):
-            return "InvalidRequiredProtocol: \(message ?? "")"
-        case .invalidResponseCode(let message):
-            return "InvalidResponseCode: \(message ?? "")"
-        case .invalidTTLOrder(let message):
-            return "InvalidTTLOrder: \(message ?? "")"
-        case .invalidTagging(let message):
-            return "InvalidTagging: \(message ?? "")"
-        case .invalidViewerCertificate(let message):
-            return "InvalidViewerCertificate: \(message ?? "")"
-        case .invalidWebACLId(let message):
-            return "InvalidWebACLId: \(message ?? "")"
-        case .missingBody(let message):
-            return "MissingBody: \(message ?? "")"
-        case .noSuchCachePolicy(let message):
-            return "NoSuchCachePolicy: \(message ?? "")"
-        case .noSuchCloudFrontOriginAccessIdentity(let message):
-            return "NoSuchCloudFrontOriginAccessIdentity: \(message ?? "")"
-        case .noSuchDistribution(let message):
-            return "NoSuchDistribution: \(message ?? "")"
-        case .noSuchFieldLevelEncryptionConfig(let message):
-            return "NoSuchFieldLevelEncryptionConfig: \(message ?? "")"
-        case .noSuchFieldLevelEncryptionProfile(let message):
-            return "NoSuchFieldLevelEncryptionProfile: \(message ?? "")"
-        case .noSuchInvalidation(let message):
-            return "NoSuchInvalidation: \(message ?? "")"
-        case .noSuchOrigin(let message):
-            return "NoSuchOrigin: \(message ?? "")"
-        case .noSuchOriginRequestPolicy(let message):
-            return "NoSuchOriginRequestPolicy: \(message ?? "")"
-        case .noSuchPublicKey(let message):
-            return "NoSuchPublicKey: \(message ?? "")"
-        case .noSuchRealtimeLogConfig(let message):
-            return "NoSuchRealtimeLogConfig: \(message ?? "")"
-        case .noSuchResource(let message):
-            return "NoSuchResource: \(message ?? "")"
-        case .noSuchStreamingDistribution(let message):
-            return "NoSuchStreamingDistribution: \(message ?? "")"
-        case .originRequestPolicyAlreadyExists(let message):
-            return "OriginRequestPolicyAlreadyExists: \(message ?? "")"
-        case .originRequestPolicyInUse(let message):
-            return "OriginRequestPolicyInUse: \(message ?? "")"
-        case .preconditionFailed(let message):
-            return "PreconditionFailed: \(message ?? "")"
-        case .publicKeyAlreadyExists(let message):
-            return "PublicKeyAlreadyExists: \(message ?? "")"
-        case .publicKeyInUse(let message):
-            return "PublicKeyInUse: \(message ?? "")"
-        case .queryArgProfileEmpty(let message):
-            return "QueryArgProfileEmpty: \(message ?? "")"
-        case .realtimeLogConfigAlreadyExists(let message):
-            return "RealtimeLogConfigAlreadyExists: \(message ?? "")"
-        case .realtimeLogConfigInUse(let message):
-            return "RealtimeLogConfigInUse: \(message ?? "")"
-        case .streamingDistributionAlreadyExists(let message):
-            return "StreamingDistributionAlreadyExists: \(message ?? "")"
-        case .streamingDistributionNotDisabled(let message):
-            return "StreamingDistributionNotDisabled: \(message ?? "")"
-        case .tooManyCacheBehaviors(let message):
-            return "TooManyCacheBehaviors: \(message ?? "")"
-        case .tooManyCachePolicies(let message):
-            return "TooManyCachePolicies: \(message ?? "")"
-        case .tooManyCertificates(let message):
-            return "TooManyCertificates: \(message ?? "")"
-        case .tooManyCloudFrontOriginAccessIdentities(let message):
-            return "TooManyCloudFrontOriginAccessIdentities: \(message ?? "")"
-        case .tooManyCookieNamesInWhiteList(let message):
-            return "TooManyCookieNamesInWhiteList: \(message ?? "")"
-        case .tooManyCookiesInCachePolicy(let message):
-            return "TooManyCookiesInCachePolicy: \(message ?? "")"
-        case .tooManyCookiesInOriginRequestPolicy(let message):
-            return "TooManyCookiesInOriginRequestPolicy: \(message ?? "")"
-        case .tooManyDistributionCNAMEs(let message):
-            return "TooManyDistributionCNAMEs: \(message ?? "")"
-        case .tooManyDistributions(let message):
-            return "TooManyDistributions: \(message ?? "")"
-        case .tooManyDistributionsAssociatedToCachePolicy(let message):
-            return "TooManyDistributionsAssociatedToCachePolicy: \(message ?? "")"
-        case .tooManyDistributionsAssociatedToFieldLevelEncryptionConfig(let message):
-            return "TooManyDistributionsAssociatedToFieldLevelEncryptionConfig: \(message ?? "")"
-        case .tooManyDistributionsAssociatedToOriginRequestPolicy(let message):
-            return "TooManyDistributionsAssociatedToOriginRequestPolicy: \(message ?? "")"
-        case .tooManyDistributionsWithLambdaAssociations(let message):
-            return "TooManyDistributionsWithLambdaAssociations: \(message ?? "")"
-        case .tooManyDistributionsWithSingleFunctionARN(let message):
-            return "TooManyDistributionsWithSingleFunctionARN: \(message ?? "")"
-        case .tooManyFieldLevelEncryptionConfigs(let message):
-            return "TooManyFieldLevelEncryptionConfigs: \(message ?? "")"
-        case .tooManyFieldLevelEncryptionContentTypeProfiles(let message):
-            return "TooManyFieldLevelEncryptionContentTypeProfiles: \(message ?? "")"
-        case .tooManyFieldLevelEncryptionEncryptionEntities(let message):
-            return "TooManyFieldLevelEncryptionEncryptionEntities: \(message ?? "")"
-        case .tooManyFieldLevelEncryptionFieldPatterns(let message):
-            return "TooManyFieldLevelEncryptionFieldPatterns: \(message ?? "")"
-        case .tooManyFieldLevelEncryptionProfiles(let message):
-            return "TooManyFieldLevelEncryptionProfiles: \(message ?? "")"
-        case .tooManyFieldLevelEncryptionQueryArgProfiles(let message):
-            return "TooManyFieldLevelEncryptionQueryArgProfiles: \(message ?? "")"
-        case .tooManyHeadersInCachePolicy(let message):
-            return "TooManyHeadersInCachePolicy: \(message ?? "")"
-        case .tooManyHeadersInForwardedValues(let message):
-            return "TooManyHeadersInForwardedValues: \(message ?? "")"
-        case .tooManyHeadersInOriginRequestPolicy(let message):
-            return "TooManyHeadersInOriginRequestPolicy: \(message ?? "")"
-        case .tooManyInvalidationsInProgress(let message):
-            return "TooManyInvalidationsInProgress: \(message ?? "")"
-        case .tooManyLambdaFunctionAssociations(let message):
-            return "TooManyLambdaFunctionAssociations: \(message ?? "")"
-        case .tooManyOriginCustomHeaders(let message):
-            return "TooManyOriginCustomHeaders: \(message ?? "")"
-        case .tooManyOriginGroupsPerDistribution(let message):
-            return "TooManyOriginGroupsPerDistribution: \(message ?? "")"
-        case .tooManyOriginRequestPolicies(let message):
-            return "TooManyOriginRequestPolicies: \(message ?? "")"
-        case .tooManyOrigins(let message):
-            return "TooManyOrigins: \(message ?? "")"
-        case .tooManyPublicKeys(let message):
-            return "TooManyPublicKeys: \(message ?? "")"
-        case .tooManyQueryStringParameters(let message):
-            return "TooManyQueryStringParameters: \(message ?? "")"
-        case .tooManyQueryStringsInCachePolicy(let message):
-            return "TooManyQueryStringsInCachePolicy: \(message ?? "")"
-        case .tooManyQueryStringsInOriginRequestPolicy(let message):
-            return "TooManyQueryStringsInOriginRequestPolicy: \(message ?? "")"
-        case .tooManyRealtimeLogConfigs(let message):
-            return "TooManyRealtimeLogConfigs: \(message ?? "")"
-        case .tooManyStreamingDistributionCNAMEs(let message):
-            return "TooManyStreamingDistributionCNAMEs: \(message ?? "")"
-        case .tooManyStreamingDistributions(let message):
-            return "TooManyStreamingDistributions: \(message ?? "")"
-        case .tooManyTrustedSigners(let message):
-            return "TooManyTrustedSigners: \(message ?? "")"
-        case .trustedSignerDoesNotExist(let message):
-            return "TrustedSignerDoesNotExist: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/CloudHSM/CloudHSM_Error.swift
+++ b/Sources/Soto/Services/CloudHSM/CloudHSM_Error.swift
@@ -17,40 +17,44 @@
 import SotoCore
 
 /// Error enum for CloudHSM
-public enum CloudHSMErrorType: AWSErrorType {
-    case cloudHsmInternalException(message: String?)
-    case cloudHsmServiceException(message: String?)
-    case invalidRequestException(message: String?)
-}
+public struct CloudHSMErrorType: AWSErrorType {
+    enum Code: String {
+        case cloudHsmInternalException = "CloudHsmInternalException"
+        case cloudHsmServiceException = "CloudHsmServiceException"
+        case invalidRequestException = "InvalidRequestException"
+    }
 
-extension CloudHSMErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "CloudHsmInternalException":
-            self = .cloudHsmInternalException(message: message)
-        case "CloudHsmServiceException":
-            self = .cloudHsmServiceException(message: message)
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var cloudHsmInternalException: Self { .init(.cloudHsmInternalException) }
+    public static var cloudHsmServiceException: Self { .init(.cloudHsmServiceException) }
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+}
+
+extension CloudHSMErrorType: Equatable {
+    public static func == (lhs: CloudHSMErrorType, rhs: CloudHSMErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension CloudHSMErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .cloudHsmInternalException(let message):
-            return "CloudHsmInternalException: \(message ?? "")"
-        case .cloudHsmServiceException(let message):
-            return "CloudHsmServiceException: \(message ?? "")"
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/CloudHSMV2/CloudHSMV2_Error.swift
+++ b/Sources/Soto/Services/CloudHSMV2/CloudHSMV2_Error.swift
@@ -17,55 +17,50 @@
 import SotoCore
 
 /// Error enum for CloudHSMV2
-public enum CloudHSMV2ErrorType: AWSErrorType {
-    case cloudHsmAccessDeniedException(message: String?)
-    case cloudHsmInternalFailureException(message: String?)
-    case cloudHsmInvalidRequestException(message: String?)
-    case cloudHsmResourceNotFoundException(message: String?)
-    case cloudHsmServiceException(message: String?)
-    case cloudHsmTagException(message: String?)
-}
+public struct CloudHSMV2ErrorType: AWSErrorType {
+    enum Code: String {
+        case cloudHsmAccessDeniedException = "CloudHsmAccessDeniedException"
+        case cloudHsmInternalFailureException = "CloudHsmInternalFailureException"
+        case cloudHsmInvalidRequestException = "CloudHsmInvalidRequestException"
+        case cloudHsmResourceNotFoundException = "CloudHsmResourceNotFoundException"
+        case cloudHsmServiceException = "CloudHsmServiceException"
+        case cloudHsmTagException = "CloudHsmTagException"
+    }
 
-extension CloudHSMV2ErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "CloudHsmAccessDeniedException":
-            self = .cloudHsmAccessDeniedException(message: message)
-        case "CloudHsmInternalFailureException":
-            self = .cloudHsmInternalFailureException(message: message)
-        case "CloudHsmInvalidRequestException":
-            self = .cloudHsmInvalidRequestException(message: message)
-        case "CloudHsmResourceNotFoundException":
-            self = .cloudHsmResourceNotFoundException(message: message)
-        case "CloudHsmServiceException":
-            self = .cloudHsmServiceException(message: message)
-        case "CloudHsmTagException":
-            self = .cloudHsmTagException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var cloudHsmAccessDeniedException: Self { .init(.cloudHsmAccessDeniedException) }
+    public static var cloudHsmInternalFailureException: Self { .init(.cloudHsmInternalFailureException) }
+    public static var cloudHsmInvalidRequestException: Self { .init(.cloudHsmInvalidRequestException) }
+    public static var cloudHsmResourceNotFoundException: Self { .init(.cloudHsmResourceNotFoundException) }
+    public static var cloudHsmServiceException: Self { .init(.cloudHsmServiceException) }
+    public static var cloudHsmTagException: Self { .init(.cloudHsmTagException) }
+}
+
+extension CloudHSMV2ErrorType: Equatable {
+    public static func == (lhs: CloudHSMV2ErrorType, rhs: CloudHSMV2ErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension CloudHSMV2ErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .cloudHsmAccessDeniedException(let message):
-            return "CloudHsmAccessDeniedException: \(message ?? "")"
-        case .cloudHsmInternalFailureException(let message):
-            return "CloudHsmInternalFailureException: \(message ?? "")"
-        case .cloudHsmInvalidRequestException(let message):
-            return "CloudHsmInvalidRequestException: \(message ?? "")"
-        case .cloudHsmResourceNotFoundException(let message):
-            return "CloudHsmResourceNotFoundException: \(message ?? "")"
-        case .cloudHsmServiceException(let message):
-            return "CloudHsmServiceException: \(message ?? "")"
-        case .cloudHsmTagException(let message):
-            return "CloudHsmTagException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/CloudSearch/CloudSearch_Error.swift
+++ b/Sources/Soto/Services/CloudSearch/CloudSearch_Error.swift
@@ -17,60 +17,52 @@
 import SotoCore
 
 /// Error enum for CloudSearch
-public enum CloudSearchErrorType: AWSErrorType {
-    case baseException(message: String?)
-    case disabledOperationException(message: String?)
-    case internalException(message: String?)
-    case invalidTypeException(message: String?)
-    case limitExceededException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case validationException(message: String?)
-}
+public struct CloudSearchErrorType: AWSErrorType {
+    enum Code: String {
+        case baseException = "BaseException"
+        case disabledOperationException = "DisabledAction"
+        case internalException = "InternalException"
+        case invalidTypeException = "InvalidType"
+        case limitExceededException = "LimitExceeded"
+        case resourceNotFoundException = "ResourceNotFound"
+        case validationException = "ValidationException"
+    }
 
-extension CloudSearchErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "BaseException":
-            self = .baseException(message: message)
-        case "DisabledAction":
-            self = .disabledOperationException(message: message)
-        case "InternalException":
-            self = .internalException(message: message)
-        case "InvalidType":
-            self = .invalidTypeException(message: message)
-        case "LimitExceeded":
-            self = .limitExceededException(message: message)
-        case "ResourceNotFound":
-            self = .resourceNotFoundException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var baseException: Self { .init(.baseException) }
+    public static var disabledOperationException: Self { .init(.disabledOperationException) }
+    public static var internalException: Self { .init(.internalException) }
+    public static var invalidTypeException: Self { .init(.invalidTypeException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension CloudSearchErrorType: Equatable {
+    public static func == (lhs: CloudSearchErrorType, rhs: CloudSearchErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension CloudSearchErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .baseException(let message):
-            return "BaseException: \(message ?? "")"
-        case .disabledOperationException(let message):
-            return "DisabledAction: \(message ?? "")"
-        case .internalException(let message):
-            return "InternalException: \(message ?? "")"
-        case .invalidTypeException(let message):
-            return "InvalidType: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceeded: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFound: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/CloudSearchDomain/CloudSearchDomain_Error.swift
+++ b/Sources/Soto/Services/CloudSearchDomain/CloudSearchDomain_Error.swift
@@ -17,35 +17,42 @@
 import SotoCore
 
 /// Error enum for CloudSearchDomain
-public enum CloudSearchDomainErrorType: AWSErrorType {
-    case documentServiceException(message: String?)
-    case searchException(message: String?)
-}
+public struct CloudSearchDomainErrorType: AWSErrorType {
+    enum Code: String {
+        case documentServiceException = "DocumentServiceException"
+        case searchException = "SearchException"
+    }
 
-extension CloudSearchDomainErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "DocumentServiceException":
-            self = .documentServiceException(message: message)
-        case "SearchException":
-            self = .searchException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var documentServiceException: Self { .init(.documentServiceException) }
+    public static var searchException: Self { .init(.searchException) }
+}
+
+extension CloudSearchDomainErrorType: Equatable {
+    public static func == (lhs: CloudSearchDomainErrorType, rhs: CloudSearchDomainErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension CloudSearchDomainErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .documentServiceException(let message):
-            return "DocumentServiceException: \(message ?? "")"
-        case .searchException(let message):
-            return "SearchException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/CloudTrail/CloudTrail_Error.swift
+++ b/Sources/Soto/Services/CloudTrail/CloudTrail_Error.swift
@@ -17,235 +17,122 @@
 import SotoCore
 
 /// Error enum for CloudTrail
-public enum CloudTrailErrorType: AWSErrorType {
-    case cloudTrailARNInvalidException(message: String?)
-    case cloudTrailAccessNotEnabledException(message: String?)
-    case cloudWatchLogsDeliveryUnavailableException(message: String?)
-    case insightNotEnabledException(message: String?)
-    case insufficientDependencyServiceAccessPermissionException(message: String?)
-    case insufficientEncryptionPolicyException(message: String?)
-    case insufficientS3BucketPolicyException(message: String?)
-    case insufficientSnsTopicPolicyException(message: String?)
-    case invalidCloudWatchLogsLogGroupArnException(message: String?)
-    case invalidCloudWatchLogsRoleArnException(message: String?)
-    case invalidEventCategoryException(message: String?)
-    case invalidEventSelectorsException(message: String?)
-    case invalidHomeRegionException(message: String?)
-    case invalidInsightSelectorsException(message: String?)
-    case invalidKmsKeyIdException(message: String?)
-    case invalidLookupAttributesException(message: String?)
-    case invalidMaxResultsException(message: String?)
-    case invalidNextTokenException(message: String?)
-    case invalidParameterCombinationException(message: String?)
-    case invalidS3BucketNameException(message: String?)
-    case invalidS3PrefixException(message: String?)
-    case invalidSnsTopicNameException(message: String?)
-    case invalidTagParameterException(message: String?)
-    case invalidTimeRangeException(message: String?)
-    case invalidTokenException(message: String?)
-    case invalidTrailNameException(message: String?)
-    case kmsException(message: String?)
-    case kmsKeyDisabledException(message: String?)
-    case kmsKeyNotFoundException(message: String?)
-    case maximumNumberOfTrailsExceededException(message: String?)
-    case notOrganizationMasterAccountException(message: String?)
-    case operationNotPermittedException(message: String?)
-    case organizationNotInAllFeaturesModeException(message: String?)
-    case organizationsNotInUseException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case resourceTypeNotSupportedException(message: String?)
-    case s3BucketDoesNotExistException(message: String?)
-    case tagsLimitExceededException(message: String?)
-    case trailAlreadyExistsException(message: String?)
-    case trailNotFoundException(message: String?)
-    case trailNotProvidedException(message: String?)
-    case unsupportedOperationException(message: String?)
-}
+public struct CloudTrailErrorType: AWSErrorType {
+    enum Code: String {
+        case cloudTrailARNInvalidException = "CloudTrailARNInvalidException"
+        case cloudTrailAccessNotEnabledException = "CloudTrailAccessNotEnabledException"
+        case cloudWatchLogsDeliveryUnavailableException = "CloudWatchLogsDeliveryUnavailableException"
+        case insightNotEnabledException = "InsightNotEnabledException"
+        case insufficientDependencyServiceAccessPermissionException = "InsufficientDependencyServiceAccessPermissionException"
+        case insufficientEncryptionPolicyException = "InsufficientEncryptionPolicyException"
+        case insufficientS3BucketPolicyException = "InsufficientS3BucketPolicyException"
+        case insufficientSnsTopicPolicyException = "InsufficientSnsTopicPolicyException"
+        case invalidCloudWatchLogsLogGroupArnException = "InvalidCloudWatchLogsLogGroupArnException"
+        case invalidCloudWatchLogsRoleArnException = "InvalidCloudWatchLogsRoleArnException"
+        case invalidEventCategoryException = "InvalidEventCategoryException"
+        case invalidEventSelectorsException = "InvalidEventSelectorsException"
+        case invalidHomeRegionException = "InvalidHomeRegionException"
+        case invalidInsightSelectorsException = "InvalidInsightSelectorsException"
+        case invalidKmsKeyIdException = "InvalidKmsKeyIdException"
+        case invalidLookupAttributesException = "InvalidLookupAttributesException"
+        case invalidMaxResultsException = "InvalidMaxResultsException"
+        case invalidNextTokenException = "InvalidNextTokenException"
+        case invalidParameterCombinationException = "InvalidParameterCombinationException"
+        case invalidS3BucketNameException = "InvalidS3BucketNameException"
+        case invalidS3PrefixException = "InvalidS3PrefixException"
+        case invalidSnsTopicNameException = "InvalidSnsTopicNameException"
+        case invalidTagParameterException = "InvalidTagParameterException"
+        case invalidTimeRangeException = "InvalidTimeRangeException"
+        case invalidTokenException = "InvalidTokenException"
+        case invalidTrailNameException = "InvalidTrailNameException"
+        case kmsException = "KmsException"
+        case kmsKeyDisabledException = "KmsKeyDisabledException"
+        case kmsKeyNotFoundException = "KmsKeyNotFoundException"
+        case maximumNumberOfTrailsExceededException = "MaximumNumberOfTrailsExceededException"
+        case notOrganizationMasterAccountException = "NotOrganizationMasterAccountException"
+        case operationNotPermittedException = "OperationNotPermittedException"
+        case organizationNotInAllFeaturesModeException = "OrganizationNotInAllFeaturesModeException"
+        case organizationsNotInUseException = "OrganizationsNotInUseException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case resourceTypeNotSupportedException = "ResourceTypeNotSupportedException"
+        case s3BucketDoesNotExistException = "S3BucketDoesNotExistException"
+        case tagsLimitExceededException = "TagsLimitExceededException"
+        case trailAlreadyExistsException = "TrailAlreadyExistsException"
+        case trailNotFoundException = "TrailNotFoundException"
+        case trailNotProvidedException = "TrailNotProvidedException"
+        case unsupportedOperationException = "UnsupportedOperationException"
+    }
 
-extension CloudTrailErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "CloudTrailARNInvalidException":
-            self = .cloudTrailARNInvalidException(message: message)
-        case "CloudTrailAccessNotEnabledException":
-            self = .cloudTrailAccessNotEnabledException(message: message)
-        case "CloudWatchLogsDeliveryUnavailableException":
-            self = .cloudWatchLogsDeliveryUnavailableException(message: message)
-        case "InsightNotEnabledException":
-            self = .insightNotEnabledException(message: message)
-        case "InsufficientDependencyServiceAccessPermissionException":
-            self = .insufficientDependencyServiceAccessPermissionException(message: message)
-        case "InsufficientEncryptionPolicyException":
-            self = .insufficientEncryptionPolicyException(message: message)
-        case "InsufficientS3BucketPolicyException":
-            self = .insufficientS3BucketPolicyException(message: message)
-        case "InsufficientSnsTopicPolicyException":
-            self = .insufficientSnsTopicPolicyException(message: message)
-        case "InvalidCloudWatchLogsLogGroupArnException":
-            self = .invalidCloudWatchLogsLogGroupArnException(message: message)
-        case "InvalidCloudWatchLogsRoleArnException":
-            self = .invalidCloudWatchLogsRoleArnException(message: message)
-        case "InvalidEventCategoryException":
-            self = .invalidEventCategoryException(message: message)
-        case "InvalidEventSelectorsException":
-            self = .invalidEventSelectorsException(message: message)
-        case "InvalidHomeRegionException":
-            self = .invalidHomeRegionException(message: message)
-        case "InvalidInsightSelectorsException":
-            self = .invalidInsightSelectorsException(message: message)
-        case "InvalidKmsKeyIdException":
-            self = .invalidKmsKeyIdException(message: message)
-        case "InvalidLookupAttributesException":
-            self = .invalidLookupAttributesException(message: message)
-        case "InvalidMaxResultsException":
-            self = .invalidMaxResultsException(message: message)
-        case "InvalidNextTokenException":
-            self = .invalidNextTokenException(message: message)
-        case "InvalidParameterCombinationException":
-            self = .invalidParameterCombinationException(message: message)
-        case "InvalidS3BucketNameException":
-            self = .invalidS3BucketNameException(message: message)
-        case "InvalidS3PrefixException":
-            self = .invalidS3PrefixException(message: message)
-        case "InvalidSnsTopicNameException":
-            self = .invalidSnsTopicNameException(message: message)
-        case "InvalidTagParameterException":
-            self = .invalidTagParameterException(message: message)
-        case "InvalidTimeRangeException":
-            self = .invalidTimeRangeException(message: message)
-        case "InvalidTokenException":
-            self = .invalidTokenException(message: message)
-        case "InvalidTrailNameException":
-            self = .invalidTrailNameException(message: message)
-        case "KmsException":
-            self = .kmsException(message: message)
-        case "KmsKeyDisabledException":
-            self = .kmsKeyDisabledException(message: message)
-        case "KmsKeyNotFoundException":
-            self = .kmsKeyNotFoundException(message: message)
-        case "MaximumNumberOfTrailsExceededException":
-            self = .maximumNumberOfTrailsExceededException(message: message)
-        case "NotOrganizationMasterAccountException":
-            self = .notOrganizationMasterAccountException(message: message)
-        case "OperationNotPermittedException":
-            self = .operationNotPermittedException(message: message)
-        case "OrganizationNotInAllFeaturesModeException":
-            self = .organizationNotInAllFeaturesModeException(message: message)
-        case "OrganizationsNotInUseException":
-            self = .organizationsNotInUseException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ResourceTypeNotSupportedException":
-            self = .resourceTypeNotSupportedException(message: message)
-        case "S3BucketDoesNotExistException":
-            self = .s3BucketDoesNotExistException(message: message)
-        case "TagsLimitExceededException":
-            self = .tagsLimitExceededException(message: message)
-        case "TrailAlreadyExistsException":
-            self = .trailAlreadyExistsException(message: message)
-        case "TrailNotFoundException":
-            self = .trailNotFoundException(message: message)
-        case "TrailNotProvidedException":
-            self = .trailNotProvidedException(message: message)
-        case "UnsupportedOperationException":
-            self = .unsupportedOperationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var cloudTrailARNInvalidException: Self { .init(.cloudTrailARNInvalidException) }
+    public static var cloudTrailAccessNotEnabledException: Self { .init(.cloudTrailAccessNotEnabledException) }
+    public static var cloudWatchLogsDeliveryUnavailableException: Self { .init(.cloudWatchLogsDeliveryUnavailableException) }
+    public static var insightNotEnabledException: Self { .init(.insightNotEnabledException) }
+    public static var insufficientDependencyServiceAccessPermissionException: Self { .init(.insufficientDependencyServiceAccessPermissionException) }
+    public static var insufficientEncryptionPolicyException: Self { .init(.insufficientEncryptionPolicyException) }
+    public static var insufficientS3BucketPolicyException: Self { .init(.insufficientS3BucketPolicyException) }
+    public static var insufficientSnsTopicPolicyException: Self { .init(.insufficientSnsTopicPolicyException) }
+    public static var invalidCloudWatchLogsLogGroupArnException: Self { .init(.invalidCloudWatchLogsLogGroupArnException) }
+    public static var invalidCloudWatchLogsRoleArnException: Self { .init(.invalidCloudWatchLogsRoleArnException) }
+    public static var invalidEventCategoryException: Self { .init(.invalidEventCategoryException) }
+    public static var invalidEventSelectorsException: Self { .init(.invalidEventSelectorsException) }
+    public static var invalidHomeRegionException: Self { .init(.invalidHomeRegionException) }
+    public static var invalidInsightSelectorsException: Self { .init(.invalidInsightSelectorsException) }
+    public static var invalidKmsKeyIdException: Self { .init(.invalidKmsKeyIdException) }
+    public static var invalidLookupAttributesException: Self { .init(.invalidLookupAttributesException) }
+    public static var invalidMaxResultsException: Self { .init(.invalidMaxResultsException) }
+    public static var invalidNextTokenException: Self { .init(.invalidNextTokenException) }
+    public static var invalidParameterCombinationException: Self { .init(.invalidParameterCombinationException) }
+    public static var invalidS3BucketNameException: Self { .init(.invalidS3BucketNameException) }
+    public static var invalidS3PrefixException: Self { .init(.invalidS3PrefixException) }
+    public static var invalidSnsTopicNameException: Self { .init(.invalidSnsTopicNameException) }
+    public static var invalidTagParameterException: Self { .init(.invalidTagParameterException) }
+    public static var invalidTimeRangeException: Self { .init(.invalidTimeRangeException) }
+    public static var invalidTokenException: Self { .init(.invalidTokenException) }
+    public static var invalidTrailNameException: Self { .init(.invalidTrailNameException) }
+    public static var kmsException: Self { .init(.kmsException) }
+    public static var kmsKeyDisabledException: Self { .init(.kmsKeyDisabledException) }
+    public static var kmsKeyNotFoundException: Self { .init(.kmsKeyNotFoundException) }
+    public static var maximumNumberOfTrailsExceededException: Self { .init(.maximumNumberOfTrailsExceededException) }
+    public static var notOrganizationMasterAccountException: Self { .init(.notOrganizationMasterAccountException) }
+    public static var operationNotPermittedException: Self { .init(.operationNotPermittedException) }
+    public static var organizationNotInAllFeaturesModeException: Self { .init(.organizationNotInAllFeaturesModeException) }
+    public static var organizationsNotInUseException: Self { .init(.organizationsNotInUseException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var resourceTypeNotSupportedException: Self { .init(.resourceTypeNotSupportedException) }
+    public static var s3BucketDoesNotExistException: Self { .init(.s3BucketDoesNotExistException) }
+    public static var tagsLimitExceededException: Self { .init(.tagsLimitExceededException) }
+    public static var trailAlreadyExistsException: Self { .init(.trailAlreadyExistsException) }
+    public static var trailNotFoundException: Self { .init(.trailNotFoundException) }
+    public static var trailNotProvidedException: Self { .init(.trailNotProvidedException) }
+    public static var unsupportedOperationException: Self { .init(.unsupportedOperationException) }
+}
+
+extension CloudTrailErrorType: Equatable {
+    public static func == (lhs: CloudTrailErrorType, rhs: CloudTrailErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension CloudTrailErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .cloudTrailARNInvalidException(let message):
-            return "CloudTrailARNInvalidException: \(message ?? "")"
-        case .cloudTrailAccessNotEnabledException(let message):
-            return "CloudTrailAccessNotEnabledException: \(message ?? "")"
-        case .cloudWatchLogsDeliveryUnavailableException(let message):
-            return "CloudWatchLogsDeliveryUnavailableException: \(message ?? "")"
-        case .insightNotEnabledException(let message):
-            return "InsightNotEnabledException: \(message ?? "")"
-        case .insufficientDependencyServiceAccessPermissionException(let message):
-            return "InsufficientDependencyServiceAccessPermissionException: \(message ?? "")"
-        case .insufficientEncryptionPolicyException(let message):
-            return "InsufficientEncryptionPolicyException: \(message ?? "")"
-        case .insufficientS3BucketPolicyException(let message):
-            return "InsufficientS3BucketPolicyException: \(message ?? "")"
-        case .insufficientSnsTopicPolicyException(let message):
-            return "InsufficientSnsTopicPolicyException: \(message ?? "")"
-        case .invalidCloudWatchLogsLogGroupArnException(let message):
-            return "InvalidCloudWatchLogsLogGroupArnException: \(message ?? "")"
-        case .invalidCloudWatchLogsRoleArnException(let message):
-            return "InvalidCloudWatchLogsRoleArnException: \(message ?? "")"
-        case .invalidEventCategoryException(let message):
-            return "InvalidEventCategoryException: \(message ?? "")"
-        case .invalidEventSelectorsException(let message):
-            return "InvalidEventSelectorsException: \(message ?? "")"
-        case .invalidHomeRegionException(let message):
-            return "InvalidHomeRegionException: \(message ?? "")"
-        case .invalidInsightSelectorsException(let message):
-            return "InvalidInsightSelectorsException: \(message ?? "")"
-        case .invalidKmsKeyIdException(let message):
-            return "InvalidKmsKeyIdException: \(message ?? "")"
-        case .invalidLookupAttributesException(let message):
-            return "InvalidLookupAttributesException: \(message ?? "")"
-        case .invalidMaxResultsException(let message):
-            return "InvalidMaxResultsException: \(message ?? "")"
-        case .invalidNextTokenException(let message):
-            return "InvalidNextTokenException: \(message ?? "")"
-        case .invalidParameterCombinationException(let message):
-            return "InvalidParameterCombinationException: \(message ?? "")"
-        case .invalidS3BucketNameException(let message):
-            return "InvalidS3BucketNameException: \(message ?? "")"
-        case .invalidS3PrefixException(let message):
-            return "InvalidS3PrefixException: \(message ?? "")"
-        case .invalidSnsTopicNameException(let message):
-            return "InvalidSnsTopicNameException: \(message ?? "")"
-        case .invalidTagParameterException(let message):
-            return "InvalidTagParameterException: \(message ?? "")"
-        case .invalidTimeRangeException(let message):
-            return "InvalidTimeRangeException: \(message ?? "")"
-        case .invalidTokenException(let message):
-            return "InvalidTokenException: \(message ?? "")"
-        case .invalidTrailNameException(let message):
-            return "InvalidTrailNameException: \(message ?? "")"
-        case .kmsException(let message):
-            return "KmsException: \(message ?? "")"
-        case .kmsKeyDisabledException(let message):
-            return "KmsKeyDisabledException: \(message ?? "")"
-        case .kmsKeyNotFoundException(let message):
-            return "KmsKeyNotFoundException: \(message ?? "")"
-        case .maximumNumberOfTrailsExceededException(let message):
-            return "MaximumNumberOfTrailsExceededException: \(message ?? "")"
-        case .notOrganizationMasterAccountException(let message):
-            return "NotOrganizationMasterAccountException: \(message ?? "")"
-        case .operationNotPermittedException(let message):
-            return "OperationNotPermittedException: \(message ?? "")"
-        case .organizationNotInAllFeaturesModeException(let message):
-            return "OrganizationNotInAllFeaturesModeException: \(message ?? "")"
-        case .organizationsNotInUseException(let message):
-            return "OrganizationsNotInUseException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .resourceTypeNotSupportedException(let message):
-            return "ResourceTypeNotSupportedException: \(message ?? "")"
-        case .s3BucketDoesNotExistException(let message):
-            return "S3BucketDoesNotExistException: \(message ?? "")"
-        case .tagsLimitExceededException(let message):
-            return "TagsLimitExceededException: \(message ?? "")"
-        case .trailAlreadyExistsException(let message):
-            return "TrailAlreadyExistsException: \(message ?? "")"
-        case .trailNotFoundException(let message):
-            return "TrailNotFoundException: \(message ?? "")"
-        case .trailNotProvidedException(let message):
-            return "TrailNotProvidedException: \(message ?? "")"
-        case .unsupportedOperationException(let message):
-            return "UnsupportedOperationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/CloudWatch/CloudWatch_Error.swift
+++ b/Sources/Soto/Services/CloudWatch/CloudWatch_Error.swift
@@ -17,85 +17,62 @@
 import SotoCore
 
 /// Error enum for CloudWatch
-public enum CloudWatchErrorType: AWSErrorType {
-    case concurrentModificationException(message: String?)
-    case dashboardInvalidInputError(message: String?)
-    case internalServiceFault(message: String?)
-    case invalidFormatFault(message: String?)
-    case invalidNextToken(message: String?)
-    case invalidParameterCombinationException(message: String?)
-    case invalidParameterValueException(message: String?)
-    case limitExceededException(message: String?)
-    case limitExceededFault(message: String?)
-    case missingRequiredParameterException(message: String?)
-    case resourceNotFound(message: String?)
-    case resourceNotFoundException(message: String?)
-}
+public struct CloudWatchErrorType: AWSErrorType {
+    enum Code: String {
+        case concurrentModificationException = "ConcurrentModificationException"
+        case dashboardInvalidInputError = "InvalidParameterInput"
+        case internalServiceFault = "InternalServiceError"
+        case invalidFormatFault = "InvalidFormat"
+        case invalidNextToken = "InvalidNextToken"
+        case invalidParameterCombinationException = "InvalidParameterCombination"
+        case invalidParameterValueException = "InvalidParameterValue"
+        case limitExceededException = "LimitExceededException"
+        case limitExceededFault = "LimitExceeded"
+        case missingRequiredParameterException = "MissingParameter"
+        case resourceNotFound = "ResourceNotFound"
+        case resourceNotFoundException = "ResourceNotFoundException"
+    }
 
-extension CloudWatchErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ConcurrentModificationException":
-            self = .concurrentModificationException(message: message)
-        case "InvalidParameterInput":
-            self = .dashboardInvalidInputError(message: message)
-        case "InternalServiceError":
-            self = .internalServiceFault(message: message)
-        case "InvalidFormat":
-            self = .invalidFormatFault(message: message)
-        case "InvalidNextToken":
-            self = .invalidNextToken(message: message)
-        case "InvalidParameterCombination":
-            self = .invalidParameterCombinationException(message: message)
-        case "InvalidParameterValue":
-            self = .invalidParameterValueException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "LimitExceeded":
-            self = .limitExceededFault(message: message)
-        case "MissingParameter":
-            self = .missingRequiredParameterException(message: message)
-        case "ResourceNotFound":
-            self = .resourceNotFound(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var concurrentModificationException: Self { .init(.concurrentModificationException) }
+    public static var dashboardInvalidInputError: Self { .init(.dashboardInvalidInputError) }
+    public static var internalServiceFault: Self { .init(.internalServiceFault) }
+    public static var invalidFormatFault: Self { .init(.invalidFormatFault) }
+    public static var invalidNextToken: Self { .init(.invalidNextToken) }
+    public static var invalidParameterCombinationException: Self { .init(.invalidParameterCombinationException) }
+    public static var invalidParameterValueException: Self { .init(.invalidParameterValueException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var limitExceededFault: Self { .init(.limitExceededFault) }
+    public static var missingRequiredParameterException: Self { .init(.missingRequiredParameterException) }
+    public static var resourceNotFound: Self { .init(.resourceNotFound) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+}
+
+extension CloudWatchErrorType: Equatable {
+    public static func == (lhs: CloudWatchErrorType, rhs: CloudWatchErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension CloudWatchErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .concurrentModificationException(let message):
-            return "ConcurrentModificationException: \(message ?? "")"
-        case .dashboardInvalidInputError(let message):
-            return "InvalidParameterInput: \(message ?? "")"
-        case .internalServiceFault(let message):
-            return "InternalServiceError: \(message ?? "")"
-        case .invalidFormatFault(let message):
-            return "InvalidFormat: \(message ?? "")"
-        case .invalidNextToken(let message):
-            return "InvalidNextToken: \(message ?? "")"
-        case .invalidParameterCombinationException(let message):
-            return "InvalidParameterCombination: \(message ?? "")"
-        case .invalidParameterValueException(let message):
-            return "InvalidParameterValue: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .limitExceededFault(let message):
-            return "LimitExceeded: \(message ?? "")"
-        case .missingRequiredParameterException(let message):
-            return "MissingParameter: \(message ?? "")"
-        case .resourceNotFound(let message):
-            return "ResourceNotFound: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/CloudWatchEvents/CloudWatchEvents_Error.swift
+++ b/Sources/Soto/Services/CloudWatchEvents/CloudWatchEvents_Error.swift
@@ -17,75 +17,58 @@
 import SotoCore
 
 /// Error enum for CloudWatchEvents
-public enum CloudWatchEventsErrorType: AWSErrorType {
-    case concurrentModificationException(message: String?)
-    case internalException(message: String?)
-    case invalidEventPatternException(message: String?)
-    case invalidStateException(message: String?)
-    case limitExceededException(message: String?)
-    case managedRuleException(message: String?)
-    case operationDisabledException(message: String?)
-    case policyLengthExceededException(message: String?)
-    case resourceAlreadyExistsException(message: String?)
-    case resourceNotFoundException(message: String?)
-}
+public struct CloudWatchEventsErrorType: AWSErrorType {
+    enum Code: String {
+        case concurrentModificationException = "ConcurrentModificationException"
+        case internalException = "InternalException"
+        case invalidEventPatternException = "InvalidEventPatternException"
+        case invalidStateException = "InvalidStateException"
+        case limitExceededException = "LimitExceededException"
+        case managedRuleException = "ManagedRuleException"
+        case operationDisabledException = "OperationDisabledException"
+        case policyLengthExceededException = "PolicyLengthExceededException"
+        case resourceAlreadyExistsException = "ResourceAlreadyExistsException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+    }
 
-extension CloudWatchEventsErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ConcurrentModificationException":
-            self = .concurrentModificationException(message: message)
-        case "InternalException":
-            self = .internalException(message: message)
-        case "InvalidEventPatternException":
-            self = .invalidEventPatternException(message: message)
-        case "InvalidStateException":
-            self = .invalidStateException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ManagedRuleException":
-            self = .managedRuleException(message: message)
-        case "OperationDisabledException":
-            self = .operationDisabledException(message: message)
-        case "PolicyLengthExceededException":
-            self = .policyLengthExceededException(message: message)
-        case "ResourceAlreadyExistsException":
-            self = .resourceAlreadyExistsException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var concurrentModificationException: Self { .init(.concurrentModificationException) }
+    public static var internalException: Self { .init(.internalException) }
+    public static var invalidEventPatternException: Self { .init(.invalidEventPatternException) }
+    public static var invalidStateException: Self { .init(.invalidStateException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var managedRuleException: Self { .init(.managedRuleException) }
+    public static var operationDisabledException: Self { .init(.operationDisabledException) }
+    public static var policyLengthExceededException: Self { .init(.policyLengthExceededException) }
+    public static var resourceAlreadyExistsException: Self { .init(.resourceAlreadyExistsException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+}
+
+extension CloudWatchEventsErrorType: Equatable {
+    public static func == (lhs: CloudWatchEventsErrorType, rhs: CloudWatchEventsErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension CloudWatchEventsErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .concurrentModificationException(let message):
-            return "ConcurrentModificationException: \(message ?? "")"
-        case .internalException(let message):
-            return "InternalException: \(message ?? "")"
-        case .invalidEventPatternException(let message):
-            return "InvalidEventPatternException: \(message ?? "")"
-        case .invalidStateException(let message):
-            return "InvalidStateException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .managedRuleException(let message):
-            return "ManagedRuleException: \(message ?? "")"
-        case .operationDisabledException(let message):
-            return "OperationDisabledException: \(message ?? "")"
-        case .policyLengthExceededException(let message):
-            return "PolicyLengthExceededException: \(message ?? "")"
-        case .resourceAlreadyExistsException(let message):
-            return "ResourceAlreadyExistsException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/CloudWatchLogs/CloudWatchLogs_Error.swift
+++ b/Sources/Soto/Services/CloudWatchLogs/CloudWatchLogs_Error.swift
@@ -17,80 +17,60 @@
 import SotoCore
 
 /// Error enum for CloudWatchLogs
-public enum CloudWatchLogsErrorType: AWSErrorType {
-    case dataAlreadyAcceptedException(message: String?)
-    case invalidOperationException(message: String?)
-    case invalidParameterException(message: String?)
-    case invalidSequenceTokenException(message: String?)
-    case limitExceededException(message: String?)
-    case malformedQueryException(message: String?)
-    case operationAbortedException(message: String?)
-    case resourceAlreadyExistsException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceUnavailableException(message: String?)
-    case unrecognizedClientException(message: String?)
-}
+public struct CloudWatchLogsErrorType: AWSErrorType {
+    enum Code: String {
+        case dataAlreadyAcceptedException = "DataAlreadyAcceptedException"
+        case invalidOperationException = "InvalidOperationException"
+        case invalidParameterException = "InvalidParameterException"
+        case invalidSequenceTokenException = "InvalidSequenceTokenException"
+        case limitExceededException = "LimitExceededException"
+        case malformedQueryException = "MalformedQueryException"
+        case operationAbortedException = "OperationAbortedException"
+        case resourceAlreadyExistsException = "ResourceAlreadyExistsException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+        case unrecognizedClientException = "UnrecognizedClientException"
+    }
 
-extension CloudWatchLogsErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "DataAlreadyAcceptedException":
-            self = .dataAlreadyAcceptedException(message: message)
-        case "InvalidOperationException":
-            self = .invalidOperationException(message: message)
-        case "InvalidParameterException":
-            self = .invalidParameterException(message: message)
-        case "InvalidSequenceTokenException":
-            self = .invalidSequenceTokenException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "MalformedQueryException":
-            self = .malformedQueryException(message: message)
-        case "OperationAbortedException":
-            self = .operationAbortedException(message: message)
-        case "ResourceAlreadyExistsException":
-            self = .resourceAlreadyExistsException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        case "UnrecognizedClientException":
-            self = .unrecognizedClientException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var dataAlreadyAcceptedException: Self { .init(.dataAlreadyAcceptedException) }
+    public static var invalidOperationException: Self { .init(.invalidOperationException) }
+    public static var invalidParameterException: Self { .init(.invalidParameterException) }
+    public static var invalidSequenceTokenException: Self { .init(.invalidSequenceTokenException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var malformedQueryException: Self { .init(.malformedQueryException) }
+    public static var operationAbortedException: Self { .init(.operationAbortedException) }
+    public static var resourceAlreadyExistsException: Self { .init(.resourceAlreadyExistsException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+    public static var unrecognizedClientException: Self { .init(.unrecognizedClientException) }
+}
+
+extension CloudWatchLogsErrorType: Equatable {
+    public static func == (lhs: CloudWatchLogsErrorType, rhs: CloudWatchLogsErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension CloudWatchLogsErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .dataAlreadyAcceptedException(let message):
-            return "DataAlreadyAcceptedException: \(message ?? "")"
-        case .invalidOperationException(let message):
-            return "InvalidOperationException: \(message ?? "")"
-        case .invalidParameterException(let message):
-            return "InvalidParameterException: \(message ?? "")"
-        case .invalidSequenceTokenException(let message):
-            return "InvalidSequenceTokenException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .malformedQueryException(let message):
-            return "MalformedQueryException: \(message ?? "")"
-        case .operationAbortedException(let message):
-            return "OperationAbortedException: \(message ?? "")"
-        case .resourceAlreadyExistsException(let message):
-            return "ResourceAlreadyExistsException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        case .unrecognizedClientException(let message):
-            return "UnrecognizedClientException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/CodeArtifact/CodeArtifact_Error.swift
+++ b/Sources/Soto/Services/CodeArtifact/CodeArtifact_Error.swift
@@ -17,60 +17,52 @@
 import SotoCore
 
 /// Error enum for CodeArtifact
-public enum CodeArtifactErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case conflictException(message: String?)
-    case internalServerException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceQuotaExceededException(message: String?)
-    case throttlingException(message: String?)
-    case validationException(message: String?)
-}
+public struct CodeArtifactErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case conflictException = "ConflictException"
+        case internalServerException = "InternalServerException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceQuotaExceededException = "ServiceQuotaExceededException"
+        case throttlingException = "ThrottlingException"
+        case validationException = "ValidationException"
+    }
 
-extension CodeArtifactErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceQuotaExceededException":
-            self = .serviceQuotaExceededException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceQuotaExceededException: Self { .init(.serviceQuotaExceededException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension CodeArtifactErrorType: Equatable {
+    public static func == (lhs: CodeArtifactErrorType, rhs: CodeArtifactErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension CodeArtifactErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceQuotaExceededException(let message):
-            return "ServiceQuotaExceededException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/CodeBuild/CodeBuild_Error.swift
+++ b/Sources/Soto/Services/CodeBuild/CodeBuild_Error.swift
@@ -17,50 +17,48 @@
 import SotoCore
 
 /// Error enum for CodeBuild
-public enum CodeBuildErrorType: AWSErrorType {
-    case accountLimitExceededException(message: String?)
-    case invalidInputException(message: String?)
-    case oAuthProviderException(message: String?)
-    case resourceAlreadyExistsException(message: String?)
-    case resourceNotFoundException(message: String?)
-}
+public struct CodeBuildErrorType: AWSErrorType {
+    enum Code: String {
+        case accountLimitExceededException = "AccountLimitExceededException"
+        case invalidInputException = "InvalidInputException"
+        case oAuthProviderException = "OAuthProviderException"
+        case resourceAlreadyExistsException = "ResourceAlreadyExistsException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+    }
 
-extension CodeBuildErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccountLimitExceededException":
-            self = .accountLimitExceededException(message: message)
-        case "InvalidInputException":
-            self = .invalidInputException(message: message)
-        case "OAuthProviderException":
-            self = .oAuthProviderException(message: message)
-        case "ResourceAlreadyExistsException":
-            self = .resourceAlreadyExistsException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accountLimitExceededException: Self { .init(.accountLimitExceededException) }
+    public static var invalidInputException: Self { .init(.invalidInputException) }
+    public static var oAuthProviderException: Self { .init(.oAuthProviderException) }
+    public static var resourceAlreadyExistsException: Self { .init(.resourceAlreadyExistsException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+}
+
+extension CodeBuildErrorType: Equatable {
+    public static func == (lhs: CodeBuildErrorType, rhs: CodeBuildErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension CodeBuildErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accountLimitExceededException(let message):
-            return "AccountLimitExceededException: \(message ?? "")"
-        case .invalidInputException(let message):
-            return "InvalidInputException: \(message ?? "")"
-        case .oAuthProviderException(let message):
-            return "OAuthProviderException: \(message ?? "")"
-        case .resourceAlreadyExistsException(let message):
-            return "ResourceAlreadyExistsException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/CodeCommit/CodeCommit_Error.swift
+++ b/Sources/Soto/Services/CodeCommit/CodeCommit_Error.swift
@@ -17,950 +17,408 @@
 import SotoCore
 
 /// Error enum for CodeCommit
-public enum CodeCommitErrorType: AWSErrorType {
-    case actorDoesNotExistException(message: String?)
-    case approvalRuleContentRequiredException(message: String?)
-    case approvalRuleDoesNotExistException(message: String?)
-    case approvalRuleNameAlreadyExistsException(message: String?)
-    case approvalRuleNameRequiredException(message: String?)
-    case approvalRuleTemplateContentRequiredException(message: String?)
-    case approvalRuleTemplateDoesNotExistException(message: String?)
-    case approvalRuleTemplateInUseException(message: String?)
-    case approvalRuleTemplateNameAlreadyExistsException(message: String?)
-    case approvalRuleTemplateNameRequiredException(message: String?)
-    case approvalStateRequiredException(message: String?)
-    case authorDoesNotExistException(message: String?)
-    case beforeCommitIdAndAfterCommitIdAreSameException(message: String?)
-    case blobIdDoesNotExistException(message: String?)
-    case blobIdRequiredException(message: String?)
-    case branchDoesNotExistException(message: String?)
-    case branchNameExistsException(message: String?)
-    case branchNameIsTagNameException(message: String?)
-    case branchNameRequiredException(message: String?)
-    case cannotDeleteApprovalRuleFromTemplateException(message: String?)
-    case cannotModifyApprovalRuleFromTemplateException(message: String?)
-    case clientRequestTokenRequiredException(message: String?)
-    case commentContentRequiredException(message: String?)
-    case commentContentSizeLimitExceededException(message: String?)
-    case commentDeletedException(message: String?)
-    case commentDoesNotExistException(message: String?)
-    case commentIdRequiredException(message: String?)
-    case commentNotCreatedByCallerException(message: String?)
-    case commitDoesNotExistException(message: String?)
-    case commitIdDoesNotExistException(message: String?)
-    case commitIdRequiredException(message: String?)
-    case commitIdsLimitExceededException(message: String?)
-    case commitIdsListRequiredException(message: String?)
-    case commitMessageLengthExceededException(message: String?)
-    case commitRequiredException(message: String?)
-    case concurrentReferenceUpdateException(message: String?)
-    case defaultBranchCannotBeDeletedException(message: String?)
-    case directoryNameConflictsWithFileNameException(message: String?)
-    case encryptionIntegrityChecksFailedException(message: String?)
-    case encryptionKeyAccessDeniedException(message: String?)
-    case encryptionKeyDisabledException(message: String?)
-    case encryptionKeyNotFoundException(message: String?)
-    case encryptionKeyUnavailableException(message: String?)
-    case fileContentAndSourceFileSpecifiedException(message: String?)
-    case fileContentRequiredException(message: String?)
-    case fileContentSizeLimitExceededException(message: String?)
-    case fileDoesNotExistException(message: String?)
-    case fileEntryRequiredException(message: String?)
-    case fileModeRequiredException(message: String?)
-    case fileNameConflictsWithDirectoryNameException(message: String?)
-    case filePathConflictsWithSubmodulePathException(message: String?)
-    case fileTooLargeException(message: String?)
-    case folderContentSizeLimitExceededException(message: String?)
-    case folderDoesNotExistException(message: String?)
-    case idempotencyParameterMismatchException(message: String?)
-    case invalidActorArnException(message: String?)
-    case invalidApprovalRuleContentException(message: String?)
-    case invalidApprovalRuleNameException(message: String?)
-    case invalidApprovalRuleTemplateContentException(message: String?)
-    case invalidApprovalRuleTemplateDescriptionException(message: String?)
-    case invalidApprovalRuleTemplateNameException(message: String?)
-    case invalidApprovalStateException(message: String?)
-    case invalidAuthorArnException(message: String?)
-    case invalidBlobIdException(message: String?)
-    case invalidBranchNameException(message: String?)
-    case invalidClientRequestTokenException(message: String?)
-    case invalidCommentIdException(message: String?)
-    case invalidCommitException(message: String?)
-    case invalidCommitIdException(message: String?)
-    case invalidConflictDetailLevelException(message: String?)
-    case invalidConflictResolutionException(message: String?)
-    case invalidConflictResolutionStrategyException(message: String?)
-    case invalidContinuationTokenException(message: String?)
-    case invalidDeletionParameterException(message: String?)
-    case invalidDescriptionException(message: String?)
-    case invalidDestinationCommitSpecifierException(message: String?)
-    case invalidEmailException(message: String?)
-    case invalidFileLocationException(message: String?)
-    case invalidFileModeException(message: String?)
-    case invalidFilePositionException(message: String?)
-    case invalidMaxConflictFilesException(message: String?)
-    case invalidMaxMergeHunksException(message: String?)
-    case invalidMaxResultsException(message: String?)
-    case invalidMergeOptionException(message: String?)
-    case invalidOrderException(message: String?)
-    case invalidOverrideStatusException(message: String?)
-    case invalidParentCommitIdException(message: String?)
-    case invalidPathException(message: String?)
-    case invalidPullRequestEventTypeException(message: String?)
-    case invalidPullRequestIdException(message: String?)
-    case invalidPullRequestStatusException(message: String?)
-    case invalidPullRequestStatusUpdateException(message: String?)
-    case invalidReactionUserArnException(message: String?)
-    case invalidReactionValueException(message: String?)
-    case invalidReferenceNameException(message: String?)
-    case invalidRelativeFileVersionEnumException(message: String?)
-    case invalidReplacementContentException(message: String?)
-    case invalidReplacementTypeException(message: String?)
-    case invalidRepositoryDescriptionException(message: String?)
-    case invalidRepositoryNameException(message: String?)
-    case invalidRepositoryTriggerBranchNameException(message: String?)
-    case invalidRepositoryTriggerCustomDataException(message: String?)
-    case invalidRepositoryTriggerDestinationArnException(message: String?)
-    case invalidRepositoryTriggerEventsException(message: String?)
-    case invalidRepositoryTriggerNameException(message: String?)
-    case invalidRepositoryTriggerRegionException(message: String?)
-    case invalidResourceArnException(message: String?)
-    case invalidRevisionIdException(message: String?)
-    case invalidRuleContentSha256Exception(message: String?)
-    case invalidSortByException(message: String?)
-    case invalidSourceCommitSpecifierException(message: String?)
-    case invalidSystemTagUsageException(message: String?)
-    case invalidTagKeysListException(message: String?)
-    case invalidTagsMapException(message: String?)
-    case invalidTargetBranchException(message: String?)
-    case invalidTargetException(message: String?)
-    case invalidTargetsException(message: String?)
-    case invalidTitleException(message: String?)
-    case manualMergeRequiredException(message: String?)
-    case maximumBranchesExceededException(message: String?)
-    case maximumConflictResolutionEntriesExceededException(message: String?)
-    case maximumFileContentToLoadExceededException(message: String?)
-    case maximumFileEntriesExceededException(message: String?)
-    case maximumItemsToCompareExceededException(message: String?)
-    case maximumNumberOfApprovalsExceededException(message: String?)
-    case maximumOpenPullRequestsExceededException(message: String?)
-    case maximumRepositoryNamesExceededException(message: String?)
-    case maximumRepositoryTriggersExceededException(message: String?)
-    case maximumRuleTemplatesAssociatedWithRepositoryException(message: String?)
-    case mergeOptionRequiredException(message: String?)
-    case multipleConflictResolutionEntriesException(message: String?)
-    case multipleRepositoriesInPullRequestException(message: String?)
-    case nameLengthExceededException(message: String?)
-    case noChangeException(message: String?)
-    case numberOfRuleTemplatesExceededException(message: String?)
-    case numberOfRulesExceededException(message: String?)
-    case overrideAlreadySetException(message: String?)
-    case overrideStatusRequiredException(message: String?)
-    case parentCommitDoesNotExistException(message: String?)
-    case parentCommitIdOutdatedException(message: String?)
-    case parentCommitIdRequiredException(message: String?)
-    case pathDoesNotExistException(message: String?)
-    case pathRequiredException(message: String?)
-    case pullRequestAlreadyClosedException(message: String?)
-    case pullRequestApprovalRulesNotSatisfiedException(message: String?)
-    case pullRequestCannotBeApprovedByAuthorException(message: String?)
-    case pullRequestDoesNotExistException(message: String?)
-    case pullRequestIdRequiredException(message: String?)
-    case pullRequestStatusRequiredException(message: String?)
-    case putFileEntryConflictException(message: String?)
-    case reactionLimitExceededException(message: String?)
-    case reactionValueRequiredException(message: String?)
-    case referenceDoesNotExistException(message: String?)
-    case referenceNameRequiredException(message: String?)
-    case referenceTypeNotSupportedException(message: String?)
-    case replacementContentRequiredException(message: String?)
-    case replacementTypeRequiredException(message: String?)
-    case repositoryDoesNotExistException(message: String?)
-    case repositoryLimitExceededException(message: String?)
-    case repositoryNameExistsException(message: String?)
-    case repositoryNameRequiredException(message: String?)
-    case repositoryNamesRequiredException(message: String?)
-    case repositoryNotAssociatedWithPullRequestException(message: String?)
-    case repositoryTriggerBranchNameListRequiredException(message: String?)
-    case repositoryTriggerDestinationArnRequiredException(message: String?)
-    case repositoryTriggerEventsListRequiredException(message: String?)
-    case repositoryTriggerNameRequiredException(message: String?)
-    case repositoryTriggersListRequiredException(message: String?)
-    case resourceArnRequiredException(message: String?)
-    case restrictedSourceFileException(message: String?)
-    case revisionIdRequiredException(message: String?)
-    case revisionNotCurrentException(message: String?)
-    case sameFileContentException(message: String?)
-    case samePathRequestException(message: String?)
-    case sourceAndDestinationAreSameException(message: String?)
-    case sourceFileOrContentRequiredException(message: String?)
-    case tagKeysListRequiredException(message: String?)
-    case tagPolicyException(message: String?)
-    case tagsMapRequiredException(message: String?)
-    case targetRequiredException(message: String?)
-    case targetsRequiredException(message: String?)
-    case tipOfSourceReferenceIsDifferentException(message: String?)
-    case tipsDivergenceExceededException(message: String?)
-    case titleRequiredException(message: String?)
-    case tooManyTagsException(message: String?)
-}
+public struct CodeCommitErrorType: AWSErrorType {
+    enum Code: String {
+        case actorDoesNotExistException = "ActorDoesNotExistException"
+        case approvalRuleContentRequiredException = "ApprovalRuleContentRequiredException"
+        case approvalRuleDoesNotExistException = "ApprovalRuleDoesNotExistException"
+        case approvalRuleNameAlreadyExistsException = "ApprovalRuleNameAlreadyExistsException"
+        case approvalRuleNameRequiredException = "ApprovalRuleNameRequiredException"
+        case approvalRuleTemplateContentRequiredException = "ApprovalRuleTemplateContentRequiredException"
+        case approvalRuleTemplateDoesNotExistException = "ApprovalRuleTemplateDoesNotExistException"
+        case approvalRuleTemplateInUseException = "ApprovalRuleTemplateInUseException"
+        case approvalRuleTemplateNameAlreadyExistsException = "ApprovalRuleTemplateNameAlreadyExistsException"
+        case approvalRuleTemplateNameRequiredException = "ApprovalRuleTemplateNameRequiredException"
+        case approvalStateRequiredException = "ApprovalStateRequiredException"
+        case authorDoesNotExistException = "AuthorDoesNotExistException"
+        case beforeCommitIdAndAfterCommitIdAreSameException = "BeforeCommitIdAndAfterCommitIdAreSameException"
+        case blobIdDoesNotExistException = "BlobIdDoesNotExistException"
+        case blobIdRequiredException = "BlobIdRequiredException"
+        case branchDoesNotExistException = "BranchDoesNotExistException"
+        case branchNameExistsException = "BranchNameExistsException"
+        case branchNameIsTagNameException = "BranchNameIsTagNameException"
+        case branchNameRequiredException = "BranchNameRequiredException"
+        case cannotDeleteApprovalRuleFromTemplateException = "CannotDeleteApprovalRuleFromTemplateException"
+        case cannotModifyApprovalRuleFromTemplateException = "CannotModifyApprovalRuleFromTemplateException"
+        case clientRequestTokenRequiredException = "ClientRequestTokenRequiredException"
+        case commentContentRequiredException = "CommentContentRequiredException"
+        case commentContentSizeLimitExceededException = "CommentContentSizeLimitExceededException"
+        case commentDeletedException = "CommentDeletedException"
+        case commentDoesNotExistException = "CommentDoesNotExistException"
+        case commentIdRequiredException = "CommentIdRequiredException"
+        case commentNotCreatedByCallerException = "CommentNotCreatedByCallerException"
+        case commitDoesNotExistException = "CommitDoesNotExistException"
+        case commitIdDoesNotExistException = "CommitIdDoesNotExistException"
+        case commitIdRequiredException = "CommitIdRequiredException"
+        case commitIdsLimitExceededException = "CommitIdsLimitExceededException"
+        case commitIdsListRequiredException = "CommitIdsListRequiredException"
+        case commitMessageLengthExceededException = "CommitMessageLengthExceededException"
+        case commitRequiredException = "CommitRequiredException"
+        case concurrentReferenceUpdateException = "ConcurrentReferenceUpdateException"
+        case defaultBranchCannotBeDeletedException = "DefaultBranchCannotBeDeletedException"
+        case directoryNameConflictsWithFileNameException = "DirectoryNameConflictsWithFileNameException"
+        case encryptionIntegrityChecksFailedException = "EncryptionIntegrityChecksFailedException"
+        case encryptionKeyAccessDeniedException = "EncryptionKeyAccessDeniedException"
+        case encryptionKeyDisabledException = "EncryptionKeyDisabledException"
+        case encryptionKeyNotFoundException = "EncryptionKeyNotFoundException"
+        case encryptionKeyUnavailableException = "EncryptionKeyUnavailableException"
+        case fileContentAndSourceFileSpecifiedException = "FileContentAndSourceFileSpecifiedException"
+        case fileContentRequiredException = "FileContentRequiredException"
+        case fileContentSizeLimitExceededException = "FileContentSizeLimitExceededException"
+        case fileDoesNotExistException = "FileDoesNotExistException"
+        case fileEntryRequiredException = "FileEntryRequiredException"
+        case fileModeRequiredException = "FileModeRequiredException"
+        case fileNameConflictsWithDirectoryNameException = "FileNameConflictsWithDirectoryNameException"
+        case filePathConflictsWithSubmodulePathException = "FilePathConflictsWithSubmodulePathException"
+        case fileTooLargeException = "FileTooLargeException"
+        case folderContentSizeLimitExceededException = "FolderContentSizeLimitExceededException"
+        case folderDoesNotExistException = "FolderDoesNotExistException"
+        case idempotencyParameterMismatchException = "IdempotencyParameterMismatchException"
+        case invalidActorArnException = "InvalidActorArnException"
+        case invalidApprovalRuleContentException = "InvalidApprovalRuleContentException"
+        case invalidApprovalRuleNameException = "InvalidApprovalRuleNameException"
+        case invalidApprovalRuleTemplateContentException = "InvalidApprovalRuleTemplateContentException"
+        case invalidApprovalRuleTemplateDescriptionException = "InvalidApprovalRuleTemplateDescriptionException"
+        case invalidApprovalRuleTemplateNameException = "InvalidApprovalRuleTemplateNameException"
+        case invalidApprovalStateException = "InvalidApprovalStateException"
+        case invalidAuthorArnException = "InvalidAuthorArnException"
+        case invalidBlobIdException = "InvalidBlobIdException"
+        case invalidBranchNameException = "InvalidBranchNameException"
+        case invalidClientRequestTokenException = "InvalidClientRequestTokenException"
+        case invalidCommentIdException = "InvalidCommentIdException"
+        case invalidCommitException = "InvalidCommitException"
+        case invalidCommitIdException = "InvalidCommitIdException"
+        case invalidConflictDetailLevelException = "InvalidConflictDetailLevelException"
+        case invalidConflictResolutionException = "InvalidConflictResolutionException"
+        case invalidConflictResolutionStrategyException = "InvalidConflictResolutionStrategyException"
+        case invalidContinuationTokenException = "InvalidContinuationTokenException"
+        case invalidDeletionParameterException = "InvalidDeletionParameterException"
+        case invalidDescriptionException = "InvalidDescriptionException"
+        case invalidDestinationCommitSpecifierException = "InvalidDestinationCommitSpecifierException"
+        case invalidEmailException = "InvalidEmailException"
+        case invalidFileLocationException = "InvalidFileLocationException"
+        case invalidFileModeException = "InvalidFileModeException"
+        case invalidFilePositionException = "InvalidFilePositionException"
+        case invalidMaxConflictFilesException = "InvalidMaxConflictFilesException"
+        case invalidMaxMergeHunksException = "InvalidMaxMergeHunksException"
+        case invalidMaxResultsException = "InvalidMaxResultsException"
+        case invalidMergeOptionException = "InvalidMergeOptionException"
+        case invalidOrderException = "InvalidOrderException"
+        case invalidOverrideStatusException = "InvalidOverrideStatusException"
+        case invalidParentCommitIdException = "InvalidParentCommitIdException"
+        case invalidPathException = "InvalidPathException"
+        case invalidPullRequestEventTypeException = "InvalidPullRequestEventTypeException"
+        case invalidPullRequestIdException = "InvalidPullRequestIdException"
+        case invalidPullRequestStatusException = "InvalidPullRequestStatusException"
+        case invalidPullRequestStatusUpdateException = "InvalidPullRequestStatusUpdateException"
+        case invalidReactionUserArnException = "InvalidReactionUserArnException"
+        case invalidReactionValueException = "InvalidReactionValueException"
+        case invalidReferenceNameException = "InvalidReferenceNameException"
+        case invalidRelativeFileVersionEnumException = "InvalidRelativeFileVersionEnumException"
+        case invalidReplacementContentException = "InvalidReplacementContentException"
+        case invalidReplacementTypeException = "InvalidReplacementTypeException"
+        case invalidRepositoryDescriptionException = "InvalidRepositoryDescriptionException"
+        case invalidRepositoryNameException = "InvalidRepositoryNameException"
+        case invalidRepositoryTriggerBranchNameException = "InvalidRepositoryTriggerBranchNameException"
+        case invalidRepositoryTriggerCustomDataException = "InvalidRepositoryTriggerCustomDataException"
+        case invalidRepositoryTriggerDestinationArnException = "InvalidRepositoryTriggerDestinationArnException"
+        case invalidRepositoryTriggerEventsException = "InvalidRepositoryTriggerEventsException"
+        case invalidRepositoryTriggerNameException = "InvalidRepositoryTriggerNameException"
+        case invalidRepositoryTriggerRegionException = "InvalidRepositoryTriggerRegionException"
+        case invalidResourceArnException = "InvalidResourceArnException"
+        case invalidRevisionIdException = "InvalidRevisionIdException"
+        case invalidRuleContentSha256Exception = "InvalidRuleContentSha256Exception"
+        case invalidSortByException = "InvalidSortByException"
+        case invalidSourceCommitSpecifierException = "InvalidSourceCommitSpecifierException"
+        case invalidSystemTagUsageException = "InvalidSystemTagUsageException"
+        case invalidTagKeysListException = "InvalidTagKeysListException"
+        case invalidTagsMapException = "InvalidTagsMapException"
+        case invalidTargetBranchException = "InvalidTargetBranchException"
+        case invalidTargetException = "InvalidTargetException"
+        case invalidTargetsException = "InvalidTargetsException"
+        case invalidTitleException = "InvalidTitleException"
+        case manualMergeRequiredException = "ManualMergeRequiredException"
+        case maximumBranchesExceededException = "MaximumBranchesExceededException"
+        case maximumConflictResolutionEntriesExceededException = "MaximumConflictResolutionEntriesExceededException"
+        case maximumFileContentToLoadExceededException = "MaximumFileContentToLoadExceededException"
+        case maximumFileEntriesExceededException = "MaximumFileEntriesExceededException"
+        case maximumItemsToCompareExceededException = "MaximumItemsToCompareExceededException"
+        case maximumNumberOfApprovalsExceededException = "MaximumNumberOfApprovalsExceededException"
+        case maximumOpenPullRequestsExceededException = "MaximumOpenPullRequestsExceededException"
+        case maximumRepositoryNamesExceededException = "MaximumRepositoryNamesExceededException"
+        case maximumRepositoryTriggersExceededException = "MaximumRepositoryTriggersExceededException"
+        case maximumRuleTemplatesAssociatedWithRepositoryException = "MaximumRuleTemplatesAssociatedWithRepositoryException"
+        case mergeOptionRequiredException = "MergeOptionRequiredException"
+        case multipleConflictResolutionEntriesException = "MultipleConflictResolutionEntriesException"
+        case multipleRepositoriesInPullRequestException = "MultipleRepositoriesInPullRequestException"
+        case nameLengthExceededException = "NameLengthExceededException"
+        case noChangeException = "NoChangeException"
+        case numberOfRuleTemplatesExceededException = "NumberOfRuleTemplatesExceededException"
+        case numberOfRulesExceededException = "NumberOfRulesExceededException"
+        case overrideAlreadySetException = "OverrideAlreadySetException"
+        case overrideStatusRequiredException = "OverrideStatusRequiredException"
+        case parentCommitDoesNotExistException = "ParentCommitDoesNotExistException"
+        case parentCommitIdOutdatedException = "ParentCommitIdOutdatedException"
+        case parentCommitIdRequiredException = "ParentCommitIdRequiredException"
+        case pathDoesNotExistException = "PathDoesNotExistException"
+        case pathRequiredException = "PathRequiredException"
+        case pullRequestAlreadyClosedException = "PullRequestAlreadyClosedException"
+        case pullRequestApprovalRulesNotSatisfiedException = "PullRequestApprovalRulesNotSatisfiedException"
+        case pullRequestCannotBeApprovedByAuthorException = "PullRequestCannotBeApprovedByAuthorException"
+        case pullRequestDoesNotExistException = "PullRequestDoesNotExistException"
+        case pullRequestIdRequiredException = "PullRequestIdRequiredException"
+        case pullRequestStatusRequiredException = "PullRequestStatusRequiredException"
+        case putFileEntryConflictException = "PutFileEntryConflictException"
+        case reactionLimitExceededException = "ReactionLimitExceededException"
+        case reactionValueRequiredException = "ReactionValueRequiredException"
+        case referenceDoesNotExistException = "ReferenceDoesNotExistException"
+        case referenceNameRequiredException = "ReferenceNameRequiredException"
+        case referenceTypeNotSupportedException = "ReferenceTypeNotSupportedException"
+        case replacementContentRequiredException = "ReplacementContentRequiredException"
+        case replacementTypeRequiredException = "ReplacementTypeRequiredException"
+        case repositoryDoesNotExistException = "RepositoryDoesNotExistException"
+        case repositoryLimitExceededException = "RepositoryLimitExceededException"
+        case repositoryNameExistsException = "RepositoryNameExistsException"
+        case repositoryNameRequiredException = "RepositoryNameRequiredException"
+        case repositoryNamesRequiredException = "RepositoryNamesRequiredException"
+        case repositoryNotAssociatedWithPullRequestException = "RepositoryNotAssociatedWithPullRequestException"
+        case repositoryTriggerBranchNameListRequiredException = "RepositoryTriggerBranchNameListRequiredException"
+        case repositoryTriggerDestinationArnRequiredException = "RepositoryTriggerDestinationArnRequiredException"
+        case repositoryTriggerEventsListRequiredException = "RepositoryTriggerEventsListRequiredException"
+        case repositoryTriggerNameRequiredException = "RepositoryTriggerNameRequiredException"
+        case repositoryTriggersListRequiredException = "RepositoryTriggersListRequiredException"
+        case resourceArnRequiredException = "ResourceArnRequiredException"
+        case restrictedSourceFileException = "RestrictedSourceFileException"
+        case revisionIdRequiredException = "RevisionIdRequiredException"
+        case revisionNotCurrentException = "RevisionNotCurrentException"
+        case sameFileContentException = "SameFileContentException"
+        case samePathRequestException = "SamePathRequestException"
+        case sourceAndDestinationAreSameException = "SourceAndDestinationAreSameException"
+        case sourceFileOrContentRequiredException = "SourceFileOrContentRequiredException"
+        case tagKeysListRequiredException = "TagKeysListRequiredException"
+        case tagPolicyException = "TagPolicyException"
+        case tagsMapRequiredException = "TagsMapRequiredException"
+        case targetRequiredException = "TargetRequiredException"
+        case targetsRequiredException = "TargetsRequiredException"
+        case tipOfSourceReferenceIsDifferentException = "TipOfSourceReferenceIsDifferentException"
+        case tipsDivergenceExceededException = "TipsDivergenceExceededException"
+        case titleRequiredException = "TitleRequiredException"
+        case tooManyTagsException = "TooManyTagsException"
+    }
 
-extension CodeCommitErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ActorDoesNotExistException":
-            self = .actorDoesNotExistException(message: message)
-        case "ApprovalRuleContentRequiredException":
-            self = .approvalRuleContentRequiredException(message: message)
-        case "ApprovalRuleDoesNotExistException":
-            self = .approvalRuleDoesNotExistException(message: message)
-        case "ApprovalRuleNameAlreadyExistsException":
-            self = .approvalRuleNameAlreadyExistsException(message: message)
-        case "ApprovalRuleNameRequiredException":
-            self = .approvalRuleNameRequiredException(message: message)
-        case "ApprovalRuleTemplateContentRequiredException":
-            self = .approvalRuleTemplateContentRequiredException(message: message)
-        case "ApprovalRuleTemplateDoesNotExistException":
-            self = .approvalRuleTemplateDoesNotExistException(message: message)
-        case "ApprovalRuleTemplateInUseException":
-            self = .approvalRuleTemplateInUseException(message: message)
-        case "ApprovalRuleTemplateNameAlreadyExistsException":
-            self = .approvalRuleTemplateNameAlreadyExistsException(message: message)
-        case "ApprovalRuleTemplateNameRequiredException":
-            self = .approvalRuleTemplateNameRequiredException(message: message)
-        case "ApprovalStateRequiredException":
-            self = .approvalStateRequiredException(message: message)
-        case "AuthorDoesNotExistException":
-            self = .authorDoesNotExistException(message: message)
-        case "BeforeCommitIdAndAfterCommitIdAreSameException":
-            self = .beforeCommitIdAndAfterCommitIdAreSameException(message: message)
-        case "BlobIdDoesNotExistException":
-            self = .blobIdDoesNotExistException(message: message)
-        case "BlobIdRequiredException":
-            self = .blobIdRequiredException(message: message)
-        case "BranchDoesNotExistException":
-            self = .branchDoesNotExistException(message: message)
-        case "BranchNameExistsException":
-            self = .branchNameExistsException(message: message)
-        case "BranchNameIsTagNameException":
-            self = .branchNameIsTagNameException(message: message)
-        case "BranchNameRequiredException":
-            self = .branchNameRequiredException(message: message)
-        case "CannotDeleteApprovalRuleFromTemplateException":
-            self = .cannotDeleteApprovalRuleFromTemplateException(message: message)
-        case "CannotModifyApprovalRuleFromTemplateException":
-            self = .cannotModifyApprovalRuleFromTemplateException(message: message)
-        case "ClientRequestTokenRequiredException":
-            self = .clientRequestTokenRequiredException(message: message)
-        case "CommentContentRequiredException":
-            self = .commentContentRequiredException(message: message)
-        case "CommentContentSizeLimitExceededException":
-            self = .commentContentSizeLimitExceededException(message: message)
-        case "CommentDeletedException":
-            self = .commentDeletedException(message: message)
-        case "CommentDoesNotExistException":
-            self = .commentDoesNotExistException(message: message)
-        case "CommentIdRequiredException":
-            self = .commentIdRequiredException(message: message)
-        case "CommentNotCreatedByCallerException":
-            self = .commentNotCreatedByCallerException(message: message)
-        case "CommitDoesNotExistException":
-            self = .commitDoesNotExistException(message: message)
-        case "CommitIdDoesNotExistException":
-            self = .commitIdDoesNotExistException(message: message)
-        case "CommitIdRequiredException":
-            self = .commitIdRequiredException(message: message)
-        case "CommitIdsLimitExceededException":
-            self = .commitIdsLimitExceededException(message: message)
-        case "CommitIdsListRequiredException":
-            self = .commitIdsListRequiredException(message: message)
-        case "CommitMessageLengthExceededException":
-            self = .commitMessageLengthExceededException(message: message)
-        case "CommitRequiredException":
-            self = .commitRequiredException(message: message)
-        case "ConcurrentReferenceUpdateException":
-            self = .concurrentReferenceUpdateException(message: message)
-        case "DefaultBranchCannotBeDeletedException":
-            self = .defaultBranchCannotBeDeletedException(message: message)
-        case "DirectoryNameConflictsWithFileNameException":
-            self = .directoryNameConflictsWithFileNameException(message: message)
-        case "EncryptionIntegrityChecksFailedException":
-            self = .encryptionIntegrityChecksFailedException(message: message)
-        case "EncryptionKeyAccessDeniedException":
-            self = .encryptionKeyAccessDeniedException(message: message)
-        case "EncryptionKeyDisabledException":
-            self = .encryptionKeyDisabledException(message: message)
-        case "EncryptionKeyNotFoundException":
-            self = .encryptionKeyNotFoundException(message: message)
-        case "EncryptionKeyUnavailableException":
-            self = .encryptionKeyUnavailableException(message: message)
-        case "FileContentAndSourceFileSpecifiedException":
-            self = .fileContentAndSourceFileSpecifiedException(message: message)
-        case "FileContentRequiredException":
-            self = .fileContentRequiredException(message: message)
-        case "FileContentSizeLimitExceededException":
-            self = .fileContentSizeLimitExceededException(message: message)
-        case "FileDoesNotExistException":
-            self = .fileDoesNotExistException(message: message)
-        case "FileEntryRequiredException":
-            self = .fileEntryRequiredException(message: message)
-        case "FileModeRequiredException":
-            self = .fileModeRequiredException(message: message)
-        case "FileNameConflictsWithDirectoryNameException":
-            self = .fileNameConflictsWithDirectoryNameException(message: message)
-        case "FilePathConflictsWithSubmodulePathException":
-            self = .filePathConflictsWithSubmodulePathException(message: message)
-        case "FileTooLargeException":
-            self = .fileTooLargeException(message: message)
-        case "FolderContentSizeLimitExceededException":
-            self = .folderContentSizeLimitExceededException(message: message)
-        case "FolderDoesNotExistException":
-            self = .folderDoesNotExistException(message: message)
-        case "IdempotencyParameterMismatchException":
-            self = .idempotencyParameterMismatchException(message: message)
-        case "InvalidActorArnException":
-            self = .invalidActorArnException(message: message)
-        case "InvalidApprovalRuleContentException":
-            self = .invalidApprovalRuleContentException(message: message)
-        case "InvalidApprovalRuleNameException":
-            self = .invalidApprovalRuleNameException(message: message)
-        case "InvalidApprovalRuleTemplateContentException":
-            self = .invalidApprovalRuleTemplateContentException(message: message)
-        case "InvalidApprovalRuleTemplateDescriptionException":
-            self = .invalidApprovalRuleTemplateDescriptionException(message: message)
-        case "InvalidApprovalRuleTemplateNameException":
-            self = .invalidApprovalRuleTemplateNameException(message: message)
-        case "InvalidApprovalStateException":
-            self = .invalidApprovalStateException(message: message)
-        case "InvalidAuthorArnException":
-            self = .invalidAuthorArnException(message: message)
-        case "InvalidBlobIdException":
-            self = .invalidBlobIdException(message: message)
-        case "InvalidBranchNameException":
-            self = .invalidBranchNameException(message: message)
-        case "InvalidClientRequestTokenException":
-            self = .invalidClientRequestTokenException(message: message)
-        case "InvalidCommentIdException":
-            self = .invalidCommentIdException(message: message)
-        case "InvalidCommitException":
-            self = .invalidCommitException(message: message)
-        case "InvalidCommitIdException":
-            self = .invalidCommitIdException(message: message)
-        case "InvalidConflictDetailLevelException":
-            self = .invalidConflictDetailLevelException(message: message)
-        case "InvalidConflictResolutionException":
-            self = .invalidConflictResolutionException(message: message)
-        case "InvalidConflictResolutionStrategyException":
-            self = .invalidConflictResolutionStrategyException(message: message)
-        case "InvalidContinuationTokenException":
-            self = .invalidContinuationTokenException(message: message)
-        case "InvalidDeletionParameterException":
-            self = .invalidDeletionParameterException(message: message)
-        case "InvalidDescriptionException":
-            self = .invalidDescriptionException(message: message)
-        case "InvalidDestinationCommitSpecifierException":
-            self = .invalidDestinationCommitSpecifierException(message: message)
-        case "InvalidEmailException":
-            self = .invalidEmailException(message: message)
-        case "InvalidFileLocationException":
-            self = .invalidFileLocationException(message: message)
-        case "InvalidFileModeException":
-            self = .invalidFileModeException(message: message)
-        case "InvalidFilePositionException":
-            self = .invalidFilePositionException(message: message)
-        case "InvalidMaxConflictFilesException":
-            self = .invalidMaxConflictFilesException(message: message)
-        case "InvalidMaxMergeHunksException":
-            self = .invalidMaxMergeHunksException(message: message)
-        case "InvalidMaxResultsException":
-            self = .invalidMaxResultsException(message: message)
-        case "InvalidMergeOptionException":
-            self = .invalidMergeOptionException(message: message)
-        case "InvalidOrderException":
-            self = .invalidOrderException(message: message)
-        case "InvalidOverrideStatusException":
-            self = .invalidOverrideStatusException(message: message)
-        case "InvalidParentCommitIdException":
-            self = .invalidParentCommitIdException(message: message)
-        case "InvalidPathException":
-            self = .invalidPathException(message: message)
-        case "InvalidPullRequestEventTypeException":
-            self = .invalidPullRequestEventTypeException(message: message)
-        case "InvalidPullRequestIdException":
-            self = .invalidPullRequestIdException(message: message)
-        case "InvalidPullRequestStatusException":
-            self = .invalidPullRequestStatusException(message: message)
-        case "InvalidPullRequestStatusUpdateException":
-            self = .invalidPullRequestStatusUpdateException(message: message)
-        case "InvalidReactionUserArnException":
-            self = .invalidReactionUserArnException(message: message)
-        case "InvalidReactionValueException":
-            self = .invalidReactionValueException(message: message)
-        case "InvalidReferenceNameException":
-            self = .invalidReferenceNameException(message: message)
-        case "InvalidRelativeFileVersionEnumException":
-            self = .invalidRelativeFileVersionEnumException(message: message)
-        case "InvalidReplacementContentException":
-            self = .invalidReplacementContentException(message: message)
-        case "InvalidReplacementTypeException":
-            self = .invalidReplacementTypeException(message: message)
-        case "InvalidRepositoryDescriptionException":
-            self = .invalidRepositoryDescriptionException(message: message)
-        case "InvalidRepositoryNameException":
-            self = .invalidRepositoryNameException(message: message)
-        case "InvalidRepositoryTriggerBranchNameException":
-            self = .invalidRepositoryTriggerBranchNameException(message: message)
-        case "InvalidRepositoryTriggerCustomDataException":
-            self = .invalidRepositoryTriggerCustomDataException(message: message)
-        case "InvalidRepositoryTriggerDestinationArnException":
-            self = .invalidRepositoryTriggerDestinationArnException(message: message)
-        case "InvalidRepositoryTriggerEventsException":
-            self = .invalidRepositoryTriggerEventsException(message: message)
-        case "InvalidRepositoryTriggerNameException":
-            self = .invalidRepositoryTriggerNameException(message: message)
-        case "InvalidRepositoryTriggerRegionException":
-            self = .invalidRepositoryTriggerRegionException(message: message)
-        case "InvalidResourceArnException":
-            self = .invalidResourceArnException(message: message)
-        case "InvalidRevisionIdException":
-            self = .invalidRevisionIdException(message: message)
-        case "InvalidRuleContentSha256Exception":
-            self = .invalidRuleContentSha256Exception(message: message)
-        case "InvalidSortByException":
-            self = .invalidSortByException(message: message)
-        case "InvalidSourceCommitSpecifierException":
-            self = .invalidSourceCommitSpecifierException(message: message)
-        case "InvalidSystemTagUsageException":
-            self = .invalidSystemTagUsageException(message: message)
-        case "InvalidTagKeysListException":
-            self = .invalidTagKeysListException(message: message)
-        case "InvalidTagsMapException":
-            self = .invalidTagsMapException(message: message)
-        case "InvalidTargetBranchException":
-            self = .invalidTargetBranchException(message: message)
-        case "InvalidTargetException":
-            self = .invalidTargetException(message: message)
-        case "InvalidTargetsException":
-            self = .invalidTargetsException(message: message)
-        case "InvalidTitleException":
-            self = .invalidTitleException(message: message)
-        case "ManualMergeRequiredException":
-            self = .manualMergeRequiredException(message: message)
-        case "MaximumBranchesExceededException":
-            self = .maximumBranchesExceededException(message: message)
-        case "MaximumConflictResolutionEntriesExceededException":
-            self = .maximumConflictResolutionEntriesExceededException(message: message)
-        case "MaximumFileContentToLoadExceededException":
-            self = .maximumFileContentToLoadExceededException(message: message)
-        case "MaximumFileEntriesExceededException":
-            self = .maximumFileEntriesExceededException(message: message)
-        case "MaximumItemsToCompareExceededException":
-            self = .maximumItemsToCompareExceededException(message: message)
-        case "MaximumNumberOfApprovalsExceededException":
-            self = .maximumNumberOfApprovalsExceededException(message: message)
-        case "MaximumOpenPullRequestsExceededException":
-            self = .maximumOpenPullRequestsExceededException(message: message)
-        case "MaximumRepositoryNamesExceededException":
-            self = .maximumRepositoryNamesExceededException(message: message)
-        case "MaximumRepositoryTriggersExceededException":
-            self = .maximumRepositoryTriggersExceededException(message: message)
-        case "MaximumRuleTemplatesAssociatedWithRepositoryException":
-            self = .maximumRuleTemplatesAssociatedWithRepositoryException(message: message)
-        case "MergeOptionRequiredException":
-            self = .mergeOptionRequiredException(message: message)
-        case "MultipleConflictResolutionEntriesException":
-            self = .multipleConflictResolutionEntriesException(message: message)
-        case "MultipleRepositoriesInPullRequestException":
-            self = .multipleRepositoriesInPullRequestException(message: message)
-        case "NameLengthExceededException":
-            self = .nameLengthExceededException(message: message)
-        case "NoChangeException":
-            self = .noChangeException(message: message)
-        case "NumberOfRuleTemplatesExceededException":
-            self = .numberOfRuleTemplatesExceededException(message: message)
-        case "NumberOfRulesExceededException":
-            self = .numberOfRulesExceededException(message: message)
-        case "OverrideAlreadySetException":
-            self = .overrideAlreadySetException(message: message)
-        case "OverrideStatusRequiredException":
-            self = .overrideStatusRequiredException(message: message)
-        case "ParentCommitDoesNotExistException":
-            self = .parentCommitDoesNotExistException(message: message)
-        case "ParentCommitIdOutdatedException":
-            self = .parentCommitIdOutdatedException(message: message)
-        case "ParentCommitIdRequiredException":
-            self = .parentCommitIdRequiredException(message: message)
-        case "PathDoesNotExistException":
-            self = .pathDoesNotExistException(message: message)
-        case "PathRequiredException":
-            self = .pathRequiredException(message: message)
-        case "PullRequestAlreadyClosedException":
-            self = .pullRequestAlreadyClosedException(message: message)
-        case "PullRequestApprovalRulesNotSatisfiedException":
-            self = .pullRequestApprovalRulesNotSatisfiedException(message: message)
-        case "PullRequestCannotBeApprovedByAuthorException":
-            self = .pullRequestCannotBeApprovedByAuthorException(message: message)
-        case "PullRequestDoesNotExistException":
-            self = .pullRequestDoesNotExistException(message: message)
-        case "PullRequestIdRequiredException":
-            self = .pullRequestIdRequiredException(message: message)
-        case "PullRequestStatusRequiredException":
-            self = .pullRequestStatusRequiredException(message: message)
-        case "PutFileEntryConflictException":
-            self = .putFileEntryConflictException(message: message)
-        case "ReactionLimitExceededException":
-            self = .reactionLimitExceededException(message: message)
-        case "ReactionValueRequiredException":
-            self = .reactionValueRequiredException(message: message)
-        case "ReferenceDoesNotExistException":
-            self = .referenceDoesNotExistException(message: message)
-        case "ReferenceNameRequiredException":
-            self = .referenceNameRequiredException(message: message)
-        case "ReferenceTypeNotSupportedException":
-            self = .referenceTypeNotSupportedException(message: message)
-        case "ReplacementContentRequiredException":
-            self = .replacementContentRequiredException(message: message)
-        case "ReplacementTypeRequiredException":
-            self = .replacementTypeRequiredException(message: message)
-        case "RepositoryDoesNotExistException":
-            self = .repositoryDoesNotExistException(message: message)
-        case "RepositoryLimitExceededException":
-            self = .repositoryLimitExceededException(message: message)
-        case "RepositoryNameExistsException":
-            self = .repositoryNameExistsException(message: message)
-        case "RepositoryNameRequiredException":
-            self = .repositoryNameRequiredException(message: message)
-        case "RepositoryNamesRequiredException":
-            self = .repositoryNamesRequiredException(message: message)
-        case "RepositoryNotAssociatedWithPullRequestException":
-            self = .repositoryNotAssociatedWithPullRequestException(message: message)
-        case "RepositoryTriggerBranchNameListRequiredException":
-            self = .repositoryTriggerBranchNameListRequiredException(message: message)
-        case "RepositoryTriggerDestinationArnRequiredException":
-            self = .repositoryTriggerDestinationArnRequiredException(message: message)
-        case "RepositoryTriggerEventsListRequiredException":
-            self = .repositoryTriggerEventsListRequiredException(message: message)
-        case "RepositoryTriggerNameRequiredException":
-            self = .repositoryTriggerNameRequiredException(message: message)
-        case "RepositoryTriggersListRequiredException":
-            self = .repositoryTriggersListRequiredException(message: message)
-        case "ResourceArnRequiredException":
-            self = .resourceArnRequiredException(message: message)
-        case "RestrictedSourceFileException":
-            self = .restrictedSourceFileException(message: message)
-        case "RevisionIdRequiredException":
-            self = .revisionIdRequiredException(message: message)
-        case "RevisionNotCurrentException":
-            self = .revisionNotCurrentException(message: message)
-        case "SameFileContentException":
-            self = .sameFileContentException(message: message)
-        case "SamePathRequestException":
-            self = .samePathRequestException(message: message)
-        case "SourceAndDestinationAreSameException":
-            self = .sourceAndDestinationAreSameException(message: message)
-        case "SourceFileOrContentRequiredException":
-            self = .sourceFileOrContentRequiredException(message: message)
-        case "TagKeysListRequiredException":
-            self = .tagKeysListRequiredException(message: message)
-        case "TagPolicyException":
-            self = .tagPolicyException(message: message)
-        case "TagsMapRequiredException":
-            self = .tagsMapRequiredException(message: message)
-        case "TargetRequiredException":
-            self = .targetRequiredException(message: message)
-        case "TargetsRequiredException":
-            self = .targetsRequiredException(message: message)
-        case "TipOfSourceReferenceIsDifferentException":
-            self = .tipOfSourceReferenceIsDifferentException(message: message)
-        case "TipsDivergenceExceededException":
-            self = .tipsDivergenceExceededException(message: message)
-        case "TitleRequiredException":
-            self = .titleRequiredException(message: message)
-        case "TooManyTagsException":
-            self = .tooManyTagsException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var actorDoesNotExistException: Self { .init(.actorDoesNotExistException) }
+    public static var approvalRuleContentRequiredException: Self { .init(.approvalRuleContentRequiredException) }
+    public static var approvalRuleDoesNotExistException: Self { .init(.approvalRuleDoesNotExistException) }
+    public static var approvalRuleNameAlreadyExistsException: Self { .init(.approvalRuleNameAlreadyExistsException) }
+    public static var approvalRuleNameRequiredException: Self { .init(.approvalRuleNameRequiredException) }
+    public static var approvalRuleTemplateContentRequiredException: Self { .init(.approvalRuleTemplateContentRequiredException) }
+    public static var approvalRuleTemplateDoesNotExistException: Self { .init(.approvalRuleTemplateDoesNotExistException) }
+    public static var approvalRuleTemplateInUseException: Self { .init(.approvalRuleTemplateInUseException) }
+    public static var approvalRuleTemplateNameAlreadyExistsException: Self { .init(.approvalRuleTemplateNameAlreadyExistsException) }
+    public static var approvalRuleTemplateNameRequiredException: Self { .init(.approvalRuleTemplateNameRequiredException) }
+    public static var approvalStateRequiredException: Self { .init(.approvalStateRequiredException) }
+    public static var authorDoesNotExistException: Self { .init(.authorDoesNotExistException) }
+    public static var beforeCommitIdAndAfterCommitIdAreSameException: Self { .init(.beforeCommitIdAndAfterCommitIdAreSameException) }
+    public static var blobIdDoesNotExistException: Self { .init(.blobIdDoesNotExistException) }
+    public static var blobIdRequiredException: Self { .init(.blobIdRequiredException) }
+    public static var branchDoesNotExistException: Self { .init(.branchDoesNotExistException) }
+    public static var branchNameExistsException: Self { .init(.branchNameExistsException) }
+    public static var branchNameIsTagNameException: Self { .init(.branchNameIsTagNameException) }
+    public static var branchNameRequiredException: Self { .init(.branchNameRequiredException) }
+    public static var cannotDeleteApprovalRuleFromTemplateException: Self { .init(.cannotDeleteApprovalRuleFromTemplateException) }
+    public static var cannotModifyApprovalRuleFromTemplateException: Self { .init(.cannotModifyApprovalRuleFromTemplateException) }
+    public static var clientRequestTokenRequiredException: Self { .init(.clientRequestTokenRequiredException) }
+    public static var commentContentRequiredException: Self { .init(.commentContentRequiredException) }
+    public static var commentContentSizeLimitExceededException: Self { .init(.commentContentSizeLimitExceededException) }
+    public static var commentDeletedException: Self { .init(.commentDeletedException) }
+    public static var commentDoesNotExistException: Self { .init(.commentDoesNotExistException) }
+    public static var commentIdRequiredException: Self { .init(.commentIdRequiredException) }
+    public static var commentNotCreatedByCallerException: Self { .init(.commentNotCreatedByCallerException) }
+    public static var commitDoesNotExistException: Self { .init(.commitDoesNotExistException) }
+    public static var commitIdDoesNotExistException: Self { .init(.commitIdDoesNotExistException) }
+    public static var commitIdRequiredException: Self { .init(.commitIdRequiredException) }
+    public static var commitIdsLimitExceededException: Self { .init(.commitIdsLimitExceededException) }
+    public static var commitIdsListRequiredException: Self { .init(.commitIdsListRequiredException) }
+    public static var commitMessageLengthExceededException: Self { .init(.commitMessageLengthExceededException) }
+    public static var commitRequiredException: Self { .init(.commitRequiredException) }
+    public static var concurrentReferenceUpdateException: Self { .init(.concurrentReferenceUpdateException) }
+    public static var defaultBranchCannotBeDeletedException: Self { .init(.defaultBranchCannotBeDeletedException) }
+    public static var directoryNameConflictsWithFileNameException: Self { .init(.directoryNameConflictsWithFileNameException) }
+    public static var encryptionIntegrityChecksFailedException: Self { .init(.encryptionIntegrityChecksFailedException) }
+    public static var encryptionKeyAccessDeniedException: Self { .init(.encryptionKeyAccessDeniedException) }
+    public static var encryptionKeyDisabledException: Self { .init(.encryptionKeyDisabledException) }
+    public static var encryptionKeyNotFoundException: Self { .init(.encryptionKeyNotFoundException) }
+    public static var encryptionKeyUnavailableException: Self { .init(.encryptionKeyUnavailableException) }
+    public static var fileContentAndSourceFileSpecifiedException: Self { .init(.fileContentAndSourceFileSpecifiedException) }
+    public static var fileContentRequiredException: Self { .init(.fileContentRequiredException) }
+    public static var fileContentSizeLimitExceededException: Self { .init(.fileContentSizeLimitExceededException) }
+    public static var fileDoesNotExistException: Self { .init(.fileDoesNotExistException) }
+    public static var fileEntryRequiredException: Self { .init(.fileEntryRequiredException) }
+    public static var fileModeRequiredException: Self { .init(.fileModeRequiredException) }
+    public static var fileNameConflictsWithDirectoryNameException: Self { .init(.fileNameConflictsWithDirectoryNameException) }
+    public static var filePathConflictsWithSubmodulePathException: Self { .init(.filePathConflictsWithSubmodulePathException) }
+    public static var fileTooLargeException: Self { .init(.fileTooLargeException) }
+    public static var folderContentSizeLimitExceededException: Self { .init(.folderContentSizeLimitExceededException) }
+    public static var folderDoesNotExistException: Self { .init(.folderDoesNotExistException) }
+    public static var idempotencyParameterMismatchException: Self { .init(.idempotencyParameterMismatchException) }
+    public static var invalidActorArnException: Self { .init(.invalidActorArnException) }
+    public static var invalidApprovalRuleContentException: Self { .init(.invalidApprovalRuleContentException) }
+    public static var invalidApprovalRuleNameException: Self { .init(.invalidApprovalRuleNameException) }
+    public static var invalidApprovalRuleTemplateContentException: Self { .init(.invalidApprovalRuleTemplateContentException) }
+    public static var invalidApprovalRuleTemplateDescriptionException: Self { .init(.invalidApprovalRuleTemplateDescriptionException) }
+    public static var invalidApprovalRuleTemplateNameException: Self { .init(.invalidApprovalRuleTemplateNameException) }
+    public static var invalidApprovalStateException: Self { .init(.invalidApprovalStateException) }
+    public static var invalidAuthorArnException: Self { .init(.invalidAuthorArnException) }
+    public static var invalidBlobIdException: Self { .init(.invalidBlobIdException) }
+    public static var invalidBranchNameException: Self { .init(.invalidBranchNameException) }
+    public static var invalidClientRequestTokenException: Self { .init(.invalidClientRequestTokenException) }
+    public static var invalidCommentIdException: Self { .init(.invalidCommentIdException) }
+    public static var invalidCommitException: Self { .init(.invalidCommitException) }
+    public static var invalidCommitIdException: Self { .init(.invalidCommitIdException) }
+    public static var invalidConflictDetailLevelException: Self { .init(.invalidConflictDetailLevelException) }
+    public static var invalidConflictResolutionException: Self { .init(.invalidConflictResolutionException) }
+    public static var invalidConflictResolutionStrategyException: Self { .init(.invalidConflictResolutionStrategyException) }
+    public static var invalidContinuationTokenException: Self { .init(.invalidContinuationTokenException) }
+    public static var invalidDeletionParameterException: Self { .init(.invalidDeletionParameterException) }
+    public static var invalidDescriptionException: Self { .init(.invalidDescriptionException) }
+    public static var invalidDestinationCommitSpecifierException: Self { .init(.invalidDestinationCommitSpecifierException) }
+    public static var invalidEmailException: Self { .init(.invalidEmailException) }
+    public static var invalidFileLocationException: Self { .init(.invalidFileLocationException) }
+    public static var invalidFileModeException: Self { .init(.invalidFileModeException) }
+    public static var invalidFilePositionException: Self { .init(.invalidFilePositionException) }
+    public static var invalidMaxConflictFilesException: Self { .init(.invalidMaxConflictFilesException) }
+    public static var invalidMaxMergeHunksException: Self { .init(.invalidMaxMergeHunksException) }
+    public static var invalidMaxResultsException: Self { .init(.invalidMaxResultsException) }
+    public static var invalidMergeOptionException: Self { .init(.invalidMergeOptionException) }
+    public static var invalidOrderException: Self { .init(.invalidOrderException) }
+    public static var invalidOverrideStatusException: Self { .init(.invalidOverrideStatusException) }
+    public static var invalidParentCommitIdException: Self { .init(.invalidParentCommitIdException) }
+    public static var invalidPathException: Self { .init(.invalidPathException) }
+    public static var invalidPullRequestEventTypeException: Self { .init(.invalidPullRequestEventTypeException) }
+    public static var invalidPullRequestIdException: Self { .init(.invalidPullRequestIdException) }
+    public static var invalidPullRequestStatusException: Self { .init(.invalidPullRequestStatusException) }
+    public static var invalidPullRequestStatusUpdateException: Self { .init(.invalidPullRequestStatusUpdateException) }
+    public static var invalidReactionUserArnException: Self { .init(.invalidReactionUserArnException) }
+    public static var invalidReactionValueException: Self { .init(.invalidReactionValueException) }
+    public static var invalidReferenceNameException: Self { .init(.invalidReferenceNameException) }
+    public static var invalidRelativeFileVersionEnumException: Self { .init(.invalidRelativeFileVersionEnumException) }
+    public static var invalidReplacementContentException: Self { .init(.invalidReplacementContentException) }
+    public static var invalidReplacementTypeException: Self { .init(.invalidReplacementTypeException) }
+    public static var invalidRepositoryDescriptionException: Self { .init(.invalidRepositoryDescriptionException) }
+    public static var invalidRepositoryNameException: Self { .init(.invalidRepositoryNameException) }
+    public static var invalidRepositoryTriggerBranchNameException: Self { .init(.invalidRepositoryTriggerBranchNameException) }
+    public static var invalidRepositoryTriggerCustomDataException: Self { .init(.invalidRepositoryTriggerCustomDataException) }
+    public static var invalidRepositoryTriggerDestinationArnException: Self { .init(.invalidRepositoryTriggerDestinationArnException) }
+    public static var invalidRepositoryTriggerEventsException: Self { .init(.invalidRepositoryTriggerEventsException) }
+    public static var invalidRepositoryTriggerNameException: Self { .init(.invalidRepositoryTriggerNameException) }
+    public static var invalidRepositoryTriggerRegionException: Self { .init(.invalidRepositoryTriggerRegionException) }
+    public static var invalidResourceArnException: Self { .init(.invalidResourceArnException) }
+    public static var invalidRevisionIdException: Self { .init(.invalidRevisionIdException) }
+    public static var invalidRuleContentSha256Exception: Self { .init(.invalidRuleContentSha256Exception) }
+    public static var invalidSortByException: Self { .init(.invalidSortByException) }
+    public static var invalidSourceCommitSpecifierException: Self { .init(.invalidSourceCommitSpecifierException) }
+    public static var invalidSystemTagUsageException: Self { .init(.invalidSystemTagUsageException) }
+    public static var invalidTagKeysListException: Self { .init(.invalidTagKeysListException) }
+    public static var invalidTagsMapException: Self { .init(.invalidTagsMapException) }
+    public static var invalidTargetBranchException: Self { .init(.invalidTargetBranchException) }
+    public static var invalidTargetException: Self { .init(.invalidTargetException) }
+    public static var invalidTargetsException: Self { .init(.invalidTargetsException) }
+    public static var invalidTitleException: Self { .init(.invalidTitleException) }
+    public static var manualMergeRequiredException: Self { .init(.manualMergeRequiredException) }
+    public static var maximumBranchesExceededException: Self { .init(.maximumBranchesExceededException) }
+    public static var maximumConflictResolutionEntriesExceededException: Self { .init(.maximumConflictResolutionEntriesExceededException) }
+    public static var maximumFileContentToLoadExceededException: Self { .init(.maximumFileContentToLoadExceededException) }
+    public static var maximumFileEntriesExceededException: Self { .init(.maximumFileEntriesExceededException) }
+    public static var maximumItemsToCompareExceededException: Self { .init(.maximumItemsToCompareExceededException) }
+    public static var maximumNumberOfApprovalsExceededException: Self { .init(.maximumNumberOfApprovalsExceededException) }
+    public static var maximumOpenPullRequestsExceededException: Self { .init(.maximumOpenPullRequestsExceededException) }
+    public static var maximumRepositoryNamesExceededException: Self { .init(.maximumRepositoryNamesExceededException) }
+    public static var maximumRepositoryTriggersExceededException: Self { .init(.maximumRepositoryTriggersExceededException) }
+    public static var maximumRuleTemplatesAssociatedWithRepositoryException: Self { .init(.maximumRuleTemplatesAssociatedWithRepositoryException) }
+    public static var mergeOptionRequiredException: Self { .init(.mergeOptionRequiredException) }
+    public static var multipleConflictResolutionEntriesException: Self { .init(.multipleConflictResolutionEntriesException) }
+    public static var multipleRepositoriesInPullRequestException: Self { .init(.multipleRepositoriesInPullRequestException) }
+    public static var nameLengthExceededException: Self { .init(.nameLengthExceededException) }
+    public static var noChangeException: Self { .init(.noChangeException) }
+    public static var numberOfRuleTemplatesExceededException: Self { .init(.numberOfRuleTemplatesExceededException) }
+    public static var numberOfRulesExceededException: Self { .init(.numberOfRulesExceededException) }
+    public static var overrideAlreadySetException: Self { .init(.overrideAlreadySetException) }
+    public static var overrideStatusRequiredException: Self { .init(.overrideStatusRequiredException) }
+    public static var parentCommitDoesNotExistException: Self { .init(.parentCommitDoesNotExistException) }
+    public static var parentCommitIdOutdatedException: Self { .init(.parentCommitIdOutdatedException) }
+    public static var parentCommitIdRequiredException: Self { .init(.parentCommitIdRequiredException) }
+    public static var pathDoesNotExistException: Self { .init(.pathDoesNotExistException) }
+    public static var pathRequiredException: Self { .init(.pathRequiredException) }
+    public static var pullRequestAlreadyClosedException: Self { .init(.pullRequestAlreadyClosedException) }
+    public static var pullRequestApprovalRulesNotSatisfiedException: Self { .init(.pullRequestApprovalRulesNotSatisfiedException) }
+    public static var pullRequestCannotBeApprovedByAuthorException: Self { .init(.pullRequestCannotBeApprovedByAuthorException) }
+    public static var pullRequestDoesNotExistException: Self { .init(.pullRequestDoesNotExistException) }
+    public static var pullRequestIdRequiredException: Self { .init(.pullRequestIdRequiredException) }
+    public static var pullRequestStatusRequiredException: Self { .init(.pullRequestStatusRequiredException) }
+    public static var putFileEntryConflictException: Self { .init(.putFileEntryConflictException) }
+    public static var reactionLimitExceededException: Self { .init(.reactionLimitExceededException) }
+    public static var reactionValueRequiredException: Self { .init(.reactionValueRequiredException) }
+    public static var referenceDoesNotExistException: Self { .init(.referenceDoesNotExistException) }
+    public static var referenceNameRequiredException: Self { .init(.referenceNameRequiredException) }
+    public static var referenceTypeNotSupportedException: Self { .init(.referenceTypeNotSupportedException) }
+    public static var replacementContentRequiredException: Self { .init(.replacementContentRequiredException) }
+    public static var replacementTypeRequiredException: Self { .init(.replacementTypeRequiredException) }
+    public static var repositoryDoesNotExistException: Self { .init(.repositoryDoesNotExistException) }
+    public static var repositoryLimitExceededException: Self { .init(.repositoryLimitExceededException) }
+    public static var repositoryNameExistsException: Self { .init(.repositoryNameExistsException) }
+    public static var repositoryNameRequiredException: Self { .init(.repositoryNameRequiredException) }
+    public static var repositoryNamesRequiredException: Self { .init(.repositoryNamesRequiredException) }
+    public static var repositoryNotAssociatedWithPullRequestException: Self { .init(.repositoryNotAssociatedWithPullRequestException) }
+    public static var repositoryTriggerBranchNameListRequiredException: Self { .init(.repositoryTriggerBranchNameListRequiredException) }
+    public static var repositoryTriggerDestinationArnRequiredException: Self { .init(.repositoryTriggerDestinationArnRequiredException) }
+    public static var repositoryTriggerEventsListRequiredException: Self { .init(.repositoryTriggerEventsListRequiredException) }
+    public static var repositoryTriggerNameRequiredException: Self { .init(.repositoryTriggerNameRequiredException) }
+    public static var repositoryTriggersListRequiredException: Self { .init(.repositoryTriggersListRequiredException) }
+    public static var resourceArnRequiredException: Self { .init(.resourceArnRequiredException) }
+    public static var restrictedSourceFileException: Self { .init(.restrictedSourceFileException) }
+    public static var revisionIdRequiredException: Self { .init(.revisionIdRequiredException) }
+    public static var revisionNotCurrentException: Self { .init(.revisionNotCurrentException) }
+    public static var sameFileContentException: Self { .init(.sameFileContentException) }
+    public static var samePathRequestException: Self { .init(.samePathRequestException) }
+    public static var sourceAndDestinationAreSameException: Self { .init(.sourceAndDestinationAreSameException) }
+    public static var sourceFileOrContentRequiredException: Self { .init(.sourceFileOrContentRequiredException) }
+    public static var tagKeysListRequiredException: Self { .init(.tagKeysListRequiredException) }
+    public static var tagPolicyException: Self { .init(.tagPolicyException) }
+    public static var tagsMapRequiredException: Self { .init(.tagsMapRequiredException) }
+    public static var targetRequiredException: Self { .init(.targetRequiredException) }
+    public static var targetsRequiredException: Self { .init(.targetsRequiredException) }
+    public static var tipOfSourceReferenceIsDifferentException: Self { .init(.tipOfSourceReferenceIsDifferentException) }
+    public static var tipsDivergenceExceededException: Self { .init(.tipsDivergenceExceededException) }
+    public static var titleRequiredException: Self { .init(.titleRequiredException) }
+    public static var tooManyTagsException: Self { .init(.tooManyTagsException) }
+}
+
+extension CodeCommitErrorType: Equatable {
+    public static func == (lhs: CodeCommitErrorType, rhs: CodeCommitErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension CodeCommitErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .actorDoesNotExistException(let message):
-            return "ActorDoesNotExistException: \(message ?? "")"
-        case .approvalRuleContentRequiredException(let message):
-            return "ApprovalRuleContentRequiredException: \(message ?? "")"
-        case .approvalRuleDoesNotExistException(let message):
-            return "ApprovalRuleDoesNotExistException: \(message ?? "")"
-        case .approvalRuleNameAlreadyExistsException(let message):
-            return "ApprovalRuleNameAlreadyExistsException: \(message ?? "")"
-        case .approvalRuleNameRequiredException(let message):
-            return "ApprovalRuleNameRequiredException: \(message ?? "")"
-        case .approvalRuleTemplateContentRequiredException(let message):
-            return "ApprovalRuleTemplateContentRequiredException: \(message ?? "")"
-        case .approvalRuleTemplateDoesNotExistException(let message):
-            return "ApprovalRuleTemplateDoesNotExistException: \(message ?? "")"
-        case .approvalRuleTemplateInUseException(let message):
-            return "ApprovalRuleTemplateInUseException: \(message ?? "")"
-        case .approvalRuleTemplateNameAlreadyExistsException(let message):
-            return "ApprovalRuleTemplateNameAlreadyExistsException: \(message ?? "")"
-        case .approvalRuleTemplateNameRequiredException(let message):
-            return "ApprovalRuleTemplateNameRequiredException: \(message ?? "")"
-        case .approvalStateRequiredException(let message):
-            return "ApprovalStateRequiredException: \(message ?? "")"
-        case .authorDoesNotExistException(let message):
-            return "AuthorDoesNotExistException: \(message ?? "")"
-        case .beforeCommitIdAndAfterCommitIdAreSameException(let message):
-            return "BeforeCommitIdAndAfterCommitIdAreSameException: \(message ?? "")"
-        case .blobIdDoesNotExistException(let message):
-            return "BlobIdDoesNotExistException: \(message ?? "")"
-        case .blobIdRequiredException(let message):
-            return "BlobIdRequiredException: \(message ?? "")"
-        case .branchDoesNotExistException(let message):
-            return "BranchDoesNotExistException: \(message ?? "")"
-        case .branchNameExistsException(let message):
-            return "BranchNameExistsException: \(message ?? "")"
-        case .branchNameIsTagNameException(let message):
-            return "BranchNameIsTagNameException: \(message ?? "")"
-        case .branchNameRequiredException(let message):
-            return "BranchNameRequiredException: \(message ?? "")"
-        case .cannotDeleteApprovalRuleFromTemplateException(let message):
-            return "CannotDeleteApprovalRuleFromTemplateException: \(message ?? "")"
-        case .cannotModifyApprovalRuleFromTemplateException(let message):
-            return "CannotModifyApprovalRuleFromTemplateException: \(message ?? "")"
-        case .clientRequestTokenRequiredException(let message):
-            return "ClientRequestTokenRequiredException: \(message ?? "")"
-        case .commentContentRequiredException(let message):
-            return "CommentContentRequiredException: \(message ?? "")"
-        case .commentContentSizeLimitExceededException(let message):
-            return "CommentContentSizeLimitExceededException: \(message ?? "")"
-        case .commentDeletedException(let message):
-            return "CommentDeletedException: \(message ?? "")"
-        case .commentDoesNotExistException(let message):
-            return "CommentDoesNotExistException: \(message ?? "")"
-        case .commentIdRequiredException(let message):
-            return "CommentIdRequiredException: \(message ?? "")"
-        case .commentNotCreatedByCallerException(let message):
-            return "CommentNotCreatedByCallerException: \(message ?? "")"
-        case .commitDoesNotExistException(let message):
-            return "CommitDoesNotExistException: \(message ?? "")"
-        case .commitIdDoesNotExistException(let message):
-            return "CommitIdDoesNotExistException: \(message ?? "")"
-        case .commitIdRequiredException(let message):
-            return "CommitIdRequiredException: \(message ?? "")"
-        case .commitIdsLimitExceededException(let message):
-            return "CommitIdsLimitExceededException: \(message ?? "")"
-        case .commitIdsListRequiredException(let message):
-            return "CommitIdsListRequiredException: \(message ?? "")"
-        case .commitMessageLengthExceededException(let message):
-            return "CommitMessageLengthExceededException: \(message ?? "")"
-        case .commitRequiredException(let message):
-            return "CommitRequiredException: \(message ?? "")"
-        case .concurrentReferenceUpdateException(let message):
-            return "ConcurrentReferenceUpdateException: \(message ?? "")"
-        case .defaultBranchCannotBeDeletedException(let message):
-            return "DefaultBranchCannotBeDeletedException: \(message ?? "")"
-        case .directoryNameConflictsWithFileNameException(let message):
-            return "DirectoryNameConflictsWithFileNameException: \(message ?? "")"
-        case .encryptionIntegrityChecksFailedException(let message):
-            return "EncryptionIntegrityChecksFailedException: \(message ?? "")"
-        case .encryptionKeyAccessDeniedException(let message):
-            return "EncryptionKeyAccessDeniedException: \(message ?? "")"
-        case .encryptionKeyDisabledException(let message):
-            return "EncryptionKeyDisabledException: \(message ?? "")"
-        case .encryptionKeyNotFoundException(let message):
-            return "EncryptionKeyNotFoundException: \(message ?? "")"
-        case .encryptionKeyUnavailableException(let message):
-            return "EncryptionKeyUnavailableException: \(message ?? "")"
-        case .fileContentAndSourceFileSpecifiedException(let message):
-            return "FileContentAndSourceFileSpecifiedException: \(message ?? "")"
-        case .fileContentRequiredException(let message):
-            return "FileContentRequiredException: \(message ?? "")"
-        case .fileContentSizeLimitExceededException(let message):
-            return "FileContentSizeLimitExceededException: \(message ?? "")"
-        case .fileDoesNotExistException(let message):
-            return "FileDoesNotExistException: \(message ?? "")"
-        case .fileEntryRequiredException(let message):
-            return "FileEntryRequiredException: \(message ?? "")"
-        case .fileModeRequiredException(let message):
-            return "FileModeRequiredException: \(message ?? "")"
-        case .fileNameConflictsWithDirectoryNameException(let message):
-            return "FileNameConflictsWithDirectoryNameException: \(message ?? "")"
-        case .filePathConflictsWithSubmodulePathException(let message):
-            return "FilePathConflictsWithSubmodulePathException: \(message ?? "")"
-        case .fileTooLargeException(let message):
-            return "FileTooLargeException: \(message ?? "")"
-        case .folderContentSizeLimitExceededException(let message):
-            return "FolderContentSizeLimitExceededException: \(message ?? "")"
-        case .folderDoesNotExistException(let message):
-            return "FolderDoesNotExistException: \(message ?? "")"
-        case .idempotencyParameterMismatchException(let message):
-            return "IdempotencyParameterMismatchException: \(message ?? "")"
-        case .invalidActorArnException(let message):
-            return "InvalidActorArnException: \(message ?? "")"
-        case .invalidApprovalRuleContentException(let message):
-            return "InvalidApprovalRuleContentException: \(message ?? "")"
-        case .invalidApprovalRuleNameException(let message):
-            return "InvalidApprovalRuleNameException: \(message ?? "")"
-        case .invalidApprovalRuleTemplateContentException(let message):
-            return "InvalidApprovalRuleTemplateContentException: \(message ?? "")"
-        case .invalidApprovalRuleTemplateDescriptionException(let message):
-            return "InvalidApprovalRuleTemplateDescriptionException: \(message ?? "")"
-        case .invalidApprovalRuleTemplateNameException(let message):
-            return "InvalidApprovalRuleTemplateNameException: \(message ?? "")"
-        case .invalidApprovalStateException(let message):
-            return "InvalidApprovalStateException: \(message ?? "")"
-        case .invalidAuthorArnException(let message):
-            return "InvalidAuthorArnException: \(message ?? "")"
-        case .invalidBlobIdException(let message):
-            return "InvalidBlobIdException: \(message ?? "")"
-        case .invalidBranchNameException(let message):
-            return "InvalidBranchNameException: \(message ?? "")"
-        case .invalidClientRequestTokenException(let message):
-            return "InvalidClientRequestTokenException: \(message ?? "")"
-        case .invalidCommentIdException(let message):
-            return "InvalidCommentIdException: \(message ?? "")"
-        case .invalidCommitException(let message):
-            return "InvalidCommitException: \(message ?? "")"
-        case .invalidCommitIdException(let message):
-            return "InvalidCommitIdException: \(message ?? "")"
-        case .invalidConflictDetailLevelException(let message):
-            return "InvalidConflictDetailLevelException: \(message ?? "")"
-        case .invalidConflictResolutionException(let message):
-            return "InvalidConflictResolutionException: \(message ?? "")"
-        case .invalidConflictResolutionStrategyException(let message):
-            return "InvalidConflictResolutionStrategyException: \(message ?? "")"
-        case .invalidContinuationTokenException(let message):
-            return "InvalidContinuationTokenException: \(message ?? "")"
-        case .invalidDeletionParameterException(let message):
-            return "InvalidDeletionParameterException: \(message ?? "")"
-        case .invalidDescriptionException(let message):
-            return "InvalidDescriptionException: \(message ?? "")"
-        case .invalidDestinationCommitSpecifierException(let message):
-            return "InvalidDestinationCommitSpecifierException: \(message ?? "")"
-        case .invalidEmailException(let message):
-            return "InvalidEmailException: \(message ?? "")"
-        case .invalidFileLocationException(let message):
-            return "InvalidFileLocationException: \(message ?? "")"
-        case .invalidFileModeException(let message):
-            return "InvalidFileModeException: \(message ?? "")"
-        case .invalidFilePositionException(let message):
-            return "InvalidFilePositionException: \(message ?? "")"
-        case .invalidMaxConflictFilesException(let message):
-            return "InvalidMaxConflictFilesException: \(message ?? "")"
-        case .invalidMaxMergeHunksException(let message):
-            return "InvalidMaxMergeHunksException: \(message ?? "")"
-        case .invalidMaxResultsException(let message):
-            return "InvalidMaxResultsException: \(message ?? "")"
-        case .invalidMergeOptionException(let message):
-            return "InvalidMergeOptionException: \(message ?? "")"
-        case .invalidOrderException(let message):
-            return "InvalidOrderException: \(message ?? "")"
-        case .invalidOverrideStatusException(let message):
-            return "InvalidOverrideStatusException: \(message ?? "")"
-        case .invalidParentCommitIdException(let message):
-            return "InvalidParentCommitIdException: \(message ?? "")"
-        case .invalidPathException(let message):
-            return "InvalidPathException: \(message ?? "")"
-        case .invalidPullRequestEventTypeException(let message):
-            return "InvalidPullRequestEventTypeException: \(message ?? "")"
-        case .invalidPullRequestIdException(let message):
-            return "InvalidPullRequestIdException: \(message ?? "")"
-        case .invalidPullRequestStatusException(let message):
-            return "InvalidPullRequestStatusException: \(message ?? "")"
-        case .invalidPullRequestStatusUpdateException(let message):
-            return "InvalidPullRequestStatusUpdateException: \(message ?? "")"
-        case .invalidReactionUserArnException(let message):
-            return "InvalidReactionUserArnException: \(message ?? "")"
-        case .invalidReactionValueException(let message):
-            return "InvalidReactionValueException: \(message ?? "")"
-        case .invalidReferenceNameException(let message):
-            return "InvalidReferenceNameException: \(message ?? "")"
-        case .invalidRelativeFileVersionEnumException(let message):
-            return "InvalidRelativeFileVersionEnumException: \(message ?? "")"
-        case .invalidReplacementContentException(let message):
-            return "InvalidReplacementContentException: \(message ?? "")"
-        case .invalidReplacementTypeException(let message):
-            return "InvalidReplacementTypeException: \(message ?? "")"
-        case .invalidRepositoryDescriptionException(let message):
-            return "InvalidRepositoryDescriptionException: \(message ?? "")"
-        case .invalidRepositoryNameException(let message):
-            return "InvalidRepositoryNameException: \(message ?? "")"
-        case .invalidRepositoryTriggerBranchNameException(let message):
-            return "InvalidRepositoryTriggerBranchNameException: \(message ?? "")"
-        case .invalidRepositoryTriggerCustomDataException(let message):
-            return "InvalidRepositoryTriggerCustomDataException: \(message ?? "")"
-        case .invalidRepositoryTriggerDestinationArnException(let message):
-            return "InvalidRepositoryTriggerDestinationArnException: \(message ?? "")"
-        case .invalidRepositoryTriggerEventsException(let message):
-            return "InvalidRepositoryTriggerEventsException: \(message ?? "")"
-        case .invalidRepositoryTriggerNameException(let message):
-            return "InvalidRepositoryTriggerNameException: \(message ?? "")"
-        case .invalidRepositoryTriggerRegionException(let message):
-            return "InvalidRepositoryTriggerRegionException: \(message ?? "")"
-        case .invalidResourceArnException(let message):
-            return "InvalidResourceArnException: \(message ?? "")"
-        case .invalidRevisionIdException(let message):
-            return "InvalidRevisionIdException: \(message ?? "")"
-        case .invalidRuleContentSha256Exception(let message):
-            return "InvalidRuleContentSha256Exception: \(message ?? "")"
-        case .invalidSortByException(let message):
-            return "InvalidSortByException: \(message ?? "")"
-        case .invalidSourceCommitSpecifierException(let message):
-            return "InvalidSourceCommitSpecifierException: \(message ?? "")"
-        case .invalidSystemTagUsageException(let message):
-            return "InvalidSystemTagUsageException: \(message ?? "")"
-        case .invalidTagKeysListException(let message):
-            return "InvalidTagKeysListException: \(message ?? "")"
-        case .invalidTagsMapException(let message):
-            return "InvalidTagsMapException: \(message ?? "")"
-        case .invalidTargetBranchException(let message):
-            return "InvalidTargetBranchException: \(message ?? "")"
-        case .invalidTargetException(let message):
-            return "InvalidTargetException: \(message ?? "")"
-        case .invalidTargetsException(let message):
-            return "InvalidTargetsException: \(message ?? "")"
-        case .invalidTitleException(let message):
-            return "InvalidTitleException: \(message ?? "")"
-        case .manualMergeRequiredException(let message):
-            return "ManualMergeRequiredException: \(message ?? "")"
-        case .maximumBranchesExceededException(let message):
-            return "MaximumBranchesExceededException: \(message ?? "")"
-        case .maximumConflictResolutionEntriesExceededException(let message):
-            return "MaximumConflictResolutionEntriesExceededException: \(message ?? "")"
-        case .maximumFileContentToLoadExceededException(let message):
-            return "MaximumFileContentToLoadExceededException: \(message ?? "")"
-        case .maximumFileEntriesExceededException(let message):
-            return "MaximumFileEntriesExceededException: \(message ?? "")"
-        case .maximumItemsToCompareExceededException(let message):
-            return "MaximumItemsToCompareExceededException: \(message ?? "")"
-        case .maximumNumberOfApprovalsExceededException(let message):
-            return "MaximumNumberOfApprovalsExceededException: \(message ?? "")"
-        case .maximumOpenPullRequestsExceededException(let message):
-            return "MaximumOpenPullRequestsExceededException: \(message ?? "")"
-        case .maximumRepositoryNamesExceededException(let message):
-            return "MaximumRepositoryNamesExceededException: \(message ?? "")"
-        case .maximumRepositoryTriggersExceededException(let message):
-            return "MaximumRepositoryTriggersExceededException: \(message ?? "")"
-        case .maximumRuleTemplatesAssociatedWithRepositoryException(let message):
-            return "MaximumRuleTemplatesAssociatedWithRepositoryException: \(message ?? "")"
-        case .mergeOptionRequiredException(let message):
-            return "MergeOptionRequiredException: \(message ?? "")"
-        case .multipleConflictResolutionEntriesException(let message):
-            return "MultipleConflictResolutionEntriesException: \(message ?? "")"
-        case .multipleRepositoriesInPullRequestException(let message):
-            return "MultipleRepositoriesInPullRequestException: \(message ?? "")"
-        case .nameLengthExceededException(let message):
-            return "NameLengthExceededException: \(message ?? "")"
-        case .noChangeException(let message):
-            return "NoChangeException: \(message ?? "")"
-        case .numberOfRuleTemplatesExceededException(let message):
-            return "NumberOfRuleTemplatesExceededException: \(message ?? "")"
-        case .numberOfRulesExceededException(let message):
-            return "NumberOfRulesExceededException: \(message ?? "")"
-        case .overrideAlreadySetException(let message):
-            return "OverrideAlreadySetException: \(message ?? "")"
-        case .overrideStatusRequiredException(let message):
-            return "OverrideStatusRequiredException: \(message ?? "")"
-        case .parentCommitDoesNotExistException(let message):
-            return "ParentCommitDoesNotExistException: \(message ?? "")"
-        case .parentCommitIdOutdatedException(let message):
-            return "ParentCommitIdOutdatedException: \(message ?? "")"
-        case .parentCommitIdRequiredException(let message):
-            return "ParentCommitIdRequiredException: \(message ?? "")"
-        case .pathDoesNotExistException(let message):
-            return "PathDoesNotExistException: \(message ?? "")"
-        case .pathRequiredException(let message):
-            return "PathRequiredException: \(message ?? "")"
-        case .pullRequestAlreadyClosedException(let message):
-            return "PullRequestAlreadyClosedException: \(message ?? "")"
-        case .pullRequestApprovalRulesNotSatisfiedException(let message):
-            return "PullRequestApprovalRulesNotSatisfiedException: \(message ?? "")"
-        case .pullRequestCannotBeApprovedByAuthorException(let message):
-            return "PullRequestCannotBeApprovedByAuthorException: \(message ?? "")"
-        case .pullRequestDoesNotExistException(let message):
-            return "PullRequestDoesNotExistException: \(message ?? "")"
-        case .pullRequestIdRequiredException(let message):
-            return "PullRequestIdRequiredException: \(message ?? "")"
-        case .pullRequestStatusRequiredException(let message):
-            return "PullRequestStatusRequiredException: \(message ?? "")"
-        case .putFileEntryConflictException(let message):
-            return "PutFileEntryConflictException: \(message ?? "")"
-        case .reactionLimitExceededException(let message):
-            return "ReactionLimitExceededException: \(message ?? "")"
-        case .reactionValueRequiredException(let message):
-            return "ReactionValueRequiredException: \(message ?? "")"
-        case .referenceDoesNotExistException(let message):
-            return "ReferenceDoesNotExistException: \(message ?? "")"
-        case .referenceNameRequiredException(let message):
-            return "ReferenceNameRequiredException: \(message ?? "")"
-        case .referenceTypeNotSupportedException(let message):
-            return "ReferenceTypeNotSupportedException: \(message ?? "")"
-        case .replacementContentRequiredException(let message):
-            return "ReplacementContentRequiredException: \(message ?? "")"
-        case .replacementTypeRequiredException(let message):
-            return "ReplacementTypeRequiredException: \(message ?? "")"
-        case .repositoryDoesNotExistException(let message):
-            return "RepositoryDoesNotExistException: \(message ?? "")"
-        case .repositoryLimitExceededException(let message):
-            return "RepositoryLimitExceededException: \(message ?? "")"
-        case .repositoryNameExistsException(let message):
-            return "RepositoryNameExistsException: \(message ?? "")"
-        case .repositoryNameRequiredException(let message):
-            return "RepositoryNameRequiredException: \(message ?? "")"
-        case .repositoryNamesRequiredException(let message):
-            return "RepositoryNamesRequiredException: \(message ?? "")"
-        case .repositoryNotAssociatedWithPullRequestException(let message):
-            return "RepositoryNotAssociatedWithPullRequestException: \(message ?? "")"
-        case .repositoryTriggerBranchNameListRequiredException(let message):
-            return "RepositoryTriggerBranchNameListRequiredException: \(message ?? "")"
-        case .repositoryTriggerDestinationArnRequiredException(let message):
-            return "RepositoryTriggerDestinationArnRequiredException: \(message ?? "")"
-        case .repositoryTriggerEventsListRequiredException(let message):
-            return "RepositoryTriggerEventsListRequiredException: \(message ?? "")"
-        case .repositoryTriggerNameRequiredException(let message):
-            return "RepositoryTriggerNameRequiredException: \(message ?? "")"
-        case .repositoryTriggersListRequiredException(let message):
-            return "RepositoryTriggersListRequiredException: \(message ?? "")"
-        case .resourceArnRequiredException(let message):
-            return "ResourceArnRequiredException: \(message ?? "")"
-        case .restrictedSourceFileException(let message):
-            return "RestrictedSourceFileException: \(message ?? "")"
-        case .revisionIdRequiredException(let message):
-            return "RevisionIdRequiredException: \(message ?? "")"
-        case .revisionNotCurrentException(let message):
-            return "RevisionNotCurrentException: \(message ?? "")"
-        case .sameFileContentException(let message):
-            return "SameFileContentException: \(message ?? "")"
-        case .samePathRequestException(let message):
-            return "SamePathRequestException: \(message ?? "")"
-        case .sourceAndDestinationAreSameException(let message):
-            return "SourceAndDestinationAreSameException: \(message ?? "")"
-        case .sourceFileOrContentRequiredException(let message):
-            return "SourceFileOrContentRequiredException: \(message ?? "")"
-        case .tagKeysListRequiredException(let message):
-            return "TagKeysListRequiredException: \(message ?? "")"
-        case .tagPolicyException(let message):
-            return "TagPolicyException: \(message ?? "")"
-        case .tagsMapRequiredException(let message):
-            return "TagsMapRequiredException: \(message ?? "")"
-        case .targetRequiredException(let message):
-            return "TargetRequiredException: \(message ?? "")"
-        case .targetsRequiredException(let message):
-            return "TargetsRequiredException: \(message ?? "")"
-        case .tipOfSourceReferenceIsDifferentException(let message):
-            return "TipOfSourceReferenceIsDifferentException: \(message ?? "")"
-        case .tipsDivergenceExceededException(let message):
-            return "TipsDivergenceExceededException: \(message ?? "")"
-        case .titleRequiredException(let message):
-            return "TitleRequiredException: \(message ?? "")"
-        case .tooManyTagsException(let message):
-            return "TooManyTagsException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/CodeDeploy/CodeDeploy_Error.swift
+++ b/Sources/Soto/Services/CodeDeploy/CodeDeploy_Error.swift
@@ -17,570 +17,256 @@
 import SotoCore
 
 /// Error enum for CodeDeploy
-public enum CodeDeployErrorType: AWSErrorType {
-    case alarmsLimitExceededException(message: String?)
-    case applicationAlreadyExistsException(message: String?)
-    case applicationDoesNotExistException(message: String?)
-    case applicationLimitExceededException(message: String?)
-    case applicationNameRequiredException(message: String?)
-    case arnNotSupportedException(message: String?)
-    case batchLimitExceededException(message: String?)
-    case bucketNameFilterRequiredException(message: String?)
-    case deploymentAlreadyCompletedException(message: String?)
-    case deploymentConfigAlreadyExistsException(message: String?)
-    case deploymentConfigDoesNotExistException(message: String?)
-    case deploymentConfigInUseException(message: String?)
-    case deploymentConfigLimitExceededException(message: String?)
-    case deploymentConfigNameRequiredException(message: String?)
-    case deploymentDoesNotExistException(message: String?)
-    case deploymentGroupAlreadyExistsException(message: String?)
-    case deploymentGroupDoesNotExistException(message: String?)
-    case deploymentGroupLimitExceededException(message: String?)
-    case deploymentGroupNameRequiredException(message: String?)
-    case deploymentIdRequiredException(message: String?)
-    case deploymentIsNotInReadyStateException(message: String?)
-    case deploymentLimitExceededException(message: String?)
-    case deploymentNotStartedException(message: String?)
-    case deploymentTargetDoesNotExistException(message: String?)
-    case deploymentTargetIdRequiredException(message: String?)
-    case deploymentTargetListSizeExceededException(message: String?)
-    case descriptionTooLongException(message: String?)
-    case eCSServiceMappingLimitExceededException(message: String?)
-    case gitHubAccountTokenDoesNotExistException(message: String?)
-    case gitHubAccountTokenNameRequiredException(message: String?)
-    case iamArnRequiredException(message: String?)
-    case iamSessionArnAlreadyRegisteredException(message: String?)
-    case iamUserArnAlreadyRegisteredException(message: String?)
-    case iamUserArnRequiredException(message: String?)
-    case instanceDoesNotExistException(message: String?)
-    case instanceIdRequiredException(message: String?)
-    case instanceLimitExceededException(message: String?)
-    case instanceNameAlreadyRegisteredException(message: String?)
-    case instanceNameRequiredException(message: String?)
-    case instanceNotRegisteredException(message: String?)
-    case invalidAlarmConfigException(message: String?)
-    case invalidApplicationNameException(message: String?)
-    case invalidArnException(message: String?)
-    case invalidAutoRollbackConfigException(message: String?)
-    case invalidAutoScalingGroupException(message: String?)
-    case invalidBlueGreenDeploymentConfigurationException(message: String?)
-    case invalidBucketNameFilterException(message: String?)
-    case invalidComputePlatformException(message: String?)
-    case invalidDeployedStateFilterException(message: String?)
-    case invalidDeploymentConfigNameException(message: String?)
-    case invalidDeploymentGroupNameException(message: String?)
-    case invalidDeploymentIdException(message: String?)
-    case invalidDeploymentInstanceTypeException(message: String?)
-    case invalidDeploymentStatusException(message: String?)
-    case invalidDeploymentStyleException(message: String?)
-    case invalidDeploymentTargetIdException(message: String?)
-    case invalidDeploymentWaitTypeException(message: String?)
-    case invalidEC2TagCombinationException(message: String?)
-    case invalidEC2TagException(message: String?)
-    case invalidECSServiceException(message: String?)
-    case invalidExternalIdException(message: String?)
-    case invalidFileExistsBehaviorException(message: String?)
-    case invalidGitHubAccountTokenException(message: String?)
-    case invalidGitHubAccountTokenNameException(message: String?)
-    case invalidIamSessionArnException(message: String?)
-    case invalidIamUserArnException(message: String?)
-    case invalidIgnoreApplicationStopFailuresValueException(message: String?)
-    case invalidInputException(message: String?)
-    case invalidInstanceNameException(message: String?)
-    case invalidInstanceStatusException(message: String?)
-    case invalidInstanceTypeException(message: String?)
-    case invalidKeyPrefixFilterException(message: String?)
-    case invalidLifecycleEventHookExecutionIdException(message: String?)
-    case invalidLifecycleEventHookExecutionStatusException(message: String?)
-    case invalidLoadBalancerInfoException(message: String?)
-    case invalidMinimumHealthyHostValueException(message: String?)
-    case invalidNextTokenException(message: String?)
-    case invalidOnPremisesTagCombinationException(message: String?)
-    case invalidOperationException(message: String?)
-    case invalidRegistrationStatusException(message: String?)
-    case invalidRevisionException(message: String?)
-    case invalidRoleException(message: String?)
-    case invalidSortByException(message: String?)
-    case invalidSortOrderException(message: String?)
-    case invalidTagException(message: String?)
-    case invalidTagFilterException(message: String?)
-    case invalidTagsToAddException(message: String?)
-    case invalidTargetFilterNameException(message: String?)
-    case invalidTargetGroupPairException(message: String?)
-    case invalidTargetInstancesException(message: String?)
-    case invalidTimeRangeException(message: String?)
-    case invalidTrafficRoutingConfigurationException(message: String?)
-    case invalidTriggerConfigException(message: String?)
-    case invalidUpdateOutdatedInstancesOnlyValueException(message: String?)
-    case lifecycleEventAlreadyCompletedException(message: String?)
-    case lifecycleHookLimitExceededException(message: String?)
-    case multipleIamArnsProvidedException(message: String?)
-    case operationNotSupportedException(message: String?)
-    case resourceArnRequiredException(message: String?)
-    case resourceValidationException(message: String?)
-    case revisionDoesNotExistException(message: String?)
-    case revisionRequiredException(message: String?)
-    case roleRequiredException(message: String?)
-    case tagLimitExceededException(message: String?)
-    case tagRequiredException(message: String?)
-    case tagSetListLimitExceededException(message: String?)
-    case throttlingException(message: String?)
-    case triggerTargetsLimitExceededException(message: String?)
-    case unsupportedActionForDeploymentTypeException(message: String?)
-}
+public struct CodeDeployErrorType: AWSErrorType {
+    enum Code: String {
+        case alarmsLimitExceededException = "AlarmsLimitExceededException"
+        case applicationAlreadyExistsException = "ApplicationAlreadyExistsException"
+        case applicationDoesNotExistException = "ApplicationDoesNotExistException"
+        case applicationLimitExceededException = "ApplicationLimitExceededException"
+        case applicationNameRequiredException = "ApplicationNameRequiredException"
+        case arnNotSupportedException = "ArnNotSupportedException"
+        case batchLimitExceededException = "BatchLimitExceededException"
+        case bucketNameFilterRequiredException = "BucketNameFilterRequiredException"
+        case deploymentAlreadyCompletedException = "DeploymentAlreadyCompletedException"
+        case deploymentConfigAlreadyExistsException = "DeploymentConfigAlreadyExistsException"
+        case deploymentConfigDoesNotExistException = "DeploymentConfigDoesNotExistException"
+        case deploymentConfigInUseException = "DeploymentConfigInUseException"
+        case deploymentConfigLimitExceededException = "DeploymentConfigLimitExceededException"
+        case deploymentConfigNameRequiredException = "DeploymentConfigNameRequiredException"
+        case deploymentDoesNotExistException = "DeploymentDoesNotExistException"
+        case deploymentGroupAlreadyExistsException = "DeploymentGroupAlreadyExistsException"
+        case deploymentGroupDoesNotExistException = "DeploymentGroupDoesNotExistException"
+        case deploymentGroupLimitExceededException = "DeploymentGroupLimitExceededException"
+        case deploymentGroupNameRequiredException = "DeploymentGroupNameRequiredException"
+        case deploymentIdRequiredException = "DeploymentIdRequiredException"
+        case deploymentIsNotInReadyStateException = "DeploymentIsNotInReadyStateException"
+        case deploymentLimitExceededException = "DeploymentLimitExceededException"
+        case deploymentNotStartedException = "DeploymentNotStartedException"
+        case deploymentTargetDoesNotExistException = "DeploymentTargetDoesNotExistException"
+        case deploymentTargetIdRequiredException = "DeploymentTargetIdRequiredException"
+        case deploymentTargetListSizeExceededException = "DeploymentTargetListSizeExceededException"
+        case descriptionTooLongException = "DescriptionTooLongException"
+        case eCSServiceMappingLimitExceededException = "ECSServiceMappingLimitExceededException"
+        case gitHubAccountTokenDoesNotExistException = "GitHubAccountTokenDoesNotExistException"
+        case gitHubAccountTokenNameRequiredException = "GitHubAccountTokenNameRequiredException"
+        case iamArnRequiredException = "IamArnRequiredException"
+        case iamSessionArnAlreadyRegisteredException = "IamSessionArnAlreadyRegisteredException"
+        case iamUserArnAlreadyRegisteredException = "IamUserArnAlreadyRegisteredException"
+        case iamUserArnRequiredException = "IamUserArnRequiredException"
+        case instanceDoesNotExistException = "InstanceDoesNotExistException"
+        case instanceIdRequiredException = "InstanceIdRequiredException"
+        case instanceLimitExceededException = "InstanceLimitExceededException"
+        case instanceNameAlreadyRegisteredException = "InstanceNameAlreadyRegisteredException"
+        case instanceNameRequiredException = "InstanceNameRequiredException"
+        case instanceNotRegisteredException = "InstanceNotRegisteredException"
+        case invalidAlarmConfigException = "InvalidAlarmConfigException"
+        case invalidApplicationNameException = "InvalidApplicationNameException"
+        case invalidArnException = "InvalidArnException"
+        case invalidAutoRollbackConfigException = "InvalidAutoRollbackConfigException"
+        case invalidAutoScalingGroupException = "InvalidAutoScalingGroupException"
+        case invalidBlueGreenDeploymentConfigurationException = "InvalidBlueGreenDeploymentConfigurationException"
+        case invalidBucketNameFilterException = "InvalidBucketNameFilterException"
+        case invalidComputePlatformException = "InvalidComputePlatformException"
+        case invalidDeployedStateFilterException = "InvalidDeployedStateFilterException"
+        case invalidDeploymentConfigNameException = "InvalidDeploymentConfigNameException"
+        case invalidDeploymentGroupNameException = "InvalidDeploymentGroupNameException"
+        case invalidDeploymentIdException = "InvalidDeploymentIdException"
+        case invalidDeploymentInstanceTypeException = "InvalidDeploymentInstanceTypeException"
+        case invalidDeploymentStatusException = "InvalidDeploymentStatusException"
+        case invalidDeploymentStyleException = "InvalidDeploymentStyleException"
+        case invalidDeploymentTargetIdException = "InvalidDeploymentTargetIdException"
+        case invalidDeploymentWaitTypeException = "InvalidDeploymentWaitTypeException"
+        case invalidEC2TagCombinationException = "InvalidEC2TagCombinationException"
+        case invalidEC2TagException = "InvalidEC2TagException"
+        case invalidECSServiceException = "InvalidECSServiceException"
+        case invalidExternalIdException = "InvalidExternalIdException"
+        case invalidFileExistsBehaviorException = "InvalidFileExistsBehaviorException"
+        case invalidGitHubAccountTokenException = "InvalidGitHubAccountTokenException"
+        case invalidGitHubAccountTokenNameException = "InvalidGitHubAccountTokenNameException"
+        case invalidIamSessionArnException = "InvalidIamSessionArnException"
+        case invalidIamUserArnException = "InvalidIamUserArnException"
+        case invalidIgnoreApplicationStopFailuresValueException = "InvalidIgnoreApplicationStopFailuresValueException"
+        case invalidInputException = "InvalidInputException"
+        case invalidInstanceNameException = "InvalidInstanceNameException"
+        case invalidInstanceStatusException = "InvalidInstanceStatusException"
+        case invalidInstanceTypeException = "InvalidInstanceTypeException"
+        case invalidKeyPrefixFilterException = "InvalidKeyPrefixFilterException"
+        case invalidLifecycleEventHookExecutionIdException = "InvalidLifecycleEventHookExecutionIdException"
+        case invalidLifecycleEventHookExecutionStatusException = "InvalidLifecycleEventHookExecutionStatusException"
+        case invalidLoadBalancerInfoException = "InvalidLoadBalancerInfoException"
+        case invalidMinimumHealthyHostValueException = "InvalidMinimumHealthyHostValueException"
+        case invalidNextTokenException = "InvalidNextTokenException"
+        case invalidOnPremisesTagCombinationException = "InvalidOnPremisesTagCombinationException"
+        case invalidOperationException = "InvalidOperationException"
+        case invalidRegistrationStatusException = "InvalidRegistrationStatusException"
+        case invalidRevisionException = "InvalidRevisionException"
+        case invalidRoleException = "InvalidRoleException"
+        case invalidSortByException = "InvalidSortByException"
+        case invalidSortOrderException = "InvalidSortOrderException"
+        case invalidTagException = "InvalidTagException"
+        case invalidTagFilterException = "InvalidTagFilterException"
+        case invalidTagsToAddException = "InvalidTagsToAddException"
+        case invalidTargetFilterNameException = "InvalidTargetFilterNameException"
+        case invalidTargetGroupPairException = "InvalidTargetGroupPairException"
+        case invalidTargetInstancesException = "InvalidTargetInstancesException"
+        case invalidTimeRangeException = "InvalidTimeRangeException"
+        case invalidTrafficRoutingConfigurationException = "InvalidTrafficRoutingConfigurationException"
+        case invalidTriggerConfigException = "InvalidTriggerConfigException"
+        case invalidUpdateOutdatedInstancesOnlyValueException = "InvalidUpdateOutdatedInstancesOnlyValueException"
+        case lifecycleEventAlreadyCompletedException = "LifecycleEventAlreadyCompletedException"
+        case lifecycleHookLimitExceededException = "LifecycleHookLimitExceededException"
+        case multipleIamArnsProvidedException = "MultipleIamArnsProvidedException"
+        case operationNotSupportedException = "OperationNotSupportedException"
+        case resourceArnRequiredException = "ResourceArnRequiredException"
+        case resourceValidationException = "ResourceValidationException"
+        case revisionDoesNotExistException = "RevisionDoesNotExistException"
+        case revisionRequiredException = "RevisionRequiredException"
+        case roleRequiredException = "RoleRequiredException"
+        case tagLimitExceededException = "TagLimitExceededException"
+        case tagRequiredException = "TagRequiredException"
+        case tagSetListLimitExceededException = "TagSetListLimitExceededException"
+        case throttlingException = "ThrottlingException"
+        case triggerTargetsLimitExceededException = "TriggerTargetsLimitExceededException"
+        case unsupportedActionForDeploymentTypeException = "UnsupportedActionForDeploymentTypeException"
+    }
 
-extension CodeDeployErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AlarmsLimitExceededException":
-            self = .alarmsLimitExceededException(message: message)
-        case "ApplicationAlreadyExistsException":
-            self = .applicationAlreadyExistsException(message: message)
-        case "ApplicationDoesNotExistException":
-            self = .applicationDoesNotExistException(message: message)
-        case "ApplicationLimitExceededException":
-            self = .applicationLimitExceededException(message: message)
-        case "ApplicationNameRequiredException":
-            self = .applicationNameRequiredException(message: message)
-        case "ArnNotSupportedException":
-            self = .arnNotSupportedException(message: message)
-        case "BatchLimitExceededException":
-            self = .batchLimitExceededException(message: message)
-        case "BucketNameFilterRequiredException":
-            self = .bucketNameFilterRequiredException(message: message)
-        case "DeploymentAlreadyCompletedException":
-            self = .deploymentAlreadyCompletedException(message: message)
-        case "DeploymentConfigAlreadyExistsException":
-            self = .deploymentConfigAlreadyExistsException(message: message)
-        case "DeploymentConfigDoesNotExistException":
-            self = .deploymentConfigDoesNotExistException(message: message)
-        case "DeploymentConfigInUseException":
-            self = .deploymentConfigInUseException(message: message)
-        case "DeploymentConfigLimitExceededException":
-            self = .deploymentConfigLimitExceededException(message: message)
-        case "DeploymentConfigNameRequiredException":
-            self = .deploymentConfigNameRequiredException(message: message)
-        case "DeploymentDoesNotExistException":
-            self = .deploymentDoesNotExistException(message: message)
-        case "DeploymentGroupAlreadyExistsException":
-            self = .deploymentGroupAlreadyExistsException(message: message)
-        case "DeploymentGroupDoesNotExistException":
-            self = .deploymentGroupDoesNotExistException(message: message)
-        case "DeploymentGroupLimitExceededException":
-            self = .deploymentGroupLimitExceededException(message: message)
-        case "DeploymentGroupNameRequiredException":
-            self = .deploymentGroupNameRequiredException(message: message)
-        case "DeploymentIdRequiredException":
-            self = .deploymentIdRequiredException(message: message)
-        case "DeploymentIsNotInReadyStateException":
-            self = .deploymentIsNotInReadyStateException(message: message)
-        case "DeploymentLimitExceededException":
-            self = .deploymentLimitExceededException(message: message)
-        case "DeploymentNotStartedException":
-            self = .deploymentNotStartedException(message: message)
-        case "DeploymentTargetDoesNotExistException":
-            self = .deploymentTargetDoesNotExistException(message: message)
-        case "DeploymentTargetIdRequiredException":
-            self = .deploymentTargetIdRequiredException(message: message)
-        case "DeploymentTargetListSizeExceededException":
-            self = .deploymentTargetListSizeExceededException(message: message)
-        case "DescriptionTooLongException":
-            self = .descriptionTooLongException(message: message)
-        case "ECSServiceMappingLimitExceededException":
-            self = .eCSServiceMappingLimitExceededException(message: message)
-        case "GitHubAccountTokenDoesNotExistException":
-            self = .gitHubAccountTokenDoesNotExistException(message: message)
-        case "GitHubAccountTokenNameRequiredException":
-            self = .gitHubAccountTokenNameRequiredException(message: message)
-        case "IamArnRequiredException":
-            self = .iamArnRequiredException(message: message)
-        case "IamSessionArnAlreadyRegisteredException":
-            self = .iamSessionArnAlreadyRegisteredException(message: message)
-        case "IamUserArnAlreadyRegisteredException":
-            self = .iamUserArnAlreadyRegisteredException(message: message)
-        case "IamUserArnRequiredException":
-            self = .iamUserArnRequiredException(message: message)
-        case "InstanceDoesNotExistException":
-            self = .instanceDoesNotExistException(message: message)
-        case "InstanceIdRequiredException":
-            self = .instanceIdRequiredException(message: message)
-        case "InstanceLimitExceededException":
-            self = .instanceLimitExceededException(message: message)
-        case "InstanceNameAlreadyRegisteredException":
-            self = .instanceNameAlreadyRegisteredException(message: message)
-        case "InstanceNameRequiredException":
-            self = .instanceNameRequiredException(message: message)
-        case "InstanceNotRegisteredException":
-            self = .instanceNotRegisteredException(message: message)
-        case "InvalidAlarmConfigException":
-            self = .invalidAlarmConfigException(message: message)
-        case "InvalidApplicationNameException":
-            self = .invalidApplicationNameException(message: message)
-        case "InvalidArnException":
-            self = .invalidArnException(message: message)
-        case "InvalidAutoRollbackConfigException":
-            self = .invalidAutoRollbackConfigException(message: message)
-        case "InvalidAutoScalingGroupException":
-            self = .invalidAutoScalingGroupException(message: message)
-        case "InvalidBlueGreenDeploymentConfigurationException":
-            self = .invalidBlueGreenDeploymentConfigurationException(message: message)
-        case "InvalidBucketNameFilterException":
-            self = .invalidBucketNameFilterException(message: message)
-        case "InvalidComputePlatformException":
-            self = .invalidComputePlatformException(message: message)
-        case "InvalidDeployedStateFilterException":
-            self = .invalidDeployedStateFilterException(message: message)
-        case "InvalidDeploymentConfigNameException":
-            self = .invalidDeploymentConfigNameException(message: message)
-        case "InvalidDeploymentGroupNameException":
-            self = .invalidDeploymentGroupNameException(message: message)
-        case "InvalidDeploymentIdException":
-            self = .invalidDeploymentIdException(message: message)
-        case "InvalidDeploymentInstanceTypeException":
-            self = .invalidDeploymentInstanceTypeException(message: message)
-        case "InvalidDeploymentStatusException":
-            self = .invalidDeploymentStatusException(message: message)
-        case "InvalidDeploymentStyleException":
-            self = .invalidDeploymentStyleException(message: message)
-        case "InvalidDeploymentTargetIdException":
-            self = .invalidDeploymentTargetIdException(message: message)
-        case "InvalidDeploymentWaitTypeException":
-            self = .invalidDeploymentWaitTypeException(message: message)
-        case "InvalidEC2TagCombinationException":
-            self = .invalidEC2TagCombinationException(message: message)
-        case "InvalidEC2TagException":
-            self = .invalidEC2TagException(message: message)
-        case "InvalidECSServiceException":
-            self = .invalidECSServiceException(message: message)
-        case "InvalidExternalIdException":
-            self = .invalidExternalIdException(message: message)
-        case "InvalidFileExistsBehaviorException":
-            self = .invalidFileExistsBehaviorException(message: message)
-        case "InvalidGitHubAccountTokenException":
-            self = .invalidGitHubAccountTokenException(message: message)
-        case "InvalidGitHubAccountTokenNameException":
-            self = .invalidGitHubAccountTokenNameException(message: message)
-        case "InvalidIamSessionArnException":
-            self = .invalidIamSessionArnException(message: message)
-        case "InvalidIamUserArnException":
-            self = .invalidIamUserArnException(message: message)
-        case "InvalidIgnoreApplicationStopFailuresValueException":
-            self = .invalidIgnoreApplicationStopFailuresValueException(message: message)
-        case "InvalidInputException":
-            self = .invalidInputException(message: message)
-        case "InvalidInstanceNameException":
-            self = .invalidInstanceNameException(message: message)
-        case "InvalidInstanceStatusException":
-            self = .invalidInstanceStatusException(message: message)
-        case "InvalidInstanceTypeException":
-            self = .invalidInstanceTypeException(message: message)
-        case "InvalidKeyPrefixFilterException":
-            self = .invalidKeyPrefixFilterException(message: message)
-        case "InvalidLifecycleEventHookExecutionIdException":
-            self = .invalidLifecycleEventHookExecutionIdException(message: message)
-        case "InvalidLifecycleEventHookExecutionStatusException":
-            self = .invalidLifecycleEventHookExecutionStatusException(message: message)
-        case "InvalidLoadBalancerInfoException":
-            self = .invalidLoadBalancerInfoException(message: message)
-        case "InvalidMinimumHealthyHostValueException":
-            self = .invalidMinimumHealthyHostValueException(message: message)
-        case "InvalidNextTokenException":
-            self = .invalidNextTokenException(message: message)
-        case "InvalidOnPremisesTagCombinationException":
-            self = .invalidOnPremisesTagCombinationException(message: message)
-        case "InvalidOperationException":
-            self = .invalidOperationException(message: message)
-        case "InvalidRegistrationStatusException":
-            self = .invalidRegistrationStatusException(message: message)
-        case "InvalidRevisionException":
-            self = .invalidRevisionException(message: message)
-        case "InvalidRoleException":
-            self = .invalidRoleException(message: message)
-        case "InvalidSortByException":
-            self = .invalidSortByException(message: message)
-        case "InvalidSortOrderException":
-            self = .invalidSortOrderException(message: message)
-        case "InvalidTagException":
-            self = .invalidTagException(message: message)
-        case "InvalidTagFilterException":
-            self = .invalidTagFilterException(message: message)
-        case "InvalidTagsToAddException":
-            self = .invalidTagsToAddException(message: message)
-        case "InvalidTargetFilterNameException":
-            self = .invalidTargetFilterNameException(message: message)
-        case "InvalidTargetGroupPairException":
-            self = .invalidTargetGroupPairException(message: message)
-        case "InvalidTargetInstancesException":
-            self = .invalidTargetInstancesException(message: message)
-        case "InvalidTimeRangeException":
-            self = .invalidTimeRangeException(message: message)
-        case "InvalidTrafficRoutingConfigurationException":
-            self = .invalidTrafficRoutingConfigurationException(message: message)
-        case "InvalidTriggerConfigException":
-            self = .invalidTriggerConfigException(message: message)
-        case "InvalidUpdateOutdatedInstancesOnlyValueException":
-            self = .invalidUpdateOutdatedInstancesOnlyValueException(message: message)
-        case "LifecycleEventAlreadyCompletedException":
-            self = .lifecycleEventAlreadyCompletedException(message: message)
-        case "LifecycleHookLimitExceededException":
-            self = .lifecycleHookLimitExceededException(message: message)
-        case "MultipleIamArnsProvidedException":
-            self = .multipleIamArnsProvidedException(message: message)
-        case "OperationNotSupportedException":
-            self = .operationNotSupportedException(message: message)
-        case "ResourceArnRequiredException":
-            self = .resourceArnRequiredException(message: message)
-        case "ResourceValidationException":
-            self = .resourceValidationException(message: message)
-        case "RevisionDoesNotExistException":
-            self = .revisionDoesNotExistException(message: message)
-        case "RevisionRequiredException":
-            self = .revisionRequiredException(message: message)
-        case "RoleRequiredException":
-            self = .roleRequiredException(message: message)
-        case "TagLimitExceededException":
-            self = .tagLimitExceededException(message: message)
-        case "TagRequiredException":
-            self = .tagRequiredException(message: message)
-        case "TagSetListLimitExceededException":
-            self = .tagSetListLimitExceededException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        case "TriggerTargetsLimitExceededException":
-            self = .triggerTargetsLimitExceededException(message: message)
-        case "UnsupportedActionForDeploymentTypeException":
-            self = .unsupportedActionForDeploymentTypeException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var alarmsLimitExceededException: Self { .init(.alarmsLimitExceededException) }
+    public static var applicationAlreadyExistsException: Self { .init(.applicationAlreadyExistsException) }
+    public static var applicationDoesNotExistException: Self { .init(.applicationDoesNotExistException) }
+    public static var applicationLimitExceededException: Self { .init(.applicationLimitExceededException) }
+    public static var applicationNameRequiredException: Self { .init(.applicationNameRequiredException) }
+    public static var arnNotSupportedException: Self { .init(.arnNotSupportedException) }
+    public static var batchLimitExceededException: Self { .init(.batchLimitExceededException) }
+    public static var bucketNameFilterRequiredException: Self { .init(.bucketNameFilterRequiredException) }
+    public static var deploymentAlreadyCompletedException: Self { .init(.deploymentAlreadyCompletedException) }
+    public static var deploymentConfigAlreadyExistsException: Self { .init(.deploymentConfigAlreadyExistsException) }
+    public static var deploymentConfigDoesNotExistException: Self { .init(.deploymentConfigDoesNotExistException) }
+    public static var deploymentConfigInUseException: Self { .init(.deploymentConfigInUseException) }
+    public static var deploymentConfigLimitExceededException: Self { .init(.deploymentConfigLimitExceededException) }
+    public static var deploymentConfigNameRequiredException: Self { .init(.deploymentConfigNameRequiredException) }
+    public static var deploymentDoesNotExistException: Self { .init(.deploymentDoesNotExistException) }
+    public static var deploymentGroupAlreadyExistsException: Self { .init(.deploymentGroupAlreadyExistsException) }
+    public static var deploymentGroupDoesNotExistException: Self { .init(.deploymentGroupDoesNotExistException) }
+    public static var deploymentGroupLimitExceededException: Self { .init(.deploymentGroupLimitExceededException) }
+    public static var deploymentGroupNameRequiredException: Self { .init(.deploymentGroupNameRequiredException) }
+    public static var deploymentIdRequiredException: Self { .init(.deploymentIdRequiredException) }
+    public static var deploymentIsNotInReadyStateException: Self { .init(.deploymentIsNotInReadyStateException) }
+    public static var deploymentLimitExceededException: Self { .init(.deploymentLimitExceededException) }
+    public static var deploymentNotStartedException: Self { .init(.deploymentNotStartedException) }
+    public static var deploymentTargetDoesNotExistException: Self { .init(.deploymentTargetDoesNotExistException) }
+    public static var deploymentTargetIdRequiredException: Self { .init(.deploymentTargetIdRequiredException) }
+    public static var deploymentTargetListSizeExceededException: Self { .init(.deploymentTargetListSizeExceededException) }
+    public static var descriptionTooLongException: Self { .init(.descriptionTooLongException) }
+    public static var eCSServiceMappingLimitExceededException: Self { .init(.eCSServiceMappingLimitExceededException) }
+    public static var gitHubAccountTokenDoesNotExistException: Self { .init(.gitHubAccountTokenDoesNotExistException) }
+    public static var gitHubAccountTokenNameRequiredException: Self { .init(.gitHubAccountTokenNameRequiredException) }
+    public static var iamArnRequiredException: Self { .init(.iamArnRequiredException) }
+    public static var iamSessionArnAlreadyRegisteredException: Self { .init(.iamSessionArnAlreadyRegisteredException) }
+    public static var iamUserArnAlreadyRegisteredException: Self { .init(.iamUserArnAlreadyRegisteredException) }
+    public static var iamUserArnRequiredException: Self { .init(.iamUserArnRequiredException) }
+    public static var instanceDoesNotExistException: Self { .init(.instanceDoesNotExistException) }
+    public static var instanceIdRequiredException: Self { .init(.instanceIdRequiredException) }
+    public static var instanceLimitExceededException: Self { .init(.instanceLimitExceededException) }
+    public static var instanceNameAlreadyRegisteredException: Self { .init(.instanceNameAlreadyRegisteredException) }
+    public static var instanceNameRequiredException: Self { .init(.instanceNameRequiredException) }
+    public static var instanceNotRegisteredException: Self { .init(.instanceNotRegisteredException) }
+    public static var invalidAlarmConfigException: Self { .init(.invalidAlarmConfigException) }
+    public static var invalidApplicationNameException: Self { .init(.invalidApplicationNameException) }
+    public static var invalidArnException: Self { .init(.invalidArnException) }
+    public static var invalidAutoRollbackConfigException: Self { .init(.invalidAutoRollbackConfigException) }
+    public static var invalidAutoScalingGroupException: Self { .init(.invalidAutoScalingGroupException) }
+    public static var invalidBlueGreenDeploymentConfigurationException: Self { .init(.invalidBlueGreenDeploymentConfigurationException) }
+    public static var invalidBucketNameFilterException: Self { .init(.invalidBucketNameFilterException) }
+    public static var invalidComputePlatformException: Self { .init(.invalidComputePlatformException) }
+    public static var invalidDeployedStateFilterException: Self { .init(.invalidDeployedStateFilterException) }
+    public static var invalidDeploymentConfigNameException: Self { .init(.invalidDeploymentConfigNameException) }
+    public static var invalidDeploymentGroupNameException: Self { .init(.invalidDeploymentGroupNameException) }
+    public static var invalidDeploymentIdException: Self { .init(.invalidDeploymentIdException) }
+    public static var invalidDeploymentInstanceTypeException: Self { .init(.invalidDeploymentInstanceTypeException) }
+    public static var invalidDeploymentStatusException: Self { .init(.invalidDeploymentStatusException) }
+    public static var invalidDeploymentStyleException: Self { .init(.invalidDeploymentStyleException) }
+    public static var invalidDeploymentTargetIdException: Self { .init(.invalidDeploymentTargetIdException) }
+    public static var invalidDeploymentWaitTypeException: Self { .init(.invalidDeploymentWaitTypeException) }
+    public static var invalidEC2TagCombinationException: Self { .init(.invalidEC2TagCombinationException) }
+    public static var invalidEC2TagException: Self { .init(.invalidEC2TagException) }
+    public static var invalidECSServiceException: Self { .init(.invalidECSServiceException) }
+    public static var invalidExternalIdException: Self { .init(.invalidExternalIdException) }
+    public static var invalidFileExistsBehaviorException: Self { .init(.invalidFileExistsBehaviorException) }
+    public static var invalidGitHubAccountTokenException: Self { .init(.invalidGitHubAccountTokenException) }
+    public static var invalidGitHubAccountTokenNameException: Self { .init(.invalidGitHubAccountTokenNameException) }
+    public static var invalidIamSessionArnException: Self { .init(.invalidIamSessionArnException) }
+    public static var invalidIamUserArnException: Self { .init(.invalidIamUserArnException) }
+    public static var invalidIgnoreApplicationStopFailuresValueException: Self { .init(.invalidIgnoreApplicationStopFailuresValueException) }
+    public static var invalidInputException: Self { .init(.invalidInputException) }
+    public static var invalidInstanceNameException: Self { .init(.invalidInstanceNameException) }
+    public static var invalidInstanceStatusException: Self { .init(.invalidInstanceStatusException) }
+    public static var invalidInstanceTypeException: Self { .init(.invalidInstanceTypeException) }
+    public static var invalidKeyPrefixFilterException: Self { .init(.invalidKeyPrefixFilterException) }
+    public static var invalidLifecycleEventHookExecutionIdException: Self { .init(.invalidLifecycleEventHookExecutionIdException) }
+    public static var invalidLifecycleEventHookExecutionStatusException: Self { .init(.invalidLifecycleEventHookExecutionStatusException) }
+    public static var invalidLoadBalancerInfoException: Self { .init(.invalidLoadBalancerInfoException) }
+    public static var invalidMinimumHealthyHostValueException: Self { .init(.invalidMinimumHealthyHostValueException) }
+    public static var invalidNextTokenException: Self { .init(.invalidNextTokenException) }
+    public static var invalidOnPremisesTagCombinationException: Self { .init(.invalidOnPremisesTagCombinationException) }
+    public static var invalidOperationException: Self { .init(.invalidOperationException) }
+    public static var invalidRegistrationStatusException: Self { .init(.invalidRegistrationStatusException) }
+    public static var invalidRevisionException: Self { .init(.invalidRevisionException) }
+    public static var invalidRoleException: Self { .init(.invalidRoleException) }
+    public static var invalidSortByException: Self { .init(.invalidSortByException) }
+    public static var invalidSortOrderException: Self { .init(.invalidSortOrderException) }
+    public static var invalidTagException: Self { .init(.invalidTagException) }
+    public static var invalidTagFilterException: Self { .init(.invalidTagFilterException) }
+    public static var invalidTagsToAddException: Self { .init(.invalidTagsToAddException) }
+    public static var invalidTargetFilterNameException: Self { .init(.invalidTargetFilterNameException) }
+    public static var invalidTargetGroupPairException: Self { .init(.invalidTargetGroupPairException) }
+    public static var invalidTargetInstancesException: Self { .init(.invalidTargetInstancesException) }
+    public static var invalidTimeRangeException: Self { .init(.invalidTimeRangeException) }
+    public static var invalidTrafficRoutingConfigurationException: Self { .init(.invalidTrafficRoutingConfigurationException) }
+    public static var invalidTriggerConfigException: Self { .init(.invalidTriggerConfigException) }
+    public static var invalidUpdateOutdatedInstancesOnlyValueException: Self { .init(.invalidUpdateOutdatedInstancesOnlyValueException) }
+    public static var lifecycleEventAlreadyCompletedException: Self { .init(.lifecycleEventAlreadyCompletedException) }
+    public static var lifecycleHookLimitExceededException: Self { .init(.lifecycleHookLimitExceededException) }
+    public static var multipleIamArnsProvidedException: Self { .init(.multipleIamArnsProvidedException) }
+    public static var operationNotSupportedException: Self { .init(.operationNotSupportedException) }
+    public static var resourceArnRequiredException: Self { .init(.resourceArnRequiredException) }
+    public static var resourceValidationException: Self { .init(.resourceValidationException) }
+    public static var revisionDoesNotExistException: Self { .init(.revisionDoesNotExistException) }
+    public static var revisionRequiredException: Self { .init(.revisionRequiredException) }
+    public static var roleRequiredException: Self { .init(.roleRequiredException) }
+    public static var tagLimitExceededException: Self { .init(.tagLimitExceededException) }
+    public static var tagRequiredException: Self { .init(.tagRequiredException) }
+    public static var tagSetListLimitExceededException: Self { .init(.tagSetListLimitExceededException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+    public static var triggerTargetsLimitExceededException: Self { .init(.triggerTargetsLimitExceededException) }
+    public static var unsupportedActionForDeploymentTypeException: Self { .init(.unsupportedActionForDeploymentTypeException) }
+}
+
+extension CodeDeployErrorType: Equatable {
+    public static func == (lhs: CodeDeployErrorType, rhs: CodeDeployErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension CodeDeployErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .alarmsLimitExceededException(let message):
-            return "AlarmsLimitExceededException: \(message ?? "")"
-        case .applicationAlreadyExistsException(let message):
-            return "ApplicationAlreadyExistsException: \(message ?? "")"
-        case .applicationDoesNotExistException(let message):
-            return "ApplicationDoesNotExistException: \(message ?? "")"
-        case .applicationLimitExceededException(let message):
-            return "ApplicationLimitExceededException: \(message ?? "")"
-        case .applicationNameRequiredException(let message):
-            return "ApplicationNameRequiredException: \(message ?? "")"
-        case .arnNotSupportedException(let message):
-            return "ArnNotSupportedException: \(message ?? "")"
-        case .batchLimitExceededException(let message):
-            return "BatchLimitExceededException: \(message ?? "")"
-        case .bucketNameFilterRequiredException(let message):
-            return "BucketNameFilterRequiredException: \(message ?? "")"
-        case .deploymentAlreadyCompletedException(let message):
-            return "DeploymentAlreadyCompletedException: \(message ?? "")"
-        case .deploymentConfigAlreadyExistsException(let message):
-            return "DeploymentConfigAlreadyExistsException: \(message ?? "")"
-        case .deploymentConfigDoesNotExistException(let message):
-            return "DeploymentConfigDoesNotExistException: \(message ?? "")"
-        case .deploymentConfigInUseException(let message):
-            return "DeploymentConfigInUseException: \(message ?? "")"
-        case .deploymentConfigLimitExceededException(let message):
-            return "DeploymentConfigLimitExceededException: \(message ?? "")"
-        case .deploymentConfigNameRequiredException(let message):
-            return "DeploymentConfigNameRequiredException: \(message ?? "")"
-        case .deploymentDoesNotExistException(let message):
-            return "DeploymentDoesNotExistException: \(message ?? "")"
-        case .deploymentGroupAlreadyExistsException(let message):
-            return "DeploymentGroupAlreadyExistsException: \(message ?? "")"
-        case .deploymentGroupDoesNotExistException(let message):
-            return "DeploymentGroupDoesNotExistException: \(message ?? "")"
-        case .deploymentGroupLimitExceededException(let message):
-            return "DeploymentGroupLimitExceededException: \(message ?? "")"
-        case .deploymentGroupNameRequiredException(let message):
-            return "DeploymentGroupNameRequiredException: \(message ?? "")"
-        case .deploymentIdRequiredException(let message):
-            return "DeploymentIdRequiredException: \(message ?? "")"
-        case .deploymentIsNotInReadyStateException(let message):
-            return "DeploymentIsNotInReadyStateException: \(message ?? "")"
-        case .deploymentLimitExceededException(let message):
-            return "DeploymentLimitExceededException: \(message ?? "")"
-        case .deploymentNotStartedException(let message):
-            return "DeploymentNotStartedException: \(message ?? "")"
-        case .deploymentTargetDoesNotExistException(let message):
-            return "DeploymentTargetDoesNotExistException: \(message ?? "")"
-        case .deploymentTargetIdRequiredException(let message):
-            return "DeploymentTargetIdRequiredException: \(message ?? "")"
-        case .deploymentTargetListSizeExceededException(let message):
-            return "DeploymentTargetListSizeExceededException: \(message ?? "")"
-        case .descriptionTooLongException(let message):
-            return "DescriptionTooLongException: \(message ?? "")"
-        case .eCSServiceMappingLimitExceededException(let message):
-            return "ECSServiceMappingLimitExceededException: \(message ?? "")"
-        case .gitHubAccountTokenDoesNotExistException(let message):
-            return "GitHubAccountTokenDoesNotExistException: \(message ?? "")"
-        case .gitHubAccountTokenNameRequiredException(let message):
-            return "GitHubAccountTokenNameRequiredException: \(message ?? "")"
-        case .iamArnRequiredException(let message):
-            return "IamArnRequiredException: \(message ?? "")"
-        case .iamSessionArnAlreadyRegisteredException(let message):
-            return "IamSessionArnAlreadyRegisteredException: \(message ?? "")"
-        case .iamUserArnAlreadyRegisteredException(let message):
-            return "IamUserArnAlreadyRegisteredException: \(message ?? "")"
-        case .iamUserArnRequiredException(let message):
-            return "IamUserArnRequiredException: \(message ?? "")"
-        case .instanceDoesNotExistException(let message):
-            return "InstanceDoesNotExistException: \(message ?? "")"
-        case .instanceIdRequiredException(let message):
-            return "InstanceIdRequiredException: \(message ?? "")"
-        case .instanceLimitExceededException(let message):
-            return "InstanceLimitExceededException: \(message ?? "")"
-        case .instanceNameAlreadyRegisteredException(let message):
-            return "InstanceNameAlreadyRegisteredException: \(message ?? "")"
-        case .instanceNameRequiredException(let message):
-            return "InstanceNameRequiredException: \(message ?? "")"
-        case .instanceNotRegisteredException(let message):
-            return "InstanceNotRegisteredException: \(message ?? "")"
-        case .invalidAlarmConfigException(let message):
-            return "InvalidAlarmConfigException: \(message ?? "")"
-        case .invalidApplicationNameException(let message):
-            return "InvalidApplicationNameException: \(message ?? "")"
-        case .invalidArnException(let message):
-            return "InvalidArnException: \(message ?? "")"
-        case .invalidAutoRollbackConfigException(let message):
-            return "InvalidAutoRollbackConfigException: \(message ?? "")"
-        case .invalidAutoScalingGroupException(let message):
-            return "InvalidAutoScalingGroupException: \(message ?? "")"
-        case .invalidBlueGreenDeploymentConfigurationException(let message):
-            return "InvalidBlueGreenDeploymentConfigurationException: \(message ?? "")"
-        case .invalidBucketNameFilterException(let message):
-            return "InvalidBucketNameFilterException: \(message ?? "")"
-        case .invalidComputePlatformException(let message):
-            return "InvalidComputePlatformException: \(message ?? "")"
-        case .invalidDeployedStateFilterException(let message):
-            return "InvalidDeployedStateFilterException: \(message ?? "")"
-        case .invalidDeploymentConfigNameException(let message):
-            return "InvalidDeploymentConfigNameException: \(message ?? "")"
-        case .invalidDeploymentGroupNameException(let message):
-            return "InvalidDeploymentGroupNameException: \(message ?? "")"
-        case .invalidDeploymentIdException(let message):
-            return "InvalidDeploymentIdException: \(message ?? "")"
-        case .invalidDeploymentInstanceTypeException(let message):
-            return "InvalidDeploymentInstanceTypeException: \(message ?? "")"
-        case .invalidDeploymentStatusException(let message):
-            return "InvalidDeploymentStatusException: \(message ?? "")"
-        case .invalidDeploymentStyleException(let message):
-            return "InvalidDeploymentStyleException: \(message ?? "")"
-        case .invalidDeploymentTargetIdException(let message):
-            return "InvalidDeploymentTargetIdException: \(message ?? "")"
-        case .invalidDeploymentWaitTypeException(let message):
-            return "InvalidDeploymentWaitTypeException: \(message ?? "")"
-        case .invalidEC2TagCombinationException(let message):
-            return "InvalidEC2TagCombinationException: \(message ?? "")"
-        case .invalidEC2TagException(let message):
-            return "InvalidEC2TagException: \(message ?? "")"
-        case .invalidECSServiceException(let message):
-            return "InvalidECSServiceException: \(message ?? "")"
-        case .invalidExternalIdException(let message):
-            return "InvalidExternalIdException: \(message ?? "")"
-        case .invalidFileExistsBehaviorException(let message):
-            return "InvalidFileExistsBehaviorException: \(message ?? "")"
-        case .invalidGitHubAccountTokenException(let message):
-            return "InvalidGitHubAccountTokenException: \(message ?? "")"
-        case .invalidGitHubAccountTokenNameException(let message):
-            return "InvalidGitHubAccountTokenNameException: \(message ?? "")"
-        case .invalidIamSessionArnException(let message):
-            return "InvalidIamSessionArnException: \(message ?? "")"
-        case .invalidIamUserArnException(let message):
-            return "InvalidIamUserArnException: \(message ?? "")"
-        case .invalidIgnoreApplicationStopFailuresValueException(let message):
-            return "InvalidIgnoreApplicationStopFailuresValueException: \(message ?? "")"
-        case .invalidInputException(let message):
-            return "InvalidInputException: \(message ?? "")"
-        case .invalidInstanceNameException(let message):
-            return "InvalidInstanceNameException: \(message ?? "")"
-        case .invalidInstanceStatusException(let message):
-            return "InvalidInstanceStatusException: \(message ?? "")"
-        case .invalidInstanceTypeException(let message):
-            return "InvalidInstanceTypeException: \(message ?? "")"
-        case .invalidKeyPrefixFilterException(let message):
-            return "InvalidKeyPrefixFilterException: \(message ?? "")"
-        case .invalidLifecycleEventHookExecutionIdException(let message):
-            return "InvalidLifecycleEventHookExecutionIdException: \(message ?? "")"
-        case .invalidLifecycleEventHookExecutionStatusException(let message):
-            return "InvalidLifecycleEventHookExecutionStatusException: \(message ?? "")"
-        case .invalidLoadBalancerInfoException(let message):
-            return "InvalidLoadBalancerInfoException: \(message ?? "")"
-        case .invalidMinimumHealthyHostValueException(let message):
-            return "InvalidMinimumHealthyHostValueException: \(message ?? "")"
-        case .invalidNextTokenException(let message):
-            return "InvalidNextTokenException: \(message ?? "")"
-        case .invalidOnPremisesTagCombinationException(let message):
-            return "InvalidOnPremisesTagCombinationException: \(message ?? "")"
-        case .invalidOperationException(let message):
-            return "InvalidOperationException: \(message ?? "")"
-        case .invalidRegistrationStatusException(let message):
-            return "InvalidRegistrationStatusException: \(message ?? "")"
-        case .invalidRevisionException(let message):
-            return "InvalidRevisionException: \(message ?? "")"
-        case .invalidRoleException(let message):
-            return "InvalidRoleException: \(message ?? "")"
-        case .invalidSortByException(let message):
-            return "InvalidSortByException: \(message ?? "")"
-        case .invalidSortOrderException(let message):
-            return "InvalidSortOrderException: \(message ?? "")"
-        case .invalidTagException(let message):
-            return "InvalidTagException: \(message ?? "")"
-        case .invalidTagFilterException(let message):
-            return "InvalidTagFilterException: \(message ?? "")"
-        case .invalidTagsToAddException(let message):
-            return "InvalidTagsToAddException: \(message ?? "")"
-        case .invalidTargetFilterNameException(let message):
-            return "InvalidTargetFilterNameException: \(message ?? "")"
-        case .invalidTargetGroupPairException(let message):
-            return "InvalidTargetGroupPairException: \(message ?? "")"
-        case .invalidTargetInstancesException(let message):
-            return "InvalidTargetInstancesException: \(message ?? "")"
-        case .invalidTimeRangeException(let message):
-            return "InvalidTimeRangeException: \(message ?? "")"
-        case .invalidTrafficRoutingConfigurationException(let message):
-            return "InvalidTrafficRoutingConfigurationException: \(message ?? "")"
-        case .invalidTriggerConfigException(let message):
-            return "InvalidTriggerConfigException: \(message ?? "")"
-        case .invalidUpdateOutdatedInstancesOnlyValueException(let message):
-            return "InvalidUpdateOutdatedInstancesOnlyValueException: \(message ?? "")"
-        case .lifecycleEventAlreadyCompletedException(let message):
-            return "LifecycleEventAlreadyCompletedException: \(message ?? "")"
-        case .lifecycleHookLimitExceededException(let message):
-            return "LifecycleHookLimitExceededException: \(message ?? "")"
-        case .multipleIamArnsProvidedException(let message):
-            return "MultipleIamArnsProvidedException: \(message ?? "")"
-        case .operationNotSupportedException(let message):
-            return "OperationNotSupportedException: \(message ?? "")"
-        case .resourceArnRequiredException(let message):
-            return "ResourceArnRequiredException: \(message ?? "")"
-        case .resourceValidationException(let message):
-            return "ResourceValidationException: \(message ?? "")"
-        case .revisionDoesNotExistException(let message):
-            return "RevisionDoesNotExistException: \(message ?? "")"
-        case .revisionRequiredException(let message):
-            return "RevisionRequiredException: \(message ?? "")"
-        case .roleRequiredException(let message):
-            return "RoleRequiredException: \(message ?? "")"
-        case .tagLimitExceededException(let message):
-            return "TagLimitExceededException: \(message ?? "")"
-        case .tagRequiredException(let message):
-            return "TagRequiredException: \(message ?? "")"
-        case .tagSetListLimitExceededException(let message):
-            return "TagSetListLimitExceededException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        case .triggerTargetsLimitExceededException(let message):
-            return "TriggerTargetsLimitExceededException: \(message ?? "")"
-        case .unsupportedActionForDeploymentTypeException(let message):
-            return "UnsupportedActionForDeploymentTypeException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/CodeGuruProfiler/CodeGuruProfiler_Error.swift
+++ b/Sources/Soto/Services/CodeGuruProfiler/CodeGuruProfiler_Error.swift
@@ -17,55 +17,50 @@
 import SotoCore
 
 /// Error enum for CodeGuruProfiler
-public enum CodeGuruProfilerErrorType: AWSErrorType {
-    case conflictException(message: String?)
-    case internalServerException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceQuotaExceededException(message: String?)
-    case throttlingException(message: String?)
-    case validationException(message: String?)
-}
+public struct CodeGuruProfilerErrorType: AWSErrorType {
+    enum Code: String {
+        case conflictException = "ConflictException"
+        case internalServerException = "InternalServerException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceQuotaExceededException = "ServiceQuotaExceededException"
+        case throttlingException = "ThrottlingException"
+        case validationException = "ValidationException"
+    }
 
-extension CodeGuruProfilerErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceQuotaExceededException":
-            self = .serviceQuotaExceededException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceQuotaExceededException: Self { .init(.serviceQuotaExceededException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension CodeGuruProfilerErrorType: Equatable {
+    public static func == (lhs: CodeGuruProfilerErrorType, rhs: CodeGuruProfilerErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension CodeGuruProfilerErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceQuotaExceededException(let message):
-            return "ServiceQuotaExceededException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/CodeGuruReviewer/CodeGuruReviewer_Error.swift
+++ b/Sources/Soto/Services/CodeGuruReviewer/CodeGuruReviewer_Error.swift
@@ -17,60 +17,52 @@
 import SotoCore
 
 /// Error enum for CodeGuruReviewer
-public enum CodeGuruReviewerErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case conflictException(message: String?)
-    case internalServerException(message: String?)
-    case notFoundException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case throttlingException(message: String?)
-    case validationException(message: String?)
-}
+public struct CodeGuruReviewerErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case conflictException = "ConflictException"
+        case internalServerException = "InternalServerException"
+        case notFoundException = "NotFoundException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case throttlingException = "ThrottlingException"
+        case validationException = "ValidationException"
+    }
 
-extension CodeGuruReviewerErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension CodeGuruReviewerErrorType: Equatable {
+    public static func == (lhs: CodeGuruReviewerErrorType, rhs: CodeGuruReviewerErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension CodeGuruReviewerErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/CodePipeline/CodePipeline_Error.swift
+++ b/Sources/Soto/Services/CodePipeline/CodePipeline_Error.swift
@@ -17,195 +17,106 @@
 import SotoCore
 
 /// Error enum for CodePipeline
-public enum CodePipelineErrorType: AWSErrorType {
-    case actionNotFoundException(message: String?)
-    case actionTypeNotFoundException(message: String?)
-    case approvalAlreadyCompletedException(message: String?)
-    case concurrentModificationException(message: String?)
-    case duplicatedStopRequestException(message: String?)
-    case invalidActionDeclarationException(message: String?)
-    case invalidApprovalTokenException(message: String?)
-    case invalidArnException(message: String?)
-    case invalidBlockerDeclarationException(message: String?)
-    case invalidClientTokenException(message: String?)
-    case invalidJobException(message: String?)
-    case invalidJobStateException(message: String?)
-    case invalidNextTokenException(message: String?)
-    case invalidNonceException(message: String?)
-    case invalidStageDeclarationException(message: String?)
-    case invalidStructureException(message: String?)
-    case invalidTagsException(message: String?)
-    case invalidWebhookAuthenticationParametersException(message: String?)
-    case invalidWebhookFilterPatternException(message: String?)
-    case jobNotFoundException(message: String?)
-    case limitExceededException(message: String?)
-    case notLatestPipelineExecutionException(message: String?)
-    case outputVariablesSizeExceededException(message: String?)
-    case pipelineExecutionNotFoundException(message: String?)
-    case pipelineExecutionNotStoppableException(message: String?)
-    case pipelineNameInUseException(message: String?)
-    case pipelineNotFoundException(message: String?)
-    case pipelineVersionNotFoundException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case stageNotFoundException(message: String?)
-    case stageNotRetryableException(message: String?)
-    case tooManyTagsException(message: String?)
-    case validationException(message: String?)
-    case webhookNotFoundException(message: String?)
-}
+public struct CodePipelineErrorType: AWSErrorType {
+    enum Code: String {
+        case actionNotFoundException = "ActionNotFoundException"
+        case actionTypeNotFoundException = "ActionTypeNotFoundException"
+        case approvalAlreadyCompletedException = "ApprovalAlreadyCompletedException"
+        case concurrentModificationException = "ConcurrentModificationException"
+        case duplicatedStopRequestException = "DuplicatedStopRequestException"
+        case invalidActionDeclarationException = "InvalidActionDeclarationException"
+        case invalidApprovalTokenException = "InvalidApprovalTokenException"
+        case invalidArnException = "InvalidArnException"
+        case invalidBlockerDeclarationException = "InvalidBlockerDeclarationException"
+        case invalidClientTokenException = "InvalidClientTokenException"
+        case invalidJobException = "InvalidJobException"
+        case invalidJobStateException = "InvalidJobStateException"
+        case invalidNextTokenException = "InvalidNextTokenException"
+        case invalidNonceException = "InvalidNonceException"
+        case invalidStageDeclarationException = "InvalidStageDeclarationException"
+        case invalidStructureException = "InvalidStructureException"
+        case invalidTagsException = "InvalidTagsException"
+        case invalidWebhookAuthenticationParametersException = "InvalidWebhookAuthenticationParametersException"
+        case invalidWebhookFilterPatternException = "InvalidWebhookFilterPatternException"
+        case jobNotFoundException = "JobNotFoundException"
+        case limitExceededException = "LimitExceededException"
+        case notLatestPipelineExecutionException = "NotLatestPipelineExecutionException"
+        case outputVariablesSizeExceededException = "OutputVariablesSizeExceededException"
+        case pipelineExecutionNotFoundException = "PipelineExecutionNotFoundException"
+        case pipelineExecutionNotStoppableException = "PipelineExecutionNotStoppableException"
+        case pipelineNameInUseException = "PipelineNameInUseException"
+        case pipelineNotFoundException = "PipelineNotFoundException"
+        case pipelineVersionNotFoundException = "PipelineVersionNotFoundException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case stageNotFoundException = "StageNotFoundException"
+        case stageNotRetryableException = "StageNotRetryableException"
+        case tooManyTagsException = "TooManyTagsException"
+        case validationException = "ValidationException"
+        case webhookNotFoundException = "WebhookNotFoundException"
+    }
 
-extension CodePipelineErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ActionNotFoundException":
-            self = .actionNotFoundException(message: message)
-        case "ActionTypeNotFoundException":
-            self = .actionTypeNotFoundException(message: message)
-        case "ApprovalAlreadyCompletedException":
-            self = .approvalAlreadyCompletedException(message: message)
-        case "ConcurrentModificationException":
-            self = .concurrentModificationException(message: message)
-        case "DuplicatedStopRequestException":
-            self = .duplicatedStopRequestException(message: message)
-        case "InvalidActionDeclarationException":
-            self = .invalidActionDeclarationException(message: message)
-        case "InvalidApprovalTokenException":
-            self = .invalidApprovalTokenException(message: message)
-        case "InvalidArnException":
-            self = .invalidArnException(message: message)
-        case "InvalidBlockerDeclarationException":
-            self = .invalidBlockerDeclarationException(message: message)
-        case "InvalidClientTokenException":
-            self = .invalidClientTokenException(message: message)
-        case "InvalidJobException":
-            self = .invalidJobException(message: message)
-        case "InvalidJobStateException":
-            self = .invalidJobStateException(message: message)
-        case "InvalidNextTokenException":
-            self = .invalidNextTokenException(message: message)
-        case "InvalidNonceException":
-            self = .invalidNonceException(message: message)
-        case "InvalidStageDeclarationException":
-            self = .invalidStageDeclarationException(message: message)
-        case "InvalidStructureException":
-            self = .invalidStructureException(message: message)
-        case "InvalidTagsException":
-            self = .invalidTagsException(message: message)
-        case "InvalidWebhookAuthenticationParametersException":
-            self = .invalidWebhookAuthenticationParametersException(message: message)
-        case "InvalidWebhookFilterPatternException":
-            self = .invalidWebhookFilterPatternException(message: message)
-        case "JobNotFoundException":
-            self = .jobNotFoundException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "NotLatestPipelineExecutionException":
-            self = .notLatestPipelineExecutionException(message: message)
-        case "OutputVariablesSizeExceededException":
-            self = .outputVariablesSizeExceededException(message: message)
-        case "PipelineExecutionNotFoundException":
-            self = .pipelineExecutionNotFoundException(message: message)
-        case "PipelineExecutionNotStoppableException":
-            self = .pipelineExecutionNotStoppableException(message: message)
-        case "PipelineNameInUseException":
-            self = .pipelineNameInUseException(message: message)
-        case "PipelineNotFoundException":
-            self = .pipelineNotFoundException(message: message)
-        case "PipelineVersionNotFoundException":
-            self = .pipelineVersionNotFoundException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "StageNotFoundException":
-            self = .stageNotFoundException(message: message)
-        case "StageNotRetryableException":
-            self = .stageNotRetryableException(message: message)
-        case "TooManyTagsException":
-            self = .tooManyTagsException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        case "WebhookNotFoundException":
-            self = .webhookNotFoundException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var actionNotFoundException: Self { .init(.actionNotFoundException) }
+    public static var actionTypeNotFoundException: Self { .init(.actionTypeNotFoundException) }
+    public static var approvalAlreadyCompletedException: Self { .init(.approvalAlreadyCompletedException) }
+    public static var concurrentModificationException: Self { .init(.concurrentModificationException) }
+    public static var duplicatedStopRequestException: Self { .init(.duplicatedStopRequestException) }
+    public static var invalidActionDeclarationException: Self { .init(.invalidActionDeclarationException) }
+    public static var invalidApprovalTokenException: Self { .init(.invalidApprovalTokenException) }
+    public static var invalidArnException: Self { .init(.invalidArnException) }
+    public static var invalidBlockerDeclarationException: Self { .init(.invalidBlockerDeclarationException) }
+    public static var invalidClientTokenException: Self { .init(.invalidClientTokenException) }
+    public static var invalidJobException: Self { .init(.invalidJobException) }
+    public static var invalidJobStateException: Self { .init(.invalidJobStateException) }
+    public static var invalidNextTokenException: Self { .init(.invalidNextTokenException) }
+    public static var invalidNonceException: Self { .init(.invalidNonceException) }
+    public static var invalidStageDeclarationException: Self { .init(.invalidStageDeclarationException) }
+    public static var invalidStructureException: Self { .init(.invalidStructureException) }
+    public static var invalidTagsException: Self { .init(.invalidTagsException) }
+    public static var invalidWebhookAuthenticationParametersException: Self { .init(.invalidWebhookAuthenticationParametersException) }
+    public static var invalidWebhookFilterPatternException: Self { .init(.invalidWebhookFilterPatternException) }
+    public static var jobNotFoundException: Self { .init(.jobNotFoundException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var notLatestPipelineExecutionException: Self { .init(.notLatestPipelineExecutionException) }
+    public static var outputVariablesSizeExceededException: Self { .init(.outputVariablesSizeExceededException) }
+    public static var pipelineExecutionNotFoundException: Self { .init(.pipelineExecutionNotFoundException) }
+    public static var pipelineExecutionNotStoppableException: Self { .init(.pipelineExecutionNotStoppableException) }
+    public static var pipelineNameInUseException: Self { .init(.pipelineNameInUseException) }
+    public static var pipelineNotFoundException: Self { .init(.pipelineNotFoundException) }
+    public static var pipelineVersionNotFoundException: Self { .init(.pipelineVersionNotFoundException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var stageNotFoundException: Self { .init(.stageNotFoundException) }
+    public static var stageNotRetryableException: Self { .init(.stageNotRetryableException) }
+    public static var tooManyTagsException: Self { .init(.tooManyTagsException) }
+    public static var validationException: Self { .init(.validationException) }
+    public static var webhookNotFoundException: Self { .init(.webhookNotFoundException) }
+}
+
+extension CodePipelineErrorType: Equatable {
+    public static func == (lhs: CodePipelineErrorType, rhs: CodePipelineErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension CodePipelineErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .actionNotFoundException(let message):
-            return "ActionNotFoundException: \(message ?? "")"
-        case .actionTypeNotFoundException(let message):
-            return "ActionTypeNotFoundException: \(message ?? "")"
-        case .approvalAlreadyCompletedException(let message):
-            return "ApprovalAlreadyCompletedException: \(message ?? "")"
-        case .concurrentModificationException(let message):
-            return "ConcurrentModificationException: \(message ?? "")"
-        case .duplicatedStopRequestException(let message):
-            return "DuplicatedStopRequestException: \(message ?? "")"
-        case .invalidActionDeclarationException(let message):
-            return "InvalidActionDeclarationException: \(message ?? "")"
-        case .invalidApprovalTokenException(let message):
-            return "InvalidApprovalTokenException: \(message ?? "")"
-        case .invalidArnException(let message):
-            return "InvalidArnException: \(message ?? "")"
-        case .invalidBlockerDeclarationException(let message):
-            return "InvalidBlockerDeclarationException: \(message ?? "")"
-        case .invalidClientTokenException(let message):
-            return "InvalidClientTokenException: \(message ?? "")"
-        case .invalidJobException(let message):
-            return "InvalidJobException: \(message ?? "")"
-        case .invalidJobStateException(let message):
-            return "InvalidJobStateException: \(message ?? "")"
-        case .invalidNextTokenException(let message):
-            return "InvalidNextTokenException: \(message ?? "")"
-        case .invalidNonceException(let message):
-            return "InvalidNonceException: \(message ?? "")"
-        case .invalidStageDeclarationException(let message):
-            return "InvalidStageDeclarationException: \(message ?? "")"
-        case .invalidStructureException(let message):
-            return "InvalidStructureException: \(message ?? "")"
-        case .invalidTagsException(let message):
-            return "InvalidTagsException: \(message ?? "")"
-        case .invalidWebhookAuthenticationParametersException(let message):
-            return "InvalidWebhookAuthenticationParametersException: \(message ?? "")"
-        case .invalidWebhookFilterPatternException(let message):
-            return "InvalidWebhookFilterPatternException: \(message ?? "")"
-        case .jobNotFoundException(let message):
-            return "JobNotFoundException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .notLatestPipelineExecutionException(let message):
-            return "NotLatestPipelineExecutionException: \(message ?? "")"
-        case .outputVariablesSizeExceededException(let message):
-            return "OutputVariablesSizeExceededException: \(message ?? "")"
-        case .pipelineExecutionNotFoundException(let message):
-            return "PipelineExecutionNotFoundException: \(message ?? "")"
-        case .pipelineExecutionNotStoppableException(let message):
-            return "PipelineExecutionNotStoppableException: \(message ?? "")"
-        case .pipelineNameInUseException(let message):
-            return "PipelineNameInUseException: \(message ?? "")"
-        case .pipelineNotFoundException(let message):
-            return "PipelineNotFoundException: \(message ?? "")"
-        case .pipelineVersionNotFoundException(let message):
-            return "PipelineVersionNotFoundException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .stageNotFoundException(let message):
-            return "StageNotFoundException: \(message ?? "")"
-        case .stageNotRetryableException(let message):
-            return "StageNotRetryableException: \(message ?? "")"
-        case .tooManyTagsException(let message):
-            return "TooManyTagsException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        case .webhookNotFoundException(let message):
-            return "WebhookNotFoundException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/CodeStar/CodeStar_Error.swift
+++ b/Sources/Soto/Services/CodeStar/CodeStar_Error.swift
@@ -17,90 +17,64 @@
 import SotoCore
 
 /// Error enum for CodeStar
-public enum CodeStarErrorType: AWSErrorType {
-    case concurrentModificationException(message: String?)
-    case invalidNextTokenException(message: String?)
-    case invalidServiceRoleException(message: String?)
-    case limitExceededException(message: String?)
-    case projectAlreadyExistsException(message: String?)
-    case projectConfigurationException(message: String?)
-    case projectCreationFailedException(message: String?)
-    case projectNotFoundException(message: String?)
-    case teamMemberAlreadyAssociatedException(message: String?)
-    case teamMemberNotFoundException(message: String?)
-    case userProfileAlreadyExistsException(message: String?)
-    case userProfileNotFoundException(message: String?)
-    case validationException(message: String?)
-}
+public struct CodeStarErrorType: AWSErrorType {
+    enum Code: String {
+        case concurrentModificationException = "ConcurrentModificationException"
+        case invalidNextTokenException = "InvalidNextTokenException"
+        case invalidServiceRoleException = "InvalidServiceRoleException"
+        case limitExceededException = "LimitExceededException"
+        case projectAlreadyExistsException = "ProjectAlreadyExistsException"
+        case projectConfigurationException = "ProjectConfigurationException"
+        case projectCreationFailedException = "ProjectCreationFailedException"
+        case projectNotFoundException = "ProjectNotFoundException"
+        case teamMemberAlreadyAssociatedException = "TeamMemberAlreadyAssociatedException"
+        case teamMemberNotFoundException = "TeamMemberNotFoundException"
+        case userProfileAlreadyExistsException = "UserProfileAlreadyExistsException"
+        case userProfileNotFoundException = "UserProfileNotFoundException"
+        case validationException = "ValidationException"
+    }
 
-extension CodeStarErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ConcurrentModificationException":
-            self = .concurrentModificationException(message: message)
-        case "InvalidNextTokenException":
-            self = .invalidNextTokenException(message: message)
-        case "InvalidServiceRoleException":
-            self = .invalidServiceRoleException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ProjectAlreadyExistsException":
-            self = .projectAlreadyExistsException(message: message)
-        case "ProjectConfigurationException":
-            self = .projectConfigurationException(message: message)
-        case "ProjectCreationFailedException":
-            self = .projectCreationFailedException(message: message)
-        case "ProjectNotFoundException":
-            self = .projectNotFoundException(message: message)
-        case "TeamMemberAlreadyAssociatedException":
-            self = .teamMemberAlreadyAssociatedException(message: message)
-        case "TeamMemberNotFoundException":
-            self = .teamMemberNotFoundException(message: message)
-        case "UserProfileAlreadyExistsException":
-            self = .userProfileAlreadyExistsException(message: message)
-        case "UserProfileNotFoundException":
-            self = .userProfileNotFoundException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var concurrentModificationException: Self { .init(.concurrentModificationException) }
+    public static var invalidNextTokenException: Self { .init(.invalidNextTokenException) }
+    public static var invalidServiceRoleException: Self { .init(.invalidServiceRoleException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var projectAlreadyExistsException: Self { .init(.projectAlreadyExistsException) }
+    public static var projectConfigurationException: Self { .init(.projectConfigurationException) }
+    public static var projectCreationFailedException: Self { .init(.projectCreationFailedException) }
+    public static var projectNotFoundException: Self { .init(.projectNotFoundException) }
+    public static var teamMemberAlreadyAssociatedException: Self { .init(.teamMemberAlreadyAssociatedException) }
+    public static var teamMemberNotFoundException: Self { .init(.teamMemberNotFoundException) }
+    public static var userProfileAlreadyExistsException: Self { .init(.userProfileAlreadyExistsException) }
+    public static var userProfileNotFoundException: Self { .init(.userProfileNotFoundException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension CodeStarErrorType: Equatable {
+    public static func == (lhs: CodeStarErrorType, rhs: CodeStarErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension CodeStarErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .concurrentModificationException(let message):
-            return "ConcurrentModificationException: \(message ?? "")"
-        case .invalidNextTokenException(let message):
-            return "InvalidNextTokenException: \(message ?? "")"
-        case .invalidServiceRoleException(let message):
-            return "InvalidServiceRoleException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .projectAlreadyExistsException(let message):
-            return "ProjectAlreadyExistsException: \(message ?? "")"
-        case .projectConfigurationException(let message):
-            return "ProjectConfigurationException: \(message ?? "")"
-        case .projectCreationFailedException(let message):
-            return "ProjectCreationFailedException: \(message ?? "")"
-        case .projectNotFoundException(let message):
-            return "ProjectNotFoundException: \(message ?? "")"
-        case .teamMemberAlreadyAssociatedException(let message):
-            return "TeamMemberAlreadyAssociatedException: \(message ?? "")"
-        case .teamMemberNotFoundException(let message):
-            return "TeamMemberNotFoundException: \(message ?? "")"
-        case .userProfileAlreadyExistsException(let message):
-            return "UserProfileAlreadyExistsException: \(message ?? "")"
-        case .userProfileNotFoundException(let message):
-            return "UserProfileNotFoundException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/CodeStarNotifications/CodeStarNotifications_Error.swift
+++ b/Sources/Soto/Services/CodeStarNotifications/CodeStarNotifications_Error.swift
@@ -17,65 +17,54 @@
 import SotoCore
 
 /// Error enum for CodeStarNotifications
-public enum CodeStarNotificationsErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case concurrentModificationException(message: String?)
-    case configurationException(message: String?)
-    case invalidNextTokenException(message: String?)
-    case limitExceededException(message: String?)
-    case resourceAlreadyExistsException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case validationException(message: String?)
-}
+public struct CodeStarNotificationsErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case concurrentModificationException = "ConcurrentModificationException"
+        case configurationException = "ConfigurationException"
+        case invalidNextTokenException = "InvalidNextTokenException"
+        case limitExceededException = "LimitExceededException"
+        case resourceAlreadyExistsException = "ResourceAlreadyExistsException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case validationException = "ValidationException"
+    }
 
-extension CodeStarNotificationsErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "ConcurrentModificationException":
-            self = .concurrentModificationException(message: message)
-        case "ConfigurationException":
-            self = .configurationException(message: message)
-        case "InvalidNextTokenException":
-            self = .invalidNextTokenException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ResourceAlreadyExistsException":
-            self = .resourceAlreadyExistsException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var concurrentModificationException: Self { .init(.concurrentModificationException) }
+    public static var configurationException: Self { .init(.configurationException) }
+    public static var invalidNextTokenException: Self { .init(.invalidNextTokenException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var resourceAlreadyExistsException: Self { .init(.resourceAlreadyExistsException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension CodeStarNotificationsErrorType: Equatable {
+    public static func == (lhs: CodeStarNotificationsErrorType, rhs: CodeStarNotificationsErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension CodeStarNotificationsErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .concurrentModificationException(let message):
-            return "ConcurrentModificationException: \(message ?? "")"
-        case .configurationException(let message):
-            return "ConfigurationException: \(message ?? "")"
-        case .invalidNextTokenException(let message):
-            return "InvalidNextTokenException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .resourceAlreadyExistsException(let message):
-            return "ResourceAlreadyExistsException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/CodeStarconnections/CodeStarconnections_Error.swift
+++ b/Sources/Soto/Services/CodeStarconnections/CodeStarconnections_Error.swift
@@ -17,40 +17,44 @@
 import SotoCore
 
 /// Error enum for CodeStarconnections
-public enum CodeStarconnectionsErrorType: AWSErrorType {
-    case limitExceededException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case resourceUnavailableException(message: String?)
-}
+public struct CodeStarconnectionsErrorType: AWSErrorType {
+    enum Code: String {
+        case limitExceededException = "LimitExceededException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case resourceUnavailableException = "ResourceUnavailableException"
+    }
 
-extension CodeStarconnectionsErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ResourceUnavailableException":
-            self = .resourceUnavailableException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var resourceUnavailableException: Self { .init(.resourceUnavailableException) }
+}
+
+extension CodeStarconnectionsErrorType: Equatable {
+    public static func == (lhs: CodeStarconnectionsErrorType, rhs: CodeStarconnectionsErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension CodeStarconnectionsErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .resourceUnavailableException(let message):
-            return "ResourceUnavailableException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/CognitoIdentity/CognitoIdentity_Error.swift
+++ b/Sources/Soto/Services/CognitoIdentity/CognitoIdentity_Error.swift
@@ -17,80 +17,60 @@
 import SotoCore
 
 /// Error enum for CognitoIdentity
-public enum CognitoIdentityErrorType: AWSErrorType {
-    case concurrentModificationException(message: String?)
-    case developerUserAlreadyRegisteredException(message: String?)
-    case externalServiceException(message: String?)
-    case internalErrorException(message: String?)
-    case invalidIdentityPoolConfigurationException(message: String?)
-    case invalidParameterException(message: String?)
-    case limitExceededException(message: String?)
-    case notAuthorizedException(message: String?)
-    case resourceConflictException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case tooManyRequestsException(message: String?)
-}
+public struct CognitoIdentityErrorType: AWSErrorType {
+    enum Code: String {
+        case concurrentModificationException = "ConcurrentModificationException"
+        case developerUserAlreadyRegisteredException = "DeveloperUserAlreadyRegisteredException"
+        case externalServiceException = "ExternalServiceException"
+        case internalErrorException = "InternalErrorException"
+        case invalidIdentityPoolConfigurationException = "InvalidIdentityPoolConfigurationException"
+        case invalidParameterException = "InvalidParameterException"
+        case limitExceededException = "LimitExceededException"
+        case notAuthorizedException = "NotAuthorizedException"
+        case resourceConflictException = "ResourceConflictException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case tooManyRequestsException = "TooManyRequestsException"
+    }
 
-extension CognitoIdentityErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ConcurrentModificationException":
-            self = .concurrentModificationException(message: message)
-        case "DeveloperUserAlreadyRegisteredException":
-            self = .developerUserAlreadyRegisteredException(message: message)
-        case "ExternalServiceException":
-            self = .externalServiceException(message: message)
-        case "InternalErrorException":
-            self = .internalErrorException(message: message)
-        case "InvalidIdentityPoolConfigurationException":
-            self = .invalidIdentityPoolConfigurationException(message: message)
-        case "InvalidParameterException":
-            self = .invalidParameterException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "NotAuthorizedException":
-            self = .notAuthorizedException(message: message)
-        case "ResourceConflictException":
-            self = .resourceConflictException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "TooManyRequestsException":
-            self = .tooManyRequestsException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var concurrentModificationException: Self { .init(.concurrentModificationException) }
+    public static var developerUserAlreadyRegisteredException: Self { .init(.developerUserAlreadyRegisteredException) }
+    public static var externalServiceException: Self { .init(.externalServiceException) }
+    public static var internalErrorException: Self { .init(.internalErrorException) }
+    public static var invalidIdentityPoolConfigurationException: Self { .init(.invalidIdentityPoolConfigurationException) }
+    public static var invalidParameterException: Self { .init(.invalidParameterException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var notAuthorizedException: Self { .init(.notAuthorizedException) }
+    public static var resourceConflictException: Self { .init(.resourceConflictException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var tooManyRequestsException: Self { .init(.tooManyRequestsException) }
+}
+
+extension CognitoIdentityErrorType: Equatable {
+    public static func == (lhs: CognitoIdentityErrorType, rhs: CognitoIdentityErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension CognitoIdentityErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .concurrentModificationException(let message):
-            return "ConcurrentModificationException: \(message ?? "")"
-        case .developerUserAlreadyRegisteredException(let message):
-            return "DeveloperUserAlreadyRegisteredException: \(message ?? "")"
-        case .externalServiceException(let message):
-            return "ExternalServiceException: \(message ?? "")"
-        case .internalErrorException(let message):
-            return "InternalErrorException: \(message ?? "")"
-        case .invalidIdentityPoolConfigurationException(let message):
-            return "InvalidIdentityPoolConfigurationException: \(message ?? "")"
-        case .invalidParameterException(let message):
-            return "InvalidParameterException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .notAuthorizedException(let message):
-            return "NotAuthorizedException: \(message ?? "")"
-        case .resourceConflictException(let message):
-            return "ResourceConflictException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .tooManyRequestsException(let message):
-            return "TooManyRequestsException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/CognitoIdentityProvider/CognitoIdentityProvider_Error.swift
+++ b/Sources/Soto/Services/CognitoIdentityProvider/CognitoIdentityProvider_Error.swift
@@ -17,210 +17,112 @@
 import SotoCore
 
 /// Error enum for CognitoIdentityProvider
-public enum CognitoIdentityProviderErrorType: AWSErrorType {
-    case aliasExistsException(message: String?)
-    case codeDeliveryFailureException(message: String?)
-    case codeMismatchException(message: String?)
-    case concurrentModificationException(message: String?)
-    case duplicateProviderException(message: String?)
-    case enableSoftwareTokenMFAException(message: String?)
-    case expiredCodeException(message: String?)
-    case groupExistsException(message: String?)
-    case internalErrorException(message: String?)
-    case invalidEmailRoleAccessPolicyException(message: String?)
-    case invalidLambdaResponseException(message: String?)
-    case invalidOAuthFlowException(message: String?)
-    case invalidParameterException(message: String?)
-    case invalidPasswordException(message: String?)
-    case invalidSmsRoleAccessPolicyException(message: String?)
-    case invalidSmsRoleTrustRelationshipException(message: String?)
-    case invalidUserPoolConfigurationException(message: String?)
-    case limitExceededException(message: String?)
-    case mFAMethodNotFoundException(message: String?)
-    case notAuthorizedException(message: String?)
-    case passwordResetRequiredException(message: String?)
-    case preconditionNotMetException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case scopeDoesNotExistException(message: String?)
-    case softwareTokenMFANotFoundException(message: String?)
-    case tooManyFailedAttemptsException(message: String?)
-    case tooManyRequestsException(message: String?)
-    case unexpectedLambdaException(message: String?)
-    case unsupportedIdentityProviderException(message: String?)
-    case unsupportedUserStateException(message: String?)
-    case userImportInProgressException(message: String?)
-    case userLambdaValidationException(message: String?)
-    case userNotConfirmedException(message: String?)
-    case userNotFoundException(message: String?)
-    case userPoolAddOnNotEnabledException(message: String?)
-    case userPoolTaggingException(message: String?)
-    case usernameExistsException(message: String?)
-}
+public struct CognitoIdentityProviderErrorType: AWSErrorType {
+    enum Code: String {
+        case aliasExistsException = "AliasExistsException"
+        case codeDeliveryFailureException = "CodeDeliveryFailureException"
+        case codeMismatchException = "CodeMismatchException"
+        case concurrentModificationException = "ConcurrentModificationException"
+        case duplicateProviderException = "DuplicateProviderException"
+        case enableSoftwareTokenMFAException = "EnableSoftwareTokenMFAException"
+        case expiredCodeException = "ExpiredCodeException"
+        case groupExistsException = "GroupExistsException"
+        case internalErrorException = "InternalErrorException"
+        case invalidEmailRoleAccessPolicyException = "InvalidEmailRoleAccessPolicyException"
+        case invalidLambdaResponseException = "InvalidLambdaResponseException"
+        case invalidOAuthFlowException = "InvalidOAuthFlowException"
+        case invalidParameterException = "InvalidParameterException"
+        case invalidPasswordException = "InvalidPasswordException"
+        case invalidSmsRoleAccessPolicyException = "InvalidSmsRoleAccessPolicyException"
+        case invalidSmsRoleTrustRelationshipException = "InvalidSmsRoleTrustRelationshipException"
+        case invalidUserPoolConfigurationException = "InvalidUserPoolConfigurationException"
+        case limitExceededException = "LimitExceededException"
+        case mFAMethodNotFoundException = "MFAMethodNotFoundException"
+        case notAuthorizedException = "NotAuthorizedException"
+        case passwordResetRequiredException = "PasswordResetRequiredException"
+        case preconditionNotMetException = "PreconditionNotMetException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case scopeDoesNotExistException = "ScopeDoesNotExistException"
+        case softwareTokenMFANotFoundException = "SoftwareTokenMFANotFoundException"
+        case tooManyFailedAttemptsException = "TooManyFailedAttemptsException"
+        case tooManyRequestsException = "TooManyRequestsException"
+        case unexpectedLambdaException = "UnexpectedLambdaException"
+        case unsupportedIdentityProviderException = "UnsupportedIdentityProviderException"
+        case unsupportedUserStateException = "UnsupportedUserStateException"
+        case userImportInProgressException = "UserImportInProgressException"
+        case userLambdaValidationException = "UserLambdaValidationException"
+        case userNotConfirmedException = "UserNotConfirmedException"
+        case userNotFoundException = "UserNotFoundException"
+        case userPoolAddOnNotEnabledException = "UserPoolAddOnNotEnabledException"
+        case userPoolTaggingException = "UserPoolTaggingException"
+        case usernameExistsException = "UsernameExistsException"
+    }
 
-extension CognitoIdentityProviderErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AliasExistsException":
-            self = .aliasExistsException(message: message)
-        case "CodeDeliveryFailureException":
-            self = .codeDeliveryFailureException(message: message)
-        case "CodeMismatchException":
-            self = .codeMismatchException(message: message)
-        case "ConcurrentModificationException":
-            self = .concurrentModificationException(message: message)
-        case "DuplicateProviderException":
-            self = .duplicateProviderException(message: message)
-        case "EnableSoftwareTokenMFAException":
-            self = .enableSoftwareTokenMFAException(message: message)
-        case "ExpiredCodeException":
-            self = .expiredCodeException(message: message)
-        case "GroupExistsException":
-            self = .groupExistsException(message: message)
-        case "InternalErrorException":
-            self = .internalErrorException(message: message)
-        case "InvalidEmailRoleAccessPolicyException":
-            self = .invalidEmailRoleAccessPolicyException(message: message)
-        case "InvalidLambdaResponseException":
-            self = .invalidLambdaResponseException(message: message)
-        case "InvalidOAuthFlowException":
-            self = .invalidOAuthFlowException(message: message)
-        case "InvalidParameterException":
-            self = .invalidParameterException(message: message)
-        case "InvalidPasswordException":
-            self = .invalidPasswordException(message: message)
-        case "InvalidSmsRoleAccessPolicyException":
-            self = .invalidSmsRoleAccessPolicyException(message: message)
-        case "InvalidSmsRoleTrustRelationshipException":
-            self = .invalidSmsRoleTrustRelationshipException(message: message)
-        case "InvalidUserPoolConfigurationException":
-            self = .invalidUserPoolConfigurationException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "MFAMethodNotFoundException":
-            self = .mFAMethodNotFoundException(message: message)
-        case "NotAuthorizedException":
-            self = .notAuthorizedException(message: message)
-        case "PasswordResetRequiredException":
-            self = .passwordResetRequiredException(message: message)
-        case "PreconditionNotMetException":
-            self = .preconditionNotMetException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ScopeDoesNotExistException":
-            self = .scopeDoesNotExistException(message: message)
-        case "SoftwareTokenMFANotFoundException":
-            self = .softwareTokenMFANotFoundException(message: message)
-        case "TooManyFailedAttemptsException":
-            self = .tooManyFailedAttemptsException(message: message)
-        case "TooManyRequestsException":
-            self = .tooManyRequestsException(message: message)
-        case "UnexpectedLambdaException":
-            self = .unexpectedLambdaException(message: message)
-        case "UnsupportedIdentityProviderException":
-            self = .unsupportedIdentityProviderException(message: message)
-        case "UnsupportedUserStateException":
-            self = .unsupportedUserStateException(message: message)
-        case "UserImportInProgressException":
-            self = .userImportInProgressException(message: message)
-        case "UserLambdaValidationException":
-            self = .userLambdaValidationException(message: message)
-        case "UserNotConfirmedException":
-            self = .userNotConfirmedException(message: message)
-        case "UserNotFoundException":
-            self = .userNotFoundException(message: message)
-        case "UserPoolAddOnNotEnabledException":
-            self = .userPoolAddOnNotEnabledException(message: message)
-        case "UserPoolTaggingException":
-            self = .userPoolTaggingException(message: message)
-        case "UsernameExistsException":
-            self = .usernameExistsException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var aliasExistsException: Self { .init(.aliasExistsException) }
+    public static var codeDeliveryFailureException: Self { .init(.codeDeliveryFailureException) }
+    public static var codeMismatchException: Self { .init(.codeMismatchException) }
+    public static var concurrentModificationException: Self { .init(.concurrentModificationException) }
+    public static var duplicateProviderException: Self { .init(.duplicateProviderException) }
+    public static var enableSoftwareTokenMFAException: Self { .init(.enableSoftwareTokenMFAException) }
+    public static var expiredCodeException: Self { .init(.expiredCodeException) }
+    public static var groupExistsException: Self { .init(.groupExistsException) }
+    public static var internalErrorException: Self { .init(.internalErrorException) }
+    public static var invalidEmailRoleAccessPolicyException: Self { .init(.invalidEmailRoleAccessPolicyException) }
+    public static var invalidLambdaResponseException: Self { .init(.invalidLambdaResponseException) }
+    public static var invalidOAuthFlowException: Self { .init(.invalidOAuthFlowException) }
+    public static var invalidParameterException: Self { .init(.invalidParameterException) }
+    public static var invalidPasswordException: Self { .init(.invalidPasswordException) }
+    public static var invalidSmsRoleAccessPolicyException: Self { .init(.invalidSmsRoleAccessPolicyException) }
+    public static var invalidSmsRoleTrustRelationshipException: Self { .init(.invalidSmsRoleTrustRelationshipException) }
+    public static var invalidUserPoolConfigurationException: Self { .init(.invalidUserPoolConfigurationException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var mFAMethodNotFoundException: Self { .init(.mFAMethodNotFoundException) }
+    public static var notAuthorizedException: Self { .init(.notAuthorizedException) }
+    public static var passwordResetRequiredException: Self { .init(.passwordResetRequiredException) }
+    public static var preconditionNotMetException: Self { .init(.preconditionNotMetException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var scopeDoesNotExistException: Self { .init(.scopeDoesNotExistException) }
+    public static var softwareTokenMFANotFoundException: Self { .init(.softwareTokenMFANotFoundException) }
+    public static var tooManyFailedAttemptsException: Self { .init(.tooManyFailedAttemptsException) }
+    public static var tooManyRequestsException: Self { .init(.tooManyRequestsException) }
+    public static var unexpectedLambdaException: Self { .init(.unexpectedLambdaException) }
+    public static var unsupportedIdentityProviderException: Self { .init(.unsupportedIdentityProviderException) }
+    public static var unsupportedUserStateException: Self { .init(.unsupportedUserStateException) }
+    public static var userImportInProgressException: Self { .init(.userImportInProgressException) }
+    public static var userLambdaValidationException: Self { .init(.userLambdaValidationException) }
+    public static var userNotConfirmedException: Self { .init(.userNotConfirmedException) }
+    public static var userNotFoundException: Self { .init(.userNotFoundException) }
+    public static var userPoolAddOnNotEnabledException: Self { .init(.userPoolAddOnNotEnabledException) }
+    public static var userPoolTaggingException: Self { .init(.userPoolTaggingException) }
+    public static var usernameExistsException: Self { .init(.usernameExistsException) }
+}
+
+extension CognitoIdentityProviderErrorType: Equatable {
+    public static func == (lhs: CognitoIdentityProviderErrorType, rhs: CognitoIdentityProviderErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension CognitoIdentityProviderErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .aliasExistsException(let message):
-            return "AliasExistsException: \(message ?? "")"
-        case .codeDeliveryFailureException(let message):
-            return "CodeDeliveryFailureException: \(message ?? "")"
-        case .codeMismatchException(let message):
-            return "CodeMismatchException: \(message ?? "")"
-        case .concurrentModificationException(let message):
-            return "ConcurrentModificationException: \(message ?? "")"
-        case .duplicateProviderException(let message):
-            return "DuplicateProviderException: \(message ?? "")"
-        case .enableSoftwareTokenMFAException(let message):
-            return "EnableSoftwareTokenMFAException: \(message ?? "")"
-        case .expiredCodeException(let message):
-            return "ExpiredCodeException: \(message ?? "")"
-        case .groupExistsException(let message):
-            return "GroupExistsException: \(message ?? "")"
-        case .internalErrorException(let message):
-            return "InternalErrorException: \(message ?? "")"
-        case .invalidEmailRoleAccessPolicyException(let message):
-            return "InvalidEmailRoleAccessPolicyException: \(message ?? "")"
-        case .invalidLambdaResponseException(let message):
-            return "InvalidLambdaResponseException: \(message ?? "")"
-        case .invalidOAuthFlowException(let message):
-            return "InvalidOAuthFlowException: \(message ?? "")"
-        case .invalidParameterException(let message):
-            return "InvalidParameterException: \(message ?? "")"
-        case .invalidPasswordException(let message):
-            return "InvalidPasswordException: \(message ?? "")"
-        case .invalidSmsRoleAccessPolicyException(let message):
-            return "InvalidSmsRoleAccessPolicyException: \(message ?? "")"
-        case .invalidSmsRoleTrustRelationshipException(let message):
-            return "InvalidSmsRoleTrustRelationshipException: \(message ?? "")"
-        case .invalidUserPoolConfigurationException(let message):
-            return "InvalidUserPoolConfigurationException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .mFAMethodNotFoundException(let message):
-            return "MFAMethodNotFoundException: \(message ?? "")"
-        case .notAuthorizedException(let message):
-            return "NotAuthorizedException: \(message ?? "")"
-        case .passwordResetRequiredException(let message):
-            return "PasswordResetRequiredException: \(message ?? "")"
-        case .preconditionNotMetException(let message):
-            return "PreconditionNotMetException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .scopeDoesNotExistException(let message):
-            return "ScopeDoesNotExistException: \(message ?? "")"
-        case .softwareTokenMFANotFoundException(let message):
-            return "SoftwareTokenMFANotFoundException: \(message ?? "")"
-        case .tooManyFailedAttemptsException(let message):
-            return "TooManyFailedAttemptsException: \(message ?? "")"
-        case .tooManyRequestsException(let message):
-            return "TooManyRequestsException: \(message ?? "")"
-        case .unexpectedLambdaException(let message):
-            return "UnexpectedLambdaException: \(message ?? "")"
-        case .unsupportedIdentityProviderException(let message):
-            return "UnsupportedIdentityProviderException: \(message ?? "")"
-        case .unsupportedUserStateException(let message):
-            return "UnsupportedUserStateException: \(message ?? "")"
-        case .userImportInProgressException(let message):
-            return "UserImportInProgressException: \(message ?? "")"
-        case .userLambdaValidationException(let message):
-            return "UserLambdaValidationException: \(message ?? "")"
-        case .userNotConfirmedException(let message):
-            return "UserNotConfirmedException: \(message ?? "")"
-        case .userNotFoundException(let message):
-            return "UserNotFoundException: \(message ?? "")"
-        case .userPoolAddOnNotEnabledException(let message):
-            return "UserPoolAddOnNotEnabledException: \(message ?? "")"
-        case .userPoolTaggingException(let message):
-            return "UserPoolTaggingException: \(message ?? "")"
-        case .usernameExistsException(let message):
-            return "UsernameExistsException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/CognitoSync/CognitoSync_Error.swift
+++ b/Sources/Soto/Services/CognitoSync/CognitoSync_Error.swift
@@ -17,90 +17,64 @@
 import SotoCore
 
 /// Error enum for CognitoSync
-public enum CognitoSyncErrorType: AWSErrorType {
-    case alreadyStreamedException(message: String?)
-    case concurrentModificationException(message: String?)
-    case duplicateRequestException(message: String?)
-    case internalErrorException(message: String?)
-    case invalidConfigurationException(message: String?)
-    case invalidLambdaFunctionOutputException(message: String?)
-    case invalidParameterException(message: String?)
-    case lambdaThrottledException(message: String?)
-    case limitExceededException(message: String?)
-    case notAuthorizedException(message: String?)
-    case resourceConflictException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case tooManyRequestsException(message: String?)
-}
+public struct CognitoSyncErrorType: AWSErrorType {
+    enum Code: String {
+        case alreadyStreamedException = "AlreadyStreamed"
+        case concurrentModificationException = "ConcurrentModification"
+        case duplicateRequestException = "DuplicateRequest"
+        case internalErrorException = "InternalError"
+        case invalidConfigurationException = "InvalidConfiguration"
+        case invalidLambdaFunctionOutputException = "InvalidLambdaFunctionOutput"
+        case invalidParameterException = "InvalidParameter"
+        case lambdaThrottledException = "LambdaThrottled"
+        case limitExceededException = "LimitExceeded"
+        case notAuthorizedException = "NotAuthorizedError"
+        case resourceConflictException = "ResourceConflict"
+        case resourceNotFoundException = "ResourceNotFound"
+        case tooManyRequestsException = "TooManyRequests"
+    }
 
-extension CognitoSyncErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AlreadyStreamed":
-            self = .alreadyStreamedException(message: message)
-        case "ConcurrentModification":
-            self = .concurrentModificationException(message: message)
-        case "DuplicateRequest":
-            self = .duplicateRequestException(message: message)
-        case "InternalError":
-            self = .internalErrorException(message: message)
-        case "InvalidConfiguration":
-            self = .invalidConfigurationException(message: message)
-        case "InvalidLambdaFunctionOutput":
-            self = .invalidLambdaFunctionOutputException(message: message)
-        case "InvalidParameter":
-            self = .invalidParameterException(message: message)
-        case "LambdaThrottled":
-            self = .lambdaThrottledException(message: message)
-        case "LimitExceeded":
-            self = .limitExceededException(message: message)
-        case "NotAuthorizedError":
-            self = .notAuthorizedException(message: message)
-        case "ResourceConflict":
-            self = .resourceConflictException(message: message)
-        case "ResourceNotFound":
-            self = .resourceNotFoundException(message: message)
-        case "TooManyRequests":
-            self = .tooManyRequestsException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var alreadyStreamedException: Self { .init(.alreadyStreamedException) }
+    public static var concurrentModificationException: Self { .init(.concurrentModificationException) }
+    public static var duplicateRequestException: Self { .init(.duplicateRequestException) }
+    public static var internalErrorException: Self { .init(.internalErrorException) }
+    public static var invalidConfigurationException: Self { .init(.invalidConfigurationException) }
+    public static var invalidLambdaFunctionOutputException: Self { .init(.invalidLambdaFunctionOutputException) }
+    public static var invalidParameterException: Self { .init(.invalidParameterException) }
+    public static var lambdaThrottledException: Self { .init(.lambdaThrottledException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var notAuthorizedException: Self { .init(.notAuthorizedException) }
+    public static var resourceConflictException: Self { .init(.resourceConflictException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var tooManyRequestsException: Self { .init(.tooManyRequestsException) }
+}
+
+extension CognitoSyncErrorType: Equatable {
+    public static func == (lhs: CognitoSyncErrorType, rhs: CognitoSyncErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension CognitoSyncErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .alreadyStreamedException(let message):
-            return "AlreadyStreamed: \(message ?? "")"
-        case .concurrentModificationException(let message):
-            return "ConcurrentModification: \(message ?? "")"
-        case .duplicateRequestException(let message):
-            return "DuplicateRequest: \(message ?? "")"
-        case .internalErrorException(let message):
-            return "InternalError: \(message ?? "")"
-        case .invalidConfigurationException(let message):
-            return "InvalidConfiguration: \(message ?? "")"
-        case .invalidLambdaFunctionOutputException(let message):
-            return "InvalidLambdaFunctionOutput: \(message ?? "")"
-        case .invalidParameterException(let message):
-            return "InvalidParameter: \(message ?? "")"
-        case .lambdaThrottledException(let message):
-            return "LambdaThrottled: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceeded: \(message ?? "")"
-        case .notAuthorizedException(let message):
-            return "NotAuthorizedError: \(message ?? "")"
-        case .resourceConflictException(let message):
-            return "ResourceConflict: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFound: \(message ?? "")"
-        case .tooManyRequestsException(let message):
-            return "TooManyRequests: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Comprehend/Comprehend_Error.swift
+++ b/Sources/Soto/Services/Comprehend/Comprehend_Error.swift
@@ -17,105 +17,70 @@
 import SotoCore
 
 /// Error enum for Comprehend
-public enum ComprehendErrorType: AWSErrorType {
-    case batchSizeLimitExceededException(message: String?)
-    case concurrentModificationException(message: String?)
-    case internalServerException(message: String?)
-    case invalidFilterException(message: String?)
-    case invalidRequestException(message: String?)
-    case jobNotFoundException(message: String?)
-    case kmsKeyValidationException(message: String?)
-    case resourceInUseException(message: String?)
-    case resourceLimitExceededException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case resourceUnavailableException(message: String?)
-    case textSizeLimitExceededException(message: String?)
-    case tooManyRequestsException(message: String?)
-    case tooManyTagKeysException(message: String?)
-    case tooManyTagsException(message: String?)
-    case unsupportedLanguageException(message: String?)
-}
+public struct ComprehendErrorType: AWSErrorType {
+    enum Code: String {
+        case batchSizeLimitExceededException = "BatchSizeLimitExceededException"
+        case concurrentModificationException = "ConcurrentModificationException"
+        case internalServerException = "InternalServerException"
+        case invalidFilterException = "InvalidFilterException"
+        case invalidRequestException = "InvalidRequestException"
+        case jobNotFoundException = "JobNotFoundException"
+        case kmsKeyValidationException = "KmsKeyValidationException"
+        case resourceInUseException = "ResourceInUseException"
+        case resourceLimitExceededException = "ResourceLimitExceededException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case resourceUnavailableException = "ResourceUnavailableException"
+        case textSizeLimitExceededException = "TextSizeLimitExceededException"
+        case tooManyRequestsException = "TooManyRequestsException"
+        case tooManyTagKeysException = "TooManyTagKeysException"
+        case tooManyTagsException = "TooManyTagsException"
+        case unsupportedLanguageException = "UnsupportedLanguageException"
+    }
 
-extension ComprehendErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "BatchSizeLimitExceededException":
-            self = .batchSizeLimitExceededException(message: message)
-        case "ConcurrentModificationException":
-            self = .concurrentModificationException(message: message)
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "InvalidFilterException":
-            self = .invalidFilterException(message: message)
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        case "JobNotFoundException":
-            self = .jobNotFoundException(message: message)
-        case "KmsKeyValidationException":
-            self = .kmsKeyValidationException(message: message)
-        case "ResourceInUseException":
-            self = .resourceInUseException(message: message)
-        case "ResourceLimitExceededException":
-            self = .resourceLimitExceededException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ResourceUnavailableException":
-            self = .resourceUnavailableException(message: message)
-        case "TextSizeLimitExceededException":
-            self = .textSizeLimitExceededException(message: message)
-        case "TooManyRequestsException":
-            self = .tooManyRequestsException(message: message)
-        case "TooManyTagKeysException":
-            self = .tooManyTagKeysException(message: message)
-        case "TooManyTagsException":
-            self = .tooManyTagsException(message: message)
-        case "UnsupportedLanguageException":
-            self = .unsupportedLanguageException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var batchSizeLimitExceededException: Self { .init(.batchSizeLimitExceededException) }
+    public static var concurrentModificationException: Self { .init(.concurrentModificationException) }
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var invalidFilterException: Self { .init(.invalidFilterException) }
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+    public static var jobNotFoundException: Self { .init(.jobNotFoundException) }
+    public static var kmsKeyValidationException: Self { .init(.kmsKeyValidationException) }
+    public static var resourceInUseException: Self { .init(.resourceInUseException) }
+    public static var resourceLimitExceededException: Self { .init(.resourceLimitExceededException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var resourceUnavailableException: Self { .init(.resourceUnavailableException) }
+    public static var textSizeLimitExceededException: Self { .init(.textSizeLimitExceededException) }
+    public static var tooManyRequestsException: Self { .init(.tooManyRequestsException) }
+    public static var tooManyTagKeysException: Self { .init(.tooManyTagKeysException) }
+    public static var tooManyTagsException: Self { .init(.tooManyTagsException) }
+    public static var unsupportedLanguageException: Self { .init(.unsupportedLanguageException) }
+}
+
+extension ComprehendErrorType: Equatable {
+    public static func == (lhs: ComprehendErrorType, rhs: ComprehendErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ComprehendErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .batchSizeLimitExceededException(let message):
-            return "BatchSizeLimitExceededException: \(message ?? "")"
-        case .concurrentModificationException(let message):
-            return "ConcurrentModificationException: \(message ?? "")"
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .invalidFilterException(let message):
-            return "InvalidFilterException: \(message ?? "")"
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        case .jobNotFoundException(let message):
-            return "JobNotFoundException: \(message ?? "")"
-        case .kmsKeyValidationException(let message):
-            return "KmsKeyValidationException: \(message ?? "")"
-        case .resourceInUseException(let message):
-            return "ResourceInUseException: \(message ?? "")"
-        case .resourceLimitExceededException(let message):
-            return "ResourceLimitExceededException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .resourceUnavailableException(let message):
-            return "ResourceUnavailableException: \(message ?? "")"
-        case .textSizeLimitExceededException(let message):
-            return "TextSizeLimitExceededException: \(message ?? "")"
-        case .tooManyRequestsException(let message):
-            return "TooManyRequestsException: \(message ?? "")"
-        case .tooManyTagKeysException(let message):
-            return "TooManyTagKeysException: \(message ?? "")"
-        case .tooManyTagsException(let message):
-            return "TooManyTagsException: \(message ?? "")"
-        case .unsupportedLanguageException(let message):
-            return "UnsupportedLanguageException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/ComprehendMedical/ComprehendMedical_Error.swift
+++ b/Sources/Soto/Services/ComprehendMedical/ComprehendMedical_Error.swift
@@ -17,65 +17,54 @@
 import SotoCore
 
 /// Error enum for ComprehendMedical
-public enum ComprehendMedicalErrorType: AWSErrorType {
-    case internalServerException(message: String?)
-    case invalidEncodingException(message: String?)
-    case invalidRequestException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceUnavailableException(message: String?)
-    case textSizeLimitExceededException(message: String?)
-    case tooManyRequestsException(message: String?)
-    case validationException(message: String?)
-}
+public struct ComprehendMedicalErrorType: AWSErrorType {
+    enum Code: String {
+        case internalServerException = "InternalServerException"
+        case invalidEncodingException = "InvalidEncodingException"
+        case invalidRequestException = "InvalidRequestException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+        case textSizeLimitExceededException = "TextSizeLimitExceededException"
+        case tooManyRequestsException = "TooManyRequestsException"
+        case validationException = "ValidationException"
+    }
 
-extension ComprehendMedicalErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "InvalidEncodingException":
-            self = .invalidEncodingException(message: message)
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        case "TextSizeLimitExceededException":
-            self = .textSizeLimitExceededException(message: message)
-        case "TooManyRequestsException":
-            self = .tooManyRequestsException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var invalidEncodingException: Self { .init(.invalidEncodingException) }
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+    public static var textSizeLimitExceededException: Self { .init(.textSizeLimitExceededException) }
+    public static var tooManyRequestsException: Self { .init(.tooManyRequestsException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension ComprehendMedicalErrorType: Equatable {
+    public static func == (lhs: ComprehendMedicalErrorType, rhs: ComprehendMedicalErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ComprehendMedicalErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .invalidEncodingException(let message):
-            return "InvalidEncodingException: \(message ?? "")"
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        case .textSizeLimitExceededException(let message):
-            return "TextSizeLimitExceededException: \(message ?? "")"
-        case .tooManyRequestsException(let message):
-            return "TooManyRequestsException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/ComputeOptimizer/ComputeOptimizer_Error.swift
+++ b/Sources/Soto/Services/ComputeOptimizer/ComputeOptimizer_Error.swift
@@ -17,70 +17,56 @@
 import SotoCore
 
 /// Error enum for ComputeOptimizer
-public enum ComputeOptimizerErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case internalServerException(message: String?)
-    case invalidParameterValueException(message: String?)
-    case limitExceededException(message: String?)
-    case missingAuthenticationToken(message: String?)
-    case optInRequiredException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceUnavailableException(message: String?)
-    case throttlingException(message: String?)
-}
+public struct ComputeOptimizerErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case internalServerException = "InternalServerException"
+        case invalidParameterValueException = "InvalidParameterValueException"
+        case limitExceededException = "LimitExceededException"
+        case missingAuthenticationToken = "MissingAuthenticationToken"
+        case optInRequiredException = "OptInRequiredException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+        case throttlingException = "ThrottlingException"
+    }
 
-extension ComputeOptimizerErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "InvalidParameterValueException":
-            self = .invalidParameterValueException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "MissingAuthenticationToken":
-            self = .missingAuthenticationToken(message: message)
-        case "OptInRequiredException":
-            self = .optInRequiredException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var invalidParameterValueException: Self { .init(.invalidParameterValueException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var missingAuthenticationToken: Self { .init(.missingAuthenticationToken) }
+    public static var optInRequiredException: Self { .init(.optInRequiredException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+}
+
+extension ComputeOptimizerErrorType: Equatable {
+    public static func == (lhs: ComputeOptimizerErrorType, rhs: ComputeOptimizerErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ComputeOptimizerErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .invalidParameterValueException(let message):
-            return "InvalidParameterValueException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .missingAuthenticationToken(let message):
-            return "MissingAuthenticationToken: \(message ?? "")"
-        case .optInRequiredException(let message):
-            return "OptInRequiredException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/ConfigService/ConfigService_Error.swift
+++ b/Sources/Soto/Services/ConfigService/ConfigService_Error.swift
@@ -17,280 +17,140 @@
 import SotoCore
 
 /// Error enum for ConfigService
-public enum ConfigServiceErrorType: AWSErrorType {
-    case conformancePackTemplateValidationException(message: String?)
-    case insufficientDeliveryPolicyException(message: String?)
-    case insufficientPermissionsException(message: String?)
-    case invalidConfigurationRecorderNameException(message: String?)
-    case invalidDeliveryChannelNameException(message: String?)
-    case invalidExpressionException(message: String?)
-    case invalidLimitException(message: String?)
-    case invalidNextTokenException(message: String?)
-    case invalidParameterValueException(message: String?)
-    case invalidRecordingGroupException(message: String?)
-    case invalidResultTokenException(message: String?)
-    case invalidRoleException(message: String?)
-    case invalidS3KeyPrefixException(message: String?)
-    case invalidSNSTopicARNException(message: String?)
-    case invalidTimeRangeException(message: String?)
-    case lastDeliveryChannelDeleteFailedException(message: String?)
-    case limitExceededException(message: String?)
-    case maxActiveResourcesExceededException(message: String?)
-    case maxNumberOfConfigRulesExceededException(message: String?)
-    case maxNumberOfConfigurationRecordersExceededException(message: String?)
-    case maxNumberOfConformancePacksExceededException(message: String?)
-    case maxNumberOfDeliveryChannelsExceededException(message: String?)
-    case maxNumberOfOrganizationConfigRulesExceededException(message: String?)
-    case maxNumberOfOrganizationConformancePacksExceededException(message: String?)
-    case maxNumberOfRetentionConfigurationsExceededException(message: String?)
-    case noAvailableConfigurationRecorderException(message: String?)
-    case noAvailableDeliveryChannelException(message: String?)
-    case noAvailableOrganizationException(message: String?)
-    case noRunningConfigurationRecorderException(message: String?)
-    case noSuchBucketException(message: String?)
-    case noSuchConfigRuleException(message: String?)
-    case noSuchConfigRuleInConformancePackException(message: String?)
-    case noSuchConfigurationAggregatorException(message: String?)
-    case noSuchConfigurationRecorderException(message: String?)
-    case noSuchConformancePackException(message: String?)
-    case noSuchDeliveryChannelException(message: String?)
-    case noSuchOrganizationConfigRuleException(message: String?)
-    case noSuchOrganizationConformancePackException(message: String?)
-    case noSuchRemediationConfigurationException(message: String?)
-    case noSuchRemediationExceptionException(message: String?)
-    case noSuchRetentionConfigurationException(message: String?)
-    case organizationAccessDeniedException(message: String?)
-    case organizationAllFeaturesNotEnabledException(message: String?)
-    case organizationConformancePackTemplateValidationException(message: String?)
-    case oversizedConfigurationItemException(message: String?)
-    case remediationInProgressException(message: String?)
-    case resourceInUseException(message: String?)
-    case resourceNotDiscoveredException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case tooManyTagsException(message: String?)
-    case validationException(message: String?)
-}
+public struct ConfigServiceErrorType: AWSErrorType {
+    enum Code: String {
+        case conformancePackTemplateValidationException = "ConformancePackTemplateValidationException"
+        case insufficientDeliveryPolicyException = "InsufficientDeliveryPolicyException"
+        case insufficientPermissionsException = "InsufficientPermissionsException"
+        case invalidConfigurationRecorderNameException = "InvalidConfigurationRecorderNameException"
+        case invalidDeliveryChannelNameException = "InvalidDeliveryChannelNameException"
+        case invalidExpressionException = "InvalidExpressionException"
+        case invalidLimitException = "InvalidLimitException"
+        case invalidNextTokenException = "InvalidNextTokenException"
+        case invalidParameterValueException = "InvalidParameterValueException"
+        case invalidRecordingGroupException = "InvalidRecordingGroupException"
+        case invalidResultTokenException = "InvalidResultTokenException"
+        case invalidRoleException = "InvalidRoleException"
+        case invalidS3KeyPrefixException = "InvalidS3KeyPrefixException"
+        case invalidSNSTopicARNException = "InvalidSNSTopicARNException"
+        case invalidTimeRangeException = "InvalidTimeRangeException"
+        case lastDeliveryChannelDeleteFailedException = "LastDeliveryChannelDeleteFailedException"
+        case limitExceededException = "LimitExceededException"
+        case maxActiveResourcesExceededException = "MaxActiveResourcesExceededException"
+        case maxNumberOfConfigRulesExceededException = "MaxNumberOfConfigRulesExceededException"
+        case maxNumberOfConfigurationRecordersExceededException = "MaxNumberOfConfigurationRecordersExceededException"
+        case maxNumberOfConformancePacksExceededException = "MaxNumberOfConformancePacksExceededException"
+        case maxNumberOfDeliveryChannelsExceededException = "MaxNumberOfDeliveryChannelsExceededException"
+        case maxNumberOfOrganizationConfigRulesExceededException = "MaxNumberOfOrganizationConfigRulesExceededException"
+        case maxNumberOfOrganizationConformancePacksExceededException = "MaxNumberOfOrganizationConformancePacksExceededException"
+        case maxNumberOfRetentionConfigurationsExceededException = "MaxNumberOfRetentionConfigurationsExceededException"
+        case noAvailableConfigurationRecorderException = "NoAvailableConfigurationRecorderException"
+        case noAvailableDeliveryChannelException = "NoAvailableDeliveryChannelException"
+        case noAvailableOrganizationException = "NoAvailableOrganizationException"
+        case noRunningConfigurationRecorderException = "NoRunningConfigurationRecorderException"
+        case noSuchBucketException = "NoSuchBucketException"
+        case noSuchConfigRuleException = "NoSuchConfigRuleException"
+        case noSuchConfigRuleInConformancePackException = "NoSuchConfigRuleInConformancePackException"
+        case noSuchConfigurationAggregatorException = "NoSuchConfigurationAggregatorException"
+        case noSuchConfigurationRecorderException = "NoSuchConfigurationRecorderException"
+        case noSuchConformancePackException = "NoSuchConformancePackException"
+        case noSuchDeliveryChannelException = "NoSuchDeliveryChannelException"
+        case noSuchOrganizationConfigRuleException = "NoSuchOrganizationConfigRuleException"
+        case noSuchOrganizationConformancePackException = "NoSuchOrganizationConformancePackException"
+        case noSuchRemediationConfigurationException = "NoSuchRemediationConfigurationException"
+        case noSuchRemediationExceptionException = "NoSuchRemediationExceptionException"
+        case noSuchRetentionConfigurationException = "NoSuchRetentionConfigurationException"
+        case organizationAccessDeniedException = "OrganizationAccessDeniedException"
+        case organizationAllFeaturesNotEnabledException = "OrganizationAllFeaturesNotEnabledException"
+        case organizationConformancePackTemplateValidationException = "OrganizationConformancePackTemplateValidationException"
+        case oversizedConfigurationItemException = "OversizedConfigurationItemException"
+        case remediationInProgressException = "RemediationInProgressException"
+        case resourceInUseException = "ResourceInUseException"
+        case resourceNotDiscoveredException = "ResourceNotDiscoveredException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case tooManyTagsException = "TooManyTagsException"
+        case validationException = "ValidationException"
+    }
 
-extension ConfigServiceErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ConformancePackTemplateValidationException":
-            self = .conformancePackTemplateValidationException(message: message)
-        case "InsufficientDeliveryPolicyException":
-            self = .insufficientDeliveryPolicyException(message: message)
-        case "InsufficientPermissionsException":
-            self = .insufficientPermissionsException(message: message)
-        case "InvalidConfigurationRecorderNameException":
-            self = .invalidConfigurationRecorderNameException(message: message)
-        case "InvalidDeliveryChannelNameException":
-            self = .invalidDeliveryChannelNameException(message: message)
-        case "InvalidExpressionException":
-            self = .invalidExpressionException(message: message)
-        case "InvalidLimitException":
-            self = .invalidLimitException(message: message)
-        case "InvalidNextTokenException":
-            self = .invalidNextTokenException(message: message)
-        case "InvalidParameterValueException":
-            self = .invalidParameterValueException(message: message)
-        case "InvalidRecordingGroupException":
-            self = .invalidRecordingGroupException(message: message)
-        case "InvalidResultTokenException":
-            self = .invalidResultTokenException(message: message)
-        case "InvalidRoleException":
-            self = .invalidRoleException(message: message)
-        case "InvalidS3KeyPrefixException":
-            self = .invalidS3KeyPrefixException(message: message)
-        case "InvalidSNSTopicARNException":
-            self = .invalidSNSTopicARNException(message: message)
-        case "InvalidTimeRangeException":
-            self = .invalidTimeRangeException(message: message)
-        case "LastDeliveryChannelDeleteFailedException":
-            self = .lastDeliveryChannelDeleteFailedException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "MaxActiveResourcesExceededException":
-            self = .maxActiveResourcesExceededException(message: message)
-        case "MaxNumberOfConfigRulesExceededException":
-            self = .maxNumberOfConfigRulesExceededException(message: message)
-        case "MaxNumberOfConfigurationRecordersExceededException":
-            self = .maxNumberOfConfigurationRecordersExceededException(message: message)
-        case "MaxNumberOfConformancePacksExceededException":
-            self = .maxNumberOfConformancePacksExceededException(message: message)
-        case "MaxNumberOfDeliveryChannelsExceededException":
-            self = .maxNumberOfDeliveryChannelsExceededException(message: message)
-        case "MaxNumberOfOrganizationConfigRulesExceededException":
-            self = .maxNumberOfOrganizationConfigRulesExceededException(message: message)
-        case "MaxNumberOfOrganizationConformancePacksExceededException":
-            self = .maxNumberOfOrganizationConformancePacksExceededException(message: message)
-        case "MaxNumberOfRetentionConfigurationsExceededException":
-            self = .maxNumberOfRetentionConfigurationsExceededException(message: message)
-        case "NoAvailableConfigurationRecorderException":
-            self = .noAvailableConfigurationRecorderException(message: message)
-        case "NoAvailableDeliveryChannelException":
-            self = .noAvailableDeliveryChannelException(message: message)
-        case "NoAvailableOrganizationException":
-            self = .noAvailableOrganizationException(message: message)
-        case "NoRunningConfigurationRecorderException":
-            self = .noRunningConfigurationRecorderException(message: message)
-        case "NoSuchBucketException":
-            self = .noSuchBucketException(message: message)
-        case "NoSuchConfigRuleException":
-            self = .noSuchConfigRuleException(message: message)
-        case "NoSuchConfigRuleInConformancePackException":
-            self = .noSuchConfigRuleInConformancePackException(message: message)
-        case "NoSuchConfigurationAggregatorException":
-            self = .noSuchConfigurationAggregatorException(message: message)
-        case "NoSuchConfigurationRecorderException":
-            self = .noSuchConfigurationRecorderException(message: message)
-        case "NoSuchConformancePackException":
-            self = .noSuchConformancePackException(message: message)
-        case "NoSuchDeliveryChannelException":
-            self = .noSuchDeliveryChannelException(message: message)
-        case "NoSuchOrganizationConfigRuleException":
-            self = .noSuchOrganizationConfigRuleException(message: message)
-        case "NoSuchOrganizationConformancePackException":
-            self = .noSuchOrganizationConformancePackException(message: message)
-        case "NoSuchRemediationConfigurationException":
-            self = .noSuchRemediationConfigurationException(message: message)
-        case "NoSuchRemediationExceptionException":
-            self = .noSuchRemediationExceptionException(message: message)
-        case "NoSuchRetentionConfigurationException":
-            self = .noSuchRetentionConfigurationException(message: message)
-        case "OrganizationAccessDeniedException":
-            self = .organizationAccessDeniedException(message: message)
-        case "OrganizationAllFeaturesNotEnabledException":
-            self = .organizationAllFeaturesNotEnabledException(message: message)
-        case "OrganizationConformancePackTemplateValidationException":
-            self = .organizationConformancePackTemplateValidationException(message: message)
-        case "OversizedConfigurationItemException":
-            self = .oversizedConfigurationItemException(message: message)
-        case "RemediationInProgressException":
-            self = .remediationInProgressException(message: message)
-        case "ResourceInUseException":
-            self = .resourceInUseException(message: message)
-        case "ResourceNotDiscoveredException":
-            self = .resourceNotDiscoveredException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "TooManyTagsException":
-            self = .tooManyTagsException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var conformancePackTemplateValidationException: Self { .init(.conformancePackTemplateValidationException) }
+    public static var insufficientDeliveryPolicyException: Self { .init(.insufficientDeliveryPolicyException) }
+    public static var insufficientPermissionsException: Self { .init(.insufficientPermissionsException) }
+    public static var invalidConfigurationRecorderNameException: Self { .init(.invalidConfigurationRecorderNameException) }
+    public static var invalidDeliveryChannelNameException: Self { .init(.invalidDeliveryChannelNameException) }
+    public static var invalidExpressionException: Self { .init(.invalidExpressionException) }
+    public static var invalidLimitException: Self { .init(.invalidLimitException) }
+    public static var invalidNextTokenException: Self { .init(.invalidNextTokenException) }
+    public static var invalidParameterValueException: Self { .init(.invalidParameterValueException) }
+    public static var invalidRecordingGroupException: Self { .init(.invalidRecordingGroupException) }
+    public static var invalidResultTokenException: Self { .init(.invalidResultTokenException) }
+    public static var invalidRoleException: Self { .init(.invalidRoleException) }
+    public static var invalidS3KeyPrefixException: Self { .init(.invalidS3KeyPrefixException) }
+    public static var invalidSNSTopicARNException: Self { .init(.invalidSNSTopicARNException) }
+    public static var invalidTimeRangeException: Self { .init(.invalidTimeRangeException) }
+    public static var lastDeliveryChannelDeleteFailedException: Self { .init(.lastDeliveryChannelDeleteFailedException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var maxActiveResourcesExceededException: Self { .init(.maxActiveResourcesExceededException) }
+    public static var maxNumberOfConfigRulesExceededException: Self { .init(.maxNumberOfConfigRulesExceededException) }
+    public static var maxNumberOfConfigurationRecordersExceededException: Self { .init(.maxNumberOfConfigurationRecordersExceededException) }
+    public static var maxNumberOfConformancePacksExceededException: Self { .init(.maxNumberOfConformancePacksExceededException) }
+    public static var maxNumberOfDeliveryChannelsExceededException: Self { .init(.maxNumberOfDeliveryChannelsExceededException) }
+    public static var maxNumberOfOrganizationConfigRulesExceededException: Self { .init(.maxNumberOfOrganizationConfigRulesExceededException) }
+    public static var maxNumberOfOrganizationConformancePacksExceededException: Self { .init(.maxNumberOfOrganizationConformancePacksExceededException) }
+    public static var maxNumberOfRetentionConfigurationsExceededException: Self { .init(.maxNumberOfRetentionConfigurationsExceededException) }
+    public static var noAvailableConfigurationRecorderException: Self { .init(.noAvailableConfigurationRecorderException) }
+    public static var noAvailableDeliveryChannelException: Self { .init(.noAvailableDeliveryChannelException) }
+    public static var noAvailableOrganizationException: Self { .init(.noAvailableOrganizationException) }
+    public static var noRunningConfigurationRecorderException: Self { .init(.noRunningConfigurationRecorderException) }
+    public static var noSuchBucketException: Self { .init(.noSuchBucketException) }
+    public static var noSuchConfigRuleException: Self { .init(.noSuchConfigRuleException) }
+    public static var noSuchConfigRuleInConformancePackException: Self { .init(.noSuchConfigRuleInConformancePackException) }
+    public static var noSuchConfigurationAggregatorException: Self { .init(.noSuchConfigurationAggregatorException) }
+    public static var noSuchConfigurationRecorderException: Self { .init(.noSuchConfigurationRecorderException) }
+    public static var noSuchConformancePackException: Self { .init(.noSuchConformancePackException) }
+    public static var noSuchDeliveryChannelException: Self { .init(.noSuchDeliveryChannelException) }
+    public static var noSuchOrganizationConfigRuleException: Self { .init(.noSuchOrganizationConfigRuleException) }
+    public static var noSuchOrganizationConformancePackException: Self { .init(.noSuchOrganizationConformancePackException) }
+    public static var noSuchRemediationConfigurationException: Self { .init(.noSuchRemediationConfigurationException) }
+    public static var noSuchRemediationExceptionException: Self { .init(.noSuchRemediationExceptionException) }
+    public static var noSuchRetentionConfigurationException: Self { .init(.noSuchRetentionConfigurationException) }
+    public static var organizationAccessDeniedException: Self { .init(.organizationAccessDeniedException) }
+    public static var organizationAllFeaturesNotEnabledException: Self { .init(.organizationAllFeaturesNotEnabledException) }
+    public static var organizationConformancePackTemplateValidationException: Self { .init(.organizationConformancePackTemplateValidationException) }
+    public static var oversizedConfigurationItemException: Self { .init(.oversizedConfigurationItemException) }
+    public static var remediationInProgressException: Self { .init(.remediationInProgressException) }
+    public static var resourceInUseException: Self { .init(.resourceInUseException) }
+    public static var resourceNotDiscoveredException: Self { .init(.resourceNotDiscoveredException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var tooManyTagsException: Self { .init(.tooManyTagsException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension ConfigServiceErrorType: Equatable {
+    public static func == (lhs: ConfigServiceErrorType, rhs: ConfigServiceErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ConfigServiceErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .conformancePackTemplateValidationException(let message):
-            return "ConformancePackTemplateValidationException: \(message ?? "")"
-        case .insufficientDeliveryPolicyException(let message):
-            return "InsufficientDeliveryPolicyException: \(message ?? "")"
-        case .insufficientPermissionsException(let message):
-            return "InsufficientPermissionsException: \(message ?? "")"
-        case .invalidConfigurationRecorderNameException(let message):
-            return "InvalidConfigurationRecorderNameException: \(message ?? "")"
-        case .invalidDeliveryChannelNameException(let message):
-            return "InvalidDeliveryChannelNameException: \(message ?? "")"
-        case .invalidExpressionException(let message):
-            return "InvalidExpressionException: \(message ?? "")"
-        case .invalidLimitException(let message):
-            return "InvalidLimitException: \(message ?? "")"
-        case .invalidNextTokenException(let message):
-            return "InvalidNextTokenException: \(message ?? "")"
-        case .invalidParameterValueException(let message):
-            return "InvalidParameterValueException: \(message ?? "")"
-        case .invalidRecordingGroupException(let message):
-            return "InvalidRecordingGroupException: \(message ?? "")"
-        case .invalidResultTokenException(let message):
-            return "InvalidResultTokenException: \(message ?? "")"
-        case .invalidRoleException(let message):
-            return "InvalidRoleException: \(message ?? "")"
-        case .invalidS3KeyPrefixException(let message):
-            return "InvalidS3KeyPrefixException: \(message ?? "")"
-        case .invalidSNSTopicARNException(let message):
-            return "InvalidSNSTopicARNException: \(message ?? "")"
-        case .invalidTimeRangeException(let message):
-            return "InvalidTimeRangeException: \(message ?? "")"
-        case .lastDeliveryChannelDeleteFailedException(let message):
-            return "LastDeliveryChannelDeleteFailedException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .maxActiveResourcesExceededException(let message):
-            return "MaxActiveResourcesExceededException: \(message ?? "")"
-        case .maxNumberOfConfigRulesExceededException(let message):
-            return "MaxNumberOfConfigRulesExceededException: \(message ?? "")"
-        case .maxNumberOfConfigurationRecordersExceededException(let message):
-            return "MaxNumberOfConfigurationRecordersExceededException: \(message ?? "")"
-        case .maxNumberOfConformancePacksExceededException(let message):
-            return "MaxNumberOfConformancePacksExceededException: \(message ?? "")"
-        case .maxNumberOfDeliveryChannelsExceededException(let message):
-            return "MaxNumberOfDeliveryChannelsExceededException: \(message ?? "")"
-        case .maxNumberOfOrganizationConfigRulesExceededException(let message):
-            return "MaxNumberOfOrganizationConfigRulesExceededException: \(message ?? "")"
-        case .maxNumberOfOrganizationConformancePacksExceededException(let message):
-            return "MaxNumberOfOrganizationConformancePacksExceededException: \(message ?? "")"
-        case .maxNumberOfRetentionConfigurationsExceededException(let message):
-            return "MaxNumberOfRetentionConfigurationsExceededException: \(message ?? "")"
-        case .noAvailableConfigurationRecorderException(let message):
-            return "NoAvailableConfigurationRecorderException: \(message ?? "")"
-        case .noAvailableDeliveryChannelException(let message):
-            return "NoAvailableDeliveryChannelException: \(message ?? "")"
-        case .noAvailableOrganizationException(let message):
-            return "NoAvailableOrganizationException: \(message ?? "")"
-        case .noRunningConfigurationRecorderException(let message):
-            return "NoRunningConfigurationRecorderException: \(message ?? "")"
-        case .noSuchBucketException(let message):
-            return "NoSuchBucketException: \(message ?? "")"
-        case .noSuchConfigRuleException(let message):
-            return "NoSuchConfigRuleException: \(message ?? "")"
-        case .noSuchConfigRuleInConformancePackException(let message):
-            return "NoSuchConfigRuleInConformancePackException: \(message ?? "")"
-        case .noSuchConfigurationAggregatorException(let message):
-            return "NoSuchConfigurationAggregatorException: \(message ?? "")"
-        case .noSuchConfigurationRecorderException(let message):
-            return "NoSuchConfigurationRecorderException: \(message ?? "")"
-        case .noSuchConformancePackException(let message):
-            return "NoSuchConformancePackException: \(message ?? "")"
-        case .noSuchDeliveryChannelException(let message):
-            return "NoSuchDeliveryChannelException: \(message ?? "")"
-        case .noSuchOrganizationConfigRuleException(let message):
-            return "NoSuchOrganizationConfigRuleException: \(message ?? "")"
-        case .noSuchOrganizationConformancePackException(let message):
-            return "NoSuchOrganizationConformancePackException: \(message ?? "")"
-        case .noSuchRemediationConfigurationException(let message):
-            return "NoSuchRemediationConfigurationException: \(message ?? "")"
-        case .noSuchRemediationExceptionException(let message):
-            return "NoSuchRemediationExceptionException: \(message ?? "")"
-        case .noSuchRetentionConfigurationException(let message):
-            return "NoSuchRetentionConfigurationException: \(message ?? "")"
-        case .organizationAccessDeniedException(let message):
-            return "OrganizationAccessDeniedException: \(message ?? "")"
-        case .organizationAllFeaturesNotEnabledException(let message):
-            return "OrganizationAllFeaturesNotEnabledException: \(message ?? "")"
-        case .organizationConformancePackTemplateValidationException(let message):
-            return "OrganizationConformancePackTemplateValidationException: \(message ?? "")"
-        case .oversizedConfigurationItemException(let message):
-            return "OversizedConfigurationItemException: \(message ?? "")"
-        case .remediationInProgressException(let message):
-            return "RemediationInProgressException: \(message ?? "")"
-        case .resourceInUseException(let message):
-            return "ResourceInUseException: \(message ?? "")"
-        case .resourceNotDiscoveredException(let message):
-            return "ResourceNotDiscoveredException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .tooManyTagsException(let message):
-            return "TooManyTagsException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Connect/Connect_Error.swift
+++ b/Sources/Soto/Services/Connect/Connect_Error.swift
@@ -17,90 +17,64 @@
 import SotoCore
 
 /// Error enum for Connect
-public enum ConnectErrorType: AWSErrorType {
-    case contactFlowNotPublishedException(message: String?)
-    case contactNotFoundException(message: String?)
-    case destinationNotAllowedException(message: String?)
-    case duplicateResourceException(message: String?)
-    case internalServiceException(message: String?)
-    case invalidContactFlowException(message: String?)
-    case invalidParameterException(message: String?)
-    case invalidRequestException(message: String?)
-    case limitExceededException(message: String?)
-    case outboundContactNotPermittedException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case throttlingException(message: String?)
-    case userNotFoundException(message: String?)
-}
+public struct ConnectErrorType: AWSErrorType {
+    enum Code: String {
+        case contactFlowNotPublishedException = "ContactFlowNotPublishedException"
+        case contactNotFoundException = "ContactNotFoundException"
+        case destinationNotAllowedException = "DestinationNotAllowedException"
+        case duplicateResourceException = "DuplicateResourceException"
+        case internalServiceException = "InternalServiceException"
+        case invalidContactFlowException = "InvalidContactFlowException"
+        case invalidParameterException = "InvalidParameterException"
+        case invalidRequestException = "InvalidRequestException"
+        case limitExceededException = "LimitExceededException"
+        case outboundContactNotPermittedException = "OutboundContactNotPermittedException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case throttlingException = "ThrottlingException"
+        case userNotFoundException = "UserNotFoundException"
+    }
 
-extension ConnectErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ContactFlowNotPublishedException":
-            self = .contactFlowNotPublishedException(message: message)
-        case "ContactNotFoundException":
-            self = .contactNotFoundException(message: message)
-        case "DestinationNotAllowedException":
-            self = .destinationNotAllowedException(message: message)
-        case "DuplicateResourceException":
-            self = .duplicateResourceException(message: message)
-        case "InternalServiceException":
-            self = .internalServiceException(message: message)
-        case "InvalidContactFlowException":
-            self = .invalidContactFlowException(message: message)
-        case "InvalidParameterException":
-            self = .invalidParameterException(message: message)
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "OutboundContactNotPermittedException":
-            self = .outboundContactNotPermittedException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        case "UserNotFoundException":
-            self = .userNotFoundException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var contactFlowNotPublishedException: Self { .init(.contactFlowNotPublishedException) }
+    public static var contactNotFoundException: Self { .init(.contactNotFoundException) }
+    public static var destinationNotAllowedException: Self { .init(.destinationNotAllowedException) }
+    public static var duplicateResourceException: Self { .init(.duplicateResourceException) }
+    public static var internalServiceException: Self { .init(.internalServiceException) }
+    public static var invalidContactFlowException: Self { .init(.invalidContactFlowException) }
+    public static var invalidParameterException: Self { .init(.invalidParameterException) }
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var outboundContactNotPermittedException: Self { .init(.outboundContactNotPermittedException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+    public static var userNotFoundException: Self { .init(.userNotFoundException) }
+}
+
+extension ConnectErrorType: Equatable {
+    public static func == (lhs: ConnectErrorType, rhs: ConnectErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ConnectErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .contactFlowNotPublishedException(let message):
-            return "ContactFlowNotPublishedException: \(message ?? "")"
-        case .contactNotFoundException(let message):
-            return "ContactNotFoundException: \(message ?? "")"
-        case .destinationNotAllowedException(let message):
-            return "DestinationNotAllowedException: \(message ?? "")"
-        case .duplicateResourceException(let message):
-            return "DuplicateResourceException: \(message ?? "")"
-        case .internalServiceException(let message):
-            return "InternalServiceException: \(message ?? "")"
-        case .invalidContactFlowException(let message):
-            return "InvalidContactFlowException: \(message ?? "")"
-        case .invalidParameterException(let message):
-            return "InvalidParameterException: \(message ?? "")"
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .outboundContactNotPermittedException(let message):
-            return "OutboundContactNotPermittedException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        case .userNotFoundException(let message):
-            return "UserNotFoundException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/ConnectParticipant/ConnectParticipant_Error.swift
+++ b/Sources/Soto/Services/ConnectParticipant/ConnectParticipant_Error.swift
@@ -17,45 +17,46 @@
 import SotoCore
 
 /// Error enum for ConnectParticipant
-public enum ConnectParticipantErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case internalServerException(message: String?)
-    case throttlingException(message: String?)
-    case validationException(message: String?)
-}
+public struct ConnectParticipantErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case internalServerException = "InternalServerException"
+        case throttlingException = "ThrottlingException"
+        case validationException = "ValidationException"
+    }
 
-extension ConnectParticipantErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension ConnectParticipantErrorType: Equatable {
+    public static func == (lhs: ConnectParticipantErrorType, rhs: ConnectParticipantErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ConnectParticipantErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/CostExplorer/CostExplorer_Error.swift
+++ b/Sources/Soto/Services/CostExplorer/CostExplorer_Error.swift
@@ -17,75 +17,58 @@
 import SotoCore
 
 /// Error enum for CostExplorer
-public enum CostExplorerErrorType: AWSErrorType {
-    case billExpirationException(message: String?)
-    case dataUnavailableException(message: String?)
-    case invalidNextTokenException(message: String?)
-    case limitExceededException(message: String?)
-    case requestChangedException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceQuotaExceededException(message: String?)
-    case unknownMonitorException(message: String?)
-    case unknownSubscriptionException(message: String?)
-    case unresolvableUsageUnitException(message: String?)
-}
+public struct CostExplorerErrorType: AWSErrorType {
+    enum Code: String {
+        case billExpirationException = "BillExpirationException"
+        case dataUnavailableException = "DataUnavailableException"
+        case invalidNextTokenException = "InvalidNextTokenException"
+        case limitExceededException = "LimitExceededException"
+        case requestChangedException = "RequestChangedException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceQuotaExceededException = "ServiceQuotaExceededException"
+        case unknownMonitorException = "UnknownMonitorException"
+        case unknownSubscriptionException = "UnknownSubscriptionException"
+        case unresolvableUsageUnitException = "UnresolvableUsageUnitException"
+    }
 
-extension CostExplorerErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "BillExpirationException":
-            self = .billExpirationException(message: message)
-        case "DataUnavailableException":
-            self = .dataUnavailableException(message: message)
-        case "InvalidNextTokenException":
-            self = .invalidNextTokenException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "RequestChangedException":
-            self = .requestChangedException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceQuotaExceededException":
-            self = .serviceQuotaExceededException(message: message)
-        case "UnknownMonitorException":
-            self = .unknownMonitorException(message: message)
-        case "UnknownSubscriptionException":
-            self = .unknownSubscriptionException(message: message)
-        case "UnresolvableUsageUnitException":
-            self = .unresolvableUsageUnitException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var billExpirationException: Self { .init(.billExpirationException) }
+    public static var dataUnavailableException: Self { .init(.dataUnavailableException) }
+    public static var invalidNextTokenException: Self { .init(.invalidNextTokenException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var requestChangedException: Self { .init(.requestChangedException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceQuotaExceededException: Self { .init(.serviceQuotaExceededException) }
+    public static var unknownMonitorException: Self { .init(.unknownMonitorException) }
+    public static var unknownSubscriptionException: Self { .init(.unknownSubscriptionException) }
+    public static var unresolvableUsageUnitException: Self { .init(.unresolvableUsageUnitException) }
+}
+
+extension CostExplorerErrorType: Equatable {
+    public static func == (lhs: CostExplorerErrorType, rhs: CostExplorerErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension CostExplorerErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .billExpirationException(let message):
-            return "BillExpirationException: \(message ?? "")"
-        case .dataUnavailableException(let message):
-            return "DataUnavailableException: \(message ?? "")"
-        case .invalidNextTokenException(let message):
-            return "InvalidNextTokenException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .requestChangedException(let message):
-            return "RequestChangedException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceQuotaExceededException(let message):
-            return "ServiceQuotaExceededException: \(message ?? "")"
-        case .unknownMonitorException(let message):
-            return "UnknownMonitorException: \(message ?? "")"
-        case .unknownSubscriptionException(let message):
-            return "UnknownSubscriptionException: \(message ?? "")"
-        case .unresolvableUsageUnitException(let message):
-            return "UnresolvableUsageUnitException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/CostandUsageReportService/CostandUsageReportService_Error.swift
+++ b/Sources/Soto/Services/CostandUsageReportService/CostandUsageReportService_Error.swift
@@ -17,45 +17,46 @@
 import SotoCore
 
 /// Error enum for CostandUsageReportService
-public enum CostandUsageReportServiceErrorType: AWSErrorType {
-    case duplicateReportNameException(message: String?)
-    case internalErrorException(message: String?)
-    case reportLimitReachedException(message: String?)
-    case validationException(message: String?)
-}
+public struct CostandUsageReportServiceErrorType: AWSErrorType {
+    enum Code: String {
+        case duplicateReportNameException = "DuplicateReportNameException"
+        case internalErrorException = "InternalErrorException"
+        case reportLimitReachedException = "ReportLimitReachedException"
+        case validationException = "ValidationException"
+    }
 
-extension CostandUsageReportServiceErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "DuplicateReportNameException":
-            self = .duplicateReportNameException(message: message)
-        case "InternalErrorException":
-            self = .internalErrorException(message: message)
-        case "ReportLimitReachedException":
-            self = .reportLimitReachedException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var duplicateReportNameException: Self { .init(.duplicateReportNameException) }
+    public static var internalErrorException: Self { .init(.internalErrorException) }
+    public static var reportLimitReachedException: Self { .init(.reportLimitReachedException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension CostandUsageReportServiceErrorType: Equatable {
+    public static func == (lhs: CostandUsageReportServiceErrorType, rhs: CostandUsageReportServiceErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension CostandUsageReportServiceErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .duplicateReportNameException(let message):
-            return "DuplicateReportNameException: \(message ?? "")"
-        case .internalErrorException(let message):
-            return "InternalErrorException: \(message ?? "")"
-        case .reportLimitReachedException(let message):
-            return "ReportLimitReachedException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/DAX/DAX_Error.swift
+++ b/Sources/Soto/Services/DAX/DAX_Error.swift
@@ -17,155 +17,90 @@
 import SotoCore
 
 /// Error enum for DAX
-public enum DAXErrorType: AWSErrorType {
-    case clusterAlreadyExistsFault(message: String?)
-    case clusterNotFoundFault(message: String?)
-    case clusterQuotaForCustomerExceededFault(message: String?)
-    case insufficientClusterCapacityFault(message: String?)
-    case invalidARNFault(message: String?)
-    case invalidClusterStateFault(message: String?)
-    case invalidParameterCombinationException(message: String?)
-    case invalidParameterGroupStateFault(message: String?)
-    case invalidParameterValueException(message: String?)
-    case invalidSubnet(message: String?)
-    case invalidVPCNetworkStateFault(message: String?)
-    case nodeNotFoundFault(message: String?)
-    case nodeQuotaForClusterExceededFault(message: String?)
-    case nodeQuotaForCustomerExceededFault(message: String?)
-    case parameterGroupAlreadyExistsFault(message: String?)
-    case parameterGroupNotFoundFault(message: String?)
-    case parameterGroupQuotaExceededFault(message: String?)
-    case serviceLinkedRoleNotFoundFault(message: String?)
-    case subnetGroupAlreadyExistsFault(message: String?)
-    case subnetGroupInUseFault(message: String?)
-    case subnetGroupNotFoundFault(message: String?)
-    case subnetGroupQuotaExceededFault(message: String?)
-    case subnetInUse(message: String?)
-    case subnetQuotaExceededFault(message: String?)
-    case tagNotFoundFault(message: String?)
-    case tagQuotaPerResourceExceeded(message: String?)
-}
+public struct DAXErrorType: AWSErrorType {
+    enum Code: String {
+        case clusterAlreadyExistsFault = "ClusterAlreadyExistsFault"
+        case clusterNotFoundFault = "ClusterNotFoundFault"
+        case clusterQuotaForCustomerExceededFault = "ClusterQuotaForCustomerExceededFault"
+        case insufficientClusterCapacityFault = "InsufficientClusterCapacityFault"
+        case invalidARNFault = "InvalidARNFault"
+        case invalidClusterStateFault = "InvalidClusterStateFault"
+        case invalidParameterCombinationException = "InvalidParameterCombinationException"
+        case invalidParameterGroupStateFault = "InvalidParameterGroupStateFault"
+        case invalidParameterValueException = "InvalidParameterValueException"
+        case invalidSubnet = "InvalidSubnet"
+        case invalidVPCNetworkStateFault = "InvalidVPCNetworkStateFault"
+        case nodeNotFoundFault = "NodeNotFoundFault"
+        case nodeQuotaForClusterExceededFault = "NodeQuotaForClusterExceededFault"
+        case nodeQuotaForCustomerExceededFault = "NodeQuotaForCustomerExceededFault"
+        case parameterGroupAlreadyExistsFault = "ParameterGroupAlreadyExistsFault"
+        case parameterGroupNotFoundFault = "ParameterGroupNotFoundFault"
+        case parameterGroupQuotaExceededFault = "ParameterGroupQuotaExceededFault"
+        case serviceLinkedRoleNotFoundFault = "ServiceLinkedRoleNotFoundFault"
+        case subnetGroupAlreadyExistsFault = "SubnetGroupAlreadyExistsFault"
+        case subnetGroupInUseFault = "SubnetGroupInUseFault"
+        case subnetGroupNotFoundFault = "SubnetGroupNotFoundFault"
+        case subnetGroupQuotaExceededFault = "SubnetGroupQuotaExceededFault"
+        case subnetInUse = "SubnetInUse"
+        case subnetQuotaExceededFault = "SubnetQuotaExceededFault"
+        case tagNotFoundFault = "TagNotFoundFault"
+        case tagQuotaPerResourceExceeded = "TagQuotaPerResourceExceeded"
+    }
 
-extension DAXErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ClusterAlreadyExistsFault":
-            self = .clusterAlreadyExistsFault(message: message)
-        case "ClusterNotFoundFault":
-            self = .clusterNotFoundFault(message: message)
-        case "ClusterQuotaForCustomerExceededFault":
-            self = .clusterQuotaForCustomerExceededFault(message: message)
-        case "InsufficientClusterCapacityFault":
-            self = .insufficientClusterCapacityFault(message: message)
-        case "InvalidARNFault":
-            self = .invalidARNFault(message: message)
-        case "InvalidClusterStateFault":
-            self = .invalidClusterStateFault(message: message)
-        case "InvalidParameterCombinationException":
-            self = .invalidParameterCombinationException(message: message)
-        case "InvalidParameterGroupStateFault":
-            self = .invalidParameterGroupStateFault(message: message)
-        case "InvalidParameterValueException":
-            self = .invalidParameterValueException(message: message)
-        case "InvalidSubnet":
-            self = .invalidSubnet(message: message)
-        case "InvalidVPCNetworkStateFault":
-            self = .invalidVPCNetworkStateFault(message: message)
-        case "NodeNotFoundFault":
-            self = .nodeNotFoundFault(message: message)
-        case "NodeQuotaForClusterExceededFault":
-            self = .nodeQuotaForClusterExceededFault(message: message)
-        case "NodeQuotaForCustomerExceededFault":
-            self = .nodeQuotaForCustomerExceededFault(message: message)
-        case "ParameterGroupAlreadyExistsFault":
-            self = .parameterGroupAlreadyExistsFault(message: message)
-        case "ParameterGroupNotFoundFault":
-            self = .parameterGroupNotFoundFault(message: message)
-        case "ParameterGroupQuotaExceededFault":
-            self = .parameterGroupQuotaExceededFault(message: message)
-        case "ServiceLinkedRoleNotFoundFault":
-            self = .serviceLinkedRoleNotFoundFault(message: message)
-        case "SubnetGroupAlreadyExistsFault":
-            self = .subnetGroupAlreadyExistsFault(message: message)
-        case "SubnetGroupInUseFault":
-            self = .subnetGroupInUseFault(message: message)
-        case "SubnetGroupNotFoundFault":
-            self = .subnetGroupNotFoundFault(message: message)
-        case "SubnetGroupQuotaExceededFault":
-            self = .subnetGroupQuotaExceededFault(message: message)
-        case "SubnetInUse":
-            self = .subnetInUse(message: message)
-        case "SubnetQuotaExceededFault":
-            self = .subnetQuotaExceededFault(message: message)
-        case "TagNotFoundFault":
-            self = .tagNotFoundFault(message: message)
-        case "TagQuotaPerResourceExceeded":
-            self = .tagQuotaPerResourceExceeded(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var clusterAlreadyExistsFault: Self { .init(.clusterAlreadyExistsFault) }
+    public static var clusterNotFoundFault: Self { .init(.clusterNotFoundFault) }
+    public static var clusterQuotaForCustomerExceededFault: Self { .init(.clusterQuotaForCustomerExceededFault) }
+    public static var insufficientClusterCapacityFault: Self { .init(.insufficientClusterCapacityFault) }
+    public static var invalidARNFault: Self { .init(.invalidARNFault) }
+    public static var invalidClusterStateFault: Self { .init(.invalidClusterStateFault) }
+    public static var invalidParameterCombinationException: Self { .init(.invalidParameterCombinationException) }
+    public static var invalidParameterGroupStateFault: Self { .init(.invalidParameterGroupStateFault) }
+    public static var invalidParameterValueException: Self { .init(.invalidParameterValueException) }
+    public static var invalidSubnet: Self { .init(.invalidSubnet) }
+    public static var invalidVPCNetworkStateFault: Self { .init(.invalidVPCNetworkStateFault) }
+    public static var nodeNotFoundFault: Self { .init(.nodeNotFoundFault) }
+    public static var nodeQuotaForClusterExceededFault: Self { .init(.nodeQuotaForClusterExceededFault) }
+    public static var nodeQuotaForCustomerExceededFault: Self { .init(.nodeQuotaForCustomerExceededFault) }
+    public static var parameterGroupAlreadyExistsFault: Self { .init(.parameterGroupAlreadyExistsFault) }
+    public static var parameterGroupNotFoundFault: Self { .init(.parameterGroupNotFoundFault) }
+    public static var parameterGroupQuotaExceededFault: Self { .init(.parameterGroupQuotaExceededFault) }
+    public static var serviceLinkedRoleNotFoundFault: Self { .init(.serviceLinkedRoleNotFoundFault) }
+    public static var subnetGroupAlreadyExistsFault: Self { .init(.subnetGroupAlreadyExistsFault) }
+    public static var subnetGroupInUseFault: Self { .init(.subnetGroupInUseFault) }
+    public static var subnetGroupNotFoundFault: Self { .init(.subnetGroupNotFoundFault) }
+    public static var subnetGroupQuotaExceededFault: Self { .init(.subnetGroupQuotaExceededFault) }
+    public static var subnetInUse: Self { .init(.subnetInUse) }
+    public static var subnetQuotaExceededFault: Self { .init(.subnetQuotaExceededFault) }
+    public static var tagNotFoundFault: Self { .init(.tagNotFoundFault) }
+    public static var tagQuotaPerResourceExceeded: Self { .init(.tagQuotaPerResourceExceeded) }
+}
+
+extension DAXErrorType: Equatable {
+    public static func == (lhs: DAXErrorType, rhs: DAXErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension DAXErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .clusterAlreadyExistsFault(let message):
-            return "ClusterAlreadyExistsFault: \(message ?? "")"
-        case .clusterNotFoundFault(let message):
-            return "ClusterNotFoundFault: \(message ?? "")"
-        case .clusterQuotaForCustomerExceededFault(let message):
-            return "ClusterQuotaForCustomerExceededFault: \(message ?? "")"
-        case .insufficientClusterCapacityFault(let message):
-            return "InsufficientClusterCapacityFault: \(message ?? "")"
-        case .invalidARNFault(let message):
-            return "InvalidARNFault: \(message ?? "")"
-        case .invalidClusterStateFault(let message):
-            return "InvalidClusterStateFault: \(message ?? "")"
-        case .invalidParameterCombinationException(let message):
-            return "InvalidParameterCombinationException: \(message ?? "")"
-        case .invalidParameterGroupStateFault(let message):
-            return "InvalidParameterGroupStateFault: \(message ?? "")"
-        case .invalidParameterValueException(let message):
-            return "InvalidParameterValueException: \(message ?? "")"
-        case .invalidSubnet(let message):
-            return "InvalidSubnet: \(message ?? "")"
-        case .invalidVPCNetworkStateFault(let message):
-            return "InvalidVPCNetworkStateFault: \(message ?? "")"
-        case .nodeNotFoundFault(let message):
-            return "NodeNotFoundFault: \(message ?? "")"
-        case .nodeQuotaForClusterExceededFault(let message):
-            return "NodeQuotaForClusterExceededFault: \(message ?? "")"
-        case .nodeQuotaForCustomerExceededFault(let message):
-            return "NodeQuotaForCustomerExceededFault: \(message ?? "")"
-        case .parameterGroupAlreadyExistsFault(let message):
-            return "ParameterGroupAlreadyExistsFault: \(message ?? "")"
-        case .parameterGroupNotFoundFault(let message):
-            return "ParameterGroupNotFoundFault: \(message ?? "")"
-        case .parameterGroupQuotaExceededFault(let message):
-            return "ParameterGroupQuotaExceededFault: \(message ?? "")"
-        case .serviceLinkedRoleNotFoundFault(let message):
-            return "ServiceLinkedRoleNotFoundFault: \(message ?? "")"
-        case .subnetGroupAlreadyExistsFault(let message):
-            return "SubnetGroupAlreadyExistsFault: \(message ?? "")"
-        case .subnetGroupInUseFault(let message):
-            return "SubnetGroupInUseFault: \(message ?? "")"
-        case .subnetGroupNotFoundFault(let message):
-            return "SubnetGroupNotFoundFault: \(message ?? "")"
-        case .subnetGroupQuotaExceededFault(let message):
-            return "SubnetGroupQuotaExceededFault: \(message ?? "")"
-        case .subnetInUse(let message):
-            return "SubnetInUse: \(message ?? "")"
-        case .subnetQuotaExceededFault(let message):
-            return "SubnetQuotaExceededFault: \(message ?? "")"
-        case .tagNotFoundFault(let message):
-            return "TagNotFoundFault: \(message ?? "")"
-        case .tagQuotaPerResourceExceeded(let message):
-            return "TagQuotaPerResourceExceeded: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/DLM/DLM_Error.swift
+++ b/Sources/Soto/Services/DLM/DLM_Error.swift
@@ -17,45 +17,46 @@
 import SotoCore
 
 /// Error enum for DLM
-public enum DLMErrorType: AWSErrorType {
-    case internalServerException(message: String?)
-    case invalidRequestException(message: String?)
-    case limitExceededException(message: String?)
-    case resourceNotFoundException(message: String?)
-}
+public struct DLMErrorType: AWSErrorType {
+    enum Code: String {
+        case internalServerException = "InternalServerException"
+        case invalidRequestException = "InvalidRequestException"
+        case limitExceededException = "LimitExceededException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+    }
 
-extension DLMErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+}
+
+extension DLMErrorType: Equatable {
+    public static func == (lhs: DLMErrorType, rhs: DLMErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension DLMErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/DataExchange/DataExchange_Error.swift
+++ b/Sources/Soto/Services/DataExchange/DataExchange_Error.swift
@@ -17,60 +17,52 @@
 import SotoCore
 
 /// Error enum for DataExchange
-public enum DataExchangeErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case conflictException(message: String?)
-    case internalServerException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceLimitExceededException(message: String?)
-    case throttlingException(message: String?)
-    case validationException(message: String?)
-}
+public struct DataExchangeErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case conflictException = "ConflictException"
+        case internalServerException = "InternalServerException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceLimitExceededException = "ServiceLimitExceededException"
+        case throttlingException = "ThrottlingException"
+        case validationException = "ValidationException"
+    }
 
-extension DataExchangeErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceLimitExceededException":
-            self = .serviceLimitExceededException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceLimitExceededException: Self { .init(.serviceLimitExceededException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension DataExchangeErrorType: Equatable {
+    public static func == (lhs: DataExchangeErrorType, rhs: DataExchangeErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension DataExchangeErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceLimitExceededException(let message):
-            return "ServiceLimitExceededException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/DataPipeline/DataPipeline_Error.swift
+++ b/Sources/Soto/Services/DataPipeline/DataPipeline_Error.swift
@@ -17,50 +17,48 @@
 import SotoCore
 
 /// Error enum for DataPipeline
-public enum DataPipelineErrorType: AWSErrorType {
-    case internalServiceError(message: String?)
-    case invalidRequestException(message: String?)
-    case pipelineDeletedException(message: String?)
-    case pipelineNotFoundException(message: String?)
-    case taskNotFoundException(message: String?)
-}
+public struct DataPipelineErrorType: AWSErrorType {
+    enum Code: String {
+        case internalServiceError = "InternalServiceError"
+        case invalidRequestException = "InvalidRequestException"
+        case pipelineDeletedException = "PipelineDeletedException"
+        case pipelineNotFoundException = "PipelineNotFoundException"
+        case taskNotFoundException = "TaskNotFoundException"
+    }
 
-extension DataPipelineErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "InternalServiceError":
-            self = .internalServiceError(message: message)
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        case "PipelineDeletedException":
-            self = .pipelineDeletedException(message: message)
-        case "PipelineNotFoundException":
-            self = .pipelineNotFoundException(message: message)
-        case "TaskNotFoundException":
-            self = .taskNotFoundException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var internalServiceError: Self { .init(.internalServiceError) }
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+    public static var pipelineDeletedException: Self { .init(.pipelineDeletedException) }
+    public static var pipelineNotFoundException: Self { .init(.pipelineNotFoundException) }
+    public static var taskNotFoundException: Self { .init(.taskNotFoundException) }
+}
+
+extension DataPipelineErrorType: Equatable {
+    public static func == (lhs: DataPipelineErrorType, rhs: DataPipelineErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension DataPipelineErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .internalServiceError(let message):
-            return "InternalServiceError: \(message ?? "")"
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        case .pipelineDeletedException(let message):
-            return "PipelineDeletedException: \(message ?? "")"
-        case .pipelineNotFoundException(let message):
-            return "PipelineNotFoundException: \(message ?? "")"
-        case .taskNotFoundException(let message):
-            return "TaskNotFoundException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/DatabaseMigrationService/DatabaseMigrationService_Error.swift
+++ b/Sources/Soto/Services/DatabaseMigrationService/DatabaseMigrationService_Error.swift
@@ -17,140 +17,84 @@
 import SotoCore
 
 /// Error enum for DatabaseMigrationService
-public enum DatabaseMigrationServiceErrorType: AWSErrorType {
-    case accessDeniedFault(message: String?)
-    case insufficientResourceCapacityFault(message: String?)
-    case invalidCertificateFault(message: String?)
-    case invalidResourceStateFault(message: String?)
-    case invalidSubnet(message: String?)
-    case kMSAccessDeniedFault(message: String?)
-    case kMSDisabledFault(message: String?)
-    case kMSFault(message: String?)
-    case kMSInvalidStateFault(message: String?)
-    case kMSKeyNotAccessibleFault(message: String?)
-    case kMSNotFoundFault(message: String?)
-    case kMSThrottlingFault(message: String?)
-    case replicationSubnetGroupDoesNotCoverEnoughAZs(message: String?)
-    case resourceAlreadyExistsFault(message: String?)
-    case resourceNotFoundFault(message: String?)
-    case resourceQuotaExceededFault(message: String?)
-    case s3AccessDeniedFault(message: String?)
-    case s3ResourceNotFoundFault(message: String?)
-    case sNSInvalidTopicFault(message: String?)
-    case sNSNoAuthorizationFault(message: String?)
-    case storageQuotaExceededFault(message: String?)
-    case subnetAlreadyInUse(message: String?)
-    case upgradeDependencyFailureFault(message: String?)
-}
+public struct DatabaseMigrationServiceErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedFault = "AccessDeniedFault"
+        case insufficientResourceCapacityFault = "InsufficientResourceCapacityFault"
+        case invalidCertificateFault = "InvalidCertificateFault"
+        case invalidResourceStateFault = "InvalidResourceStateFault"
+        case invalidSubnet = "InvalidSubnet"
+        case kMSAccessDeniedFault = "KMSAccessDeniedFault"
+        case kMSDisabledFault = "KMSDisabledFault"
+        case kMSFault = "KMSFault"
+        case kMSInvalidStateFault = "KMSInvalidStateFault"
+        case kMSKeyNotAccessibleFault = "KMSKeyNotAccessibleFault"
+        case kMSNotFoundFault = "KMSNotFoundFault"
+        case kMSThrottlingFault = "KMSThrottlingFault"
+        case replicationSubnetGroupDoesNotCoverEnoughAZs = "ReplicationSubnetGroupDoesNotCoverEnoughAZs"
+        case resourceAlreadyExistsFault = "ResourceAlreadyExistsFault"
+        case resourceNotFoundFault = "ResourceNotFoundFault"
+        case resourceQuotaExceededFault = "ResourceQuotaExceededFault"
+        case s3AccessDeniedFault = "S3AccessDeniedFault"
+        case s3ResourceNotFoundFault = "S3ResourceNotFoundFault"
+        case sNSInvalidTopicFault = "SNSInvalidTopicFault"
+        case sNSNoAuthorizationFault = "SNSNoAuthorizationFault"
+        case storageQuotaExceededFault = "StorageQuotaExceededFault"
+        case subnetAlreadyInUse = "SubnetAlreadyInUse"
+        case upgradeDependencyFailureFault = "UpgradeDependencyFailureFault"
+    }
 
-extension DatabaseMigrationServiceErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedFault":
-            self = .accessDeniedFault(message: message)
-        case "InsufficientResourceCapacityFault":
-            self = .insufficientResourceCapacityFault(message: message)
-        case "InvalidCertificateFault":
-            self = .invalidCertificateFault(message: message)
-        case "InvalidResourceStateFault":
-            self = .invalidResourceStateFault(message: message)
-        case "InvalidSubnet":
-            self = .invalidSubnet(message: message)
-        case "KMSAccessDeniedFault":
-            self = .kMSAccessDeniedFault(message: message)
-        case "KMSDisabledFault":
-            self = .kMSDisabledFault(message: message)
-        case "KMSFault":
-            self = .kMSFault(message: message)
-        case "KMSInvalidStateFault":
-            self = .kMSInvalidStateFault(message: message)
-        case "KMSKeyNotAccessibleFault":
-            self = .kMSKeyNotAccessibleFault(message: message)
-        case "KMSNotFoundFault":
-            self = .kMSNotFoundFault(message: message)
-        case "KMSThrottlingFault":
-            self = .kMSThrottlingFault(message: message)
-        case "ReplicationSubnetGroupDoesNotCoverEnoughAZs":
-            self = .replicationSubnetGroupDoesNotCoverEnoughAZs(message: message)
-        case "ResourceAlreadyExistsFault":
-            self = .resourceAlreadyExistsFault(message: message)
-        case "ResourceNotFoundFault":
-            self = .resourceNotFoundFault(message: message)
-        case "ResourceQuotaExceededFault":
-            self = .resourceQuotaExceededFault(message: message)
-        case "S3AccessDeniedFault":
-            self = .s3AccessDeniedFault(message: message)
-        case "S3ResourceNotFoundFault":
-            self = .s3ResourceNotFoundFault(message: message)
-        case "SNSInvalidTopicFault":
-            self = .sNSInvalidTopicFault(message: message)
-        case "SNSNoAuthorizationFault":
-            self = .sNSNoAuthorizationFault(message: message)
-        case "StorageQuotaExceededFault":
-            self = .storageQuotaExceededFault(message: message)
-        case "SubnetAlreadyInUse":
-            self = .subnetAlreadyInUse(message: message)
-        case "UpgradeDependencyFailureFault":
-            self = .upgradeDependencyFailureFault(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedFault: Self { .init(.accessDeniedFault) }
+    public static var insufficientResourceCapacityFault: Self { .init(.insufficientResourceCapacityFault) }
+    public static var invalidCertificateFault: Self { .init(.invalidCertificateFault) }
+    public static var invalidResourceStateFault: Self { .init(.invalidResourceStateFault) }
+    public static var invalidSubnet: Self { .init(.invalidSubnet) }
+    public static var kMSAccessDeniedFault: Self { .init(.kMSAccessDeniedFault) }
+    public static var kMSDisabledFault: Self { .init(.kMSDisabledFault) }
+    public static var kMSFault: Self { .init(.kMSFault) }
+    public static var kMSInvalidStateFault: Self { .init(.kMSInvalidStateFault) }
+    public static var kMSKeyNotAccessibleFault: Self { .init(.kMSKeyNotAccessibleFault) }
+    public static var kMSNotFoundFault: Self { .init(.kMSNotFoundFault) }
+    public static var kMSThrottlingFault: Self { .init(.kMSThrottlingFault) }
+    public static var replicationSubnetGroupDoesNotCoverEnoughAZs: Self { .init(.replicationSubnetGroupDoesNotCoverEnoughAZs) }
+    public static var resourceAlreadyExistsFault: Self { .init(.resourceAlreadyExistsFault) }
+    public static var resourceNotFoundFault: Self { .init(.resourceNotFoundFault) }
+    public static var resourceQuotaExceededFault: Self { .init(.resourceQuotaExceededFault) }
+    public static var s3AccessDeniedFault: Self { .init(.s3AccessDeniedFault) }
+    public static var s3ResourceNotFoundFault: Self { .init(.s3ResourceNotFoundFault) }
+    public static var sNSInvalidTopicFault: Self { .init(.sNSInvalidTopicFault) }
+    public static var sNSNoAuthorizationFault: Self { .init(.sNSNoAuthorizationFault) }
+    public static var storageQuotaExceededFault: Self { .init(.storageQuotaExceededFault) }
+    public static var subnetAlreadyInUse: Self { .init(.subnetAlreadyInUse) }
+    public static var upgradeDependencyFailureFault: Self { .init(.upgradeDependencyFailureFault) }
+}
+
+extension DatabaseMigrationServiceErrorType: Equatable {
+    public static func == (lhs: DatabaseMigrationServiceErrorType, rhs: DatabaseMigrationServiceErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension DatabaseMigrationServiceErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedFault(let message):
-            return "AccessDeniedFault: \(message ?? "")"
-        case .insufficientResourceCapacityFault(let message):
-            return "InsufficientResourceCapacityFault: \(message ?? "")"
-        case .invalidCertificateFault(let message):
-            return "InvalidCertificateFault: \(message ?? "")"
-        case .invalidResourceStateFault(let message):
-            return "InvalidResourceStateFault: \(message ?? "")"
-        case .invalidSubnet(let message):
-            return "InvalidSubnet: \(message ?? "")"
-        case .kMSAccessDeniedFault(let message):
-            return "KMSAccessDeniedFault: \(message ?? "")"
-        case .kMSDisabledFault(let message):
-            return "KMSDisabledFault: \(message ?? "")"
-        case .kMSFault(let message):
-            return "KMSFault: \(message ?? "")"
-        case .kMSInvalidStateFault(let message):
-            return "KMSInvalidStateFault: \(message ?? "")"
-        case .kMSKeyNotAccessibleFault(let message):
-            return "KMSKeyNotAccessibleFault: \(message ?? "")"
-        case .kMSNotFoundFault(let message):
-            return "KMSNotFoundFault: \(message ?? "")"
-        case .kMSThrottlingFault(let message):
-            return "KMSThrottlingFault: \(message ?? "")"
-        case .replicationSubnetGroupDoesNotCoverEnoughAZs(let message):
-            return "ReplicationSubnetGroupDoesNotCoverEnoughAZs: \(message ?? "")"
-        case .resourceAlreadyExistsFault(let message):
-            return "ResourceAlreadyExistsFault: \(message ?? "")"
-        case .resourceNotFoundFault(let message):
-            return "ResourceNotFoundFault: \(message ?? "")"
-        case .resourceQuotaExceededFault(let message):
-            return "ResourceQuotaExceededFault: \(message ?? "")"
-        case .s3AccessDeniedFault(let message):
-            return "S3AccessDeniedFault: \(message ?? "")"
-        case .s3ResourceNotFoundFault(let message):
-            return "S3ResourceNotFoundFault: \(message ?? "")"
-        case .sNSInvalidTopicFault(let message):
-            return "SNSInvalidTopicFault: \(message ?? "")"
-        case .sNSNoAuthorizationFault(let message):
-            return "SNSNoAuthorizationFault: \(message ?? "")"
-        case .storageQuotaExceededFault(let message):
-            return "StorageQuotaExceededFault: \(message ?? "")"
-        case .subnetAlreadyInUse(let message):
-            return "SubnetAlreadyInUse: \(message ?? "")"
-        case .upgradeDependencyFailureFault(let message):
-            return "UpgradeDependencyFailureFault: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Detective/Detective_Error.swift
+++ b/Sources/Soto/Services/Detective/Detective_Error.swift
@@ -17,50 +17,48 @@
 import SotoCore
 
 /// Error enum for Detective
-public enum DetectiveErrorType: AWSErrorType {
-    case conflictException(message: String?)
-    case internalServerException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceQuotaExceededException(message: String?)
-    case validationException(message: String?)
-}
+public struct DetectiveErrorType: AWSErrorType {
+    enum Code: String {
+        case conflictException = "ConflictException"
+        case internalServerException = "InternalServerException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceQuotaExceededException = "ServiceQuotaExceededException"
+        case validationException = "ValidationException"
+    }
 
-extension DetectiveErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceQuotaExceededException":
-            self = .serviceQuotaExceededException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceQuotaExceededException: Self { .init(.serviceQuotaExceededException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension DetectiveErrorType: Equatable {
+    public static func == (lhs: DetectiveErrorType, rhs: DetectiveErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension DetectiveErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceQuotaExceededException(let message):
-            return "ServiceQuotaExceededException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/DeviceFarm/DeviceFarm_Error.swift
+++ b/Sources/Soto/Services/DeviceFarm/DeviceFarm_Error.swift
@@ -17,85 +17,62 @@
 import SotoCore
 
 /// Error enum for DeviceFarm
-public enum DeviceFarmErrorType: AWSErrorType {
-    case argumentException(message: String?)
-    case cannotDeleteException(message: String?)
-    case idempotencyException(message: String?)
-    case internalServiceException(message: String?)
-    case invalidOperationException(message: String?)
-    case limitExceededException(message: String?)
-    case notEligibleException(message: String?)
-    case notFoundException(message: String?)
-    case serviceAccountException(message: String?)
-    case tagOperationException(message: String?)
-    case tagPolicyException(message: String?)
-    case tooManyTagsException(message: String?)
-}
+public struct DeviceFarmErrorType: AWSErrorType {
+    enum Code: String {
+        case argumentException = "ArgumentException"
+        case cannotDeleteException = "CannotDeleteException"
+        case idempotencyException = "IdempotencyException"
+        case internalServiceException = "InternalServiceException"
+        case invalidOperationException = "InvalidOperationException"
+        case limitExceededException = "LimitExceededException"
+        case notEligibleException = "NotEligibleException"
+        case notFoundException = "NotFoundException"
+        case serviceAccountException = "ServiceAccountException"
+        case tagOperationException = "TagOperationException"
+        case tagPolicyException = "TagPolicyException"
+        case tooManyTagsException = "TooManyTagsException"
+    }
 
-extension DeviceFarmErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ArgumentException":
-            self = .argumentException(message: message)
-        case "CannotDeleteException":
-            self = .cannotDeleteException(message: message)
-        case "IdempotencyException":
-            self = .idempotencyException(message: message)
-        case "InternalServiceException":
-            self = .internalServiceException(message: message)
-        case "InvalidOperationException":
-            self = .invalidOperationException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "NotEligibleException":
-            self = .notEligibleException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "ServiceAccountException":
-            self = .serviceAccountException(message: message)
-        case "TagOperationException":
-            self = .tagOperationException(message: message)
-        case "TagPolicyException":
-            self = .tagPolicyException(message: message)
-        case "TooManyTagsException":
-            self = .tooManyTagsException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var argumentException: Self { .init(.argumentException) }
+    public static var cannotDeleteException: Self { .init(.cannotDeleteException) }
+    public static var idempotencyException: Self { .init(.idempotencyException) }
+    public static var internalServiceException: Self { .init(.internalServiceException) }
+    public static var invalidOperationException: Self { .init(.invalidOperationException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var notEligibleException: Self { .init(.notEligibleException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var serviceAccountException: Self { .init(.serviceAccountException) }
+    public static var tagOperationException: Self { .init(.tagOperationException) }
+    public static var tagPolicyException: Self { .init(.tagPolicyException) }
+    public static var tooManyTagsException: Self { .init(.tooManyTagsException) }
+}
+
+extension DeviceFarmErrorType: Equatable {
+    public static func == (lhs: DeviceFarmErrorType, rhs: DeviceFarmErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension DeviceFarmErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .argumentException(let message):
-            return "ArgumentException: \(message ?? "")"
-        case .cannotDeleteException(let message):
-            return "CannotDeleteException: \(message ?? "")"
-        case .idempotencyException(let message):
-            return "IdempotencyException: \(message ?? "")"
-        case .internalServiceException(let message):
-            return "InternalServiceException: \(message ?? "")"
-        case .invalidOperationException(let message):
-            return "InvalidOperationException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .notEligibleException(let message):
-            return "NotEligibleException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .serviceAccountException(let message):
-            return "ServiceAccountException: \(message ?? "")"
-        case .tagOperationException(let message):
-            return "TagOperationException: \(message ?? "")"
-        case .tagPolicyException(let message):
-            return "TagPolicyException: \(message ?? "")"
-        case .tooManyTagsException(let message):
-            return "TooManyTagsException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/DirectConnect/DirectConnect_Error.swift
+++ b/Sources/Soto/Services/DirectConnect/DirectConnect_Error.swift
@@ -17,45 +17,46 @@
 import SotoCore
 
 /// Error enum for DirectConnect
-public enum DirectConnectErrorType: AWSErrorType {
-    case directConnectClientException(message: String?)
-    case directConnectServerException(message: String?)
-    case duplicateTagKeysException(message: String?)
-    case tooManyTagsException(message: String?)
-}
+public struct DirectConnectErrorType: AWSErrorType {
+    enum Code: String {
+        case directConnectClientException = "DirectConnectClientException"
+        case directConnectServerException = "DirectConnectServerException"
+        case duplicateTagKeysException = "DuplicateTagKeysException"
+        case tooManyTagsException = "TooManyTagsException"
+    }
 
-extension DirectConnectErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "DirectConnectClientException":
-            self = .directConnectClientException(message: message)
-        case "DirectConnectServerException":
-            self = .directConnectServerException(message: message)
-        case "DuplicateTagKeysException":
-            self = .duplicateTagKeysException(message: message)
-        case "TooManyTagsException":
-            self = .tooManyTagsException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var directConnectClientException: Self { .init(.directConnectClientException) }
+    public static var directConnectServerException: Self { .init(.directConnectServerException) }
+    public static var duplicateTagKeysException: Self { .init(.duplicateTagKeysException) }
+    public static var tooManyTagsException: Self { .init(.tooManyTagsException) }
+}
+
+extension DirectConnectErrorType: Equatable {
+    public static func == (lhs: DirectConnectErrorType, rhs: DirectConnectErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension DirectConnectErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .directConnectClientException(let message):
-            return "DirectConnectClientException: \(message ?? "")"
-        case .directConnectServerException(let message):
-            return "DirectConnectServerException: \(message ?? "")"
-        case .duplicateTagKeysException(let message):
-            return "DuplicateTagKeysException: \(message ?? "")"
-        case .tooManyTagsException(let message):
-            return "TooManyTagsException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/DirectoryService/DirectoryService_Error.swift
+++ b/Sources/Soto/Services/DirectoryService/DirectoryService_Error.swift
@@ -17,180 +17,100 @@
 import SotoCore
 
 /// Error enum for DirectoryService
-public enum DirectoryServiceErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case authenticationFailedException(message: String?)
-    case certificateAlreadyExistsException(message: String?)
-    case certificateDoesNotExistException(message: String?)
-    case certificateInUseException(message: String?)
-    case certificateLimitExceededException(message: String?)
-    case clientException(message: String?)
-    case directoryAlreadySharedException(message: String?)
-    case directoryDoesNotExistException(message: String?)
-    case directoryLimitExceededException(message: String?)
-    case directoryNotSharedException(message: String?)
-    case directoryUnavailableException(message: String?)
-    case domainControllerLimitExceededException(message: String?)
-    case entityAlreadyExistsException(message: String?)
-    case entityDoesNotExistException(message: String?)
-    case insufficientPermissionsException(message: String?)
-    case invalidCertificateException(message: String?)
-    case invalidLDAPSStatusException(message: String?)
-    case invalidNextTokenException(message: String?)
-    case invalidParameterException(message: String?)
-    case invalidPasswordException(message: String?)
-    case invalidTargetException(message: String?)
-    case ipRouteLimitExceededException(message: String?)
-    case noAvailableCertificateException(message: String?)
-    case organizationsException(message: String?)
-    case serviceException(message: String?)
-    case shareLimitExceededException(message: String?)
-    case snapshotLimitExceededException(message: String?)
-    case tagLimitExceededException(message: String?)
-    case unsupportedOperationException(message: String?)
-    case userDoesNotExistException(message: String?)
-}
+public struct DirectoryServiceErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case authenticationFailedException = "AuthenticationFailedException"
+        case certificateAlreadyExistsException = "CertificateAlreadyExistsException"
+        case certificateDoesNotExistException = "CertificateDoesNotExistException"
+        case certificateInUseException = "CertificateInUseException"
+        case certificateLimitExceededException = "CertificateLimitExceededException"
+        case clientException = "ClientException"
+        case directoryAlreadySharedException = "DirectoryAlreadySharedException"
+        case directoryDoesNotExistException = "DirectoryDoesNotExistException"
+        case directoryLimitExceededException = "DirectoryLimitExceededException"
+        case directoryNotSharedException = "DirectoryNotSharedException"
+        case directoryUnavailableException = "DirectoryUnavailableException"
+        case domainControllerLimitExceededException = "DomainControllerLimitExceededException"
+        case entityAlreadyExistsException = "EntityAlreadyExistsException"
+        case entityDoesNotExistException = "EntityDoesNotExistException"
+        case insufficientPermissionsException = "InsufficientPermissionsException"
+        case invalidCertificateException = "InvalidCertificateException"
+        case invalidLDAPSStatusException = "InvalidLDAPSStatusException"
+        case invalidNextTokenException = "InvalidNextTokenException"
+        case invalidParameterException = "InvalidParameterException"
+        case invalidPasswordException = "InvalidPasswordException"
+        case invalidTargetException = "InvalidTargetException"
+        case ipRouteLimitExceededException = "IpRouteLimitExceededException"
+        case noAvailableCertificateException = "NoAvailableCertificateException"
+        case organizationsException = "OrganizationsException"
+        case serviceException = "ServiceException"
+        case shareLimitExceededException = "ShareLimitExceededException"
+        case snapshotLimitExceededException = "SnapshotLimitExceededException"
+        case tagLimitExceededException = "TagLimitExceededException"
+        case unsupportedOperationException = "UnsupportedOperationException"
+        case userDoesNotExistException = "UserDoesNotExistException"
+    }
 
-extension DirectoryServiceErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "AuthenticationFailedException":
-            self = .authenticationFailedException(message: message)
-        case "CertificateAlreadyExistsException":
-            self = .certificateAlreadyExistsException(message: message)
-        case "CertificateDoesNotExistException":
-            self = .certificateDoesNotExistException(message: message)
-        case "CertificateInUseException":
-            self = .certificateInUseException(message: message)
-        case "CertificateLimitExceededException":
-            self = .certificateLimitExceededException(message: message)
-        case "ClientException":
-            self = .clientException(message: message)
-        case "DirectoryAlreadySharedException":
-            self = .directoryAlreadySharedException(message: message)
-        case "DirectoryDoesNotExistException":
-            self = .directoryDoesNotExistException(message: message)
-        case "DirectoryLimitExceededException":
-            self = .directoryLimitExceededException(message: message)
-        case "DirectoryNotSharedException":
-            self = .directoryNotSharedException(message: message)
-        case "DirectoryUnavailableException":
-            self = .directoryUnavailableException(message: message)
-        case "DomainControllerLimitExceededException":
-            self = .domainControllerLimitExceededException(message: message)
-        case "EntityAlreadyExistsException":
-            self = .entityAlreadyExistsException(message: message)
-        case "EntityDoesNotExistException":
-            self = .entityDoesNotExistException(message: message)
-        case "InsufficientPermissionsException":
-            self = .insufficientPermissionsException(message: message)
-        case "InvalidCertificateException":
-            self = .invalidCertificateException(message: message)
-        case "InvalidLDAPSStatusException":
-            self = .invalidLDAPSStatusException(message: message)
-        case "InvalidNextTokenException":
-            self = .invalidNextTokenException(message: message)
-        case "InvalidParameterException":
-            self = .invalidParameterException(message: message)
-        case "InvalidPasswordException":
-            self = .invalidPasswordException(message: message)
-        case "InvalidTargetException":
-            self = .invalidTargetException(message: message)
-        case "IpRouteLimitExceededException":
-            self = .ipRouteLimitExceededException(message: message)
-        case "NoAvailableCertificateException":
-            self = .noAvailableCertificateException(message: message)
-        case "OrganizationsException":
-            self = .organizationsException(message: message)
-        case "ServiceException":
-            self = .serviceException(message: message)
-        case "ShareLimitExceededException":
-            self = .shareLimitExceededException(message: message)
-        case "SnapshotLimitExceededException":
-            self = .snapshotLimitExceededException(message: message)
-        case "TagLimitExceededException":
-            self = .tagLimitExceededException(message: message)
-        case "UnsupportedOperationException":
-            self = .unsupportedOperationException(message: message)
-        case "UserDoesNotExistException":
-            self = .userDoesNotExistException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var authenticationFailedException: Self { .init(.authenticationFailedException) }
+    public static var certificateAlreadyExistsException: Self { .init(.certificateAlreadyExistsException) }
+    public static var certificateDoesNotExistException: Self { .init(.certificateDoesNotExistException) }
+    public static var certificateInUseException: Self { .init(.certificateInUseException) }
+    public static var certificateLimitExceededException: Self { .init(.certificateLimitExceededException) }
+    public static var clientException: Self { .init(.clientException) }
+    public static var directoryAlreadySharedException: Self { .init(.directoryAlreadySharedException) }
+    public static var directoryDoesNotExistException: Self { .init(.directoryDoesNotExistException) }
+    public static var directoryLimitExceededException: Self { .init(.directoryLimitExceededException) }
+    public static var directoryNotSharedException: Self { .init(.directoryNotSharedException) }
+    public static var directoryUnavailableException: Self { .init(.directoryUnavailableException) }
+    public static var domainControllerLimitExceededException: Self { .init(.domainControllerLimitExceededException) }
+    public static var entityAlreadyExistsException: Self { .init(.entityAlreadyExistsException) }
+    public static var entityDoesNotExistException: Self { .init(.entityDoesNotExistException) }
+    public static var insufficientPermissionsException: Self { .init(.insufficientPermissionsException) }
+    public static var invalidCertificateException: Self { .init(.invalidCertificateException) }
+    public static var invalidLDAPSStatusException: Self { .init(.invalidLDAPSStatusException) }
+    public static var invalidNextTokenException: Self { .init(.invalidNextTokenException) }
+    public static var invalidParameterException: Self { .init(.invalidParameterException) }
+    public static var invalidPasswordException: Self { .init(.invalidPasswordException) }
+    public static var invalidTargetException: Self { .init(.invalidTargetException) }
+    public static var ipRouteLimitExceededException: Self { .init(.ipRouteLimitExceededException) }
+    public static var noAvailableCertificateException: Self { .init(.noAvailableCertificateException) }
+    public static var organizationsException: Self { .init(.organizationsException) }
+    public static var serviceException: Self { .init(.serviceException) }
+    public static var shareLimitExceededException: Self { .init(.shareLimitExceededException) }
+    public static var snapshotLimitExceededException: Self { .init(.snapshotLimitExceededException) }
+    public static var tagLimitExceededException: Self { .init(.tagLimitExceededException) }
+    public static var unsupportedOperationException: Self { .init(.unsupportedOperationException) }
+    public static var userDoesNotExistException: Self { .init(.userDoesNotExistException) }
+}
+
+extension DirectoryServiceErrorType: Equatable {
+    public static func == (lhs: DirectoryServiceErrorType, rhs: DirectoryServiceErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension DirectoryServiceErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .authenticationFailedException(let message):
-            return "AuthenticationFailedException: \(message ?? "")"
-        case .certificateAlreadyExistsException(let message):
-            return "CertificateAlreadyExistsException: \(message ?? "")"
-        case .certificateDoesNotExistException(let message):
-            return "CertificateDoesNotExistException: \(message ?? "")"
-        case .certificateInUseException(let message):
-            return "CertificateInUseException: \(message ?? "")"
-        case .certificateLimitExceededException(let message):
-            return "CertificateLimitExceededException: \(message ?? "")"
-        case .clientException(let message):
-            return "ClientException: \(message ?? "")"
-        case .directoryAlreadySharedException(let message):
-            return "DirectoryAlreadySharedException: \(message ?? "")"
-        case .directoryDoesNotExistException(let message):
-            return "DirectoryDoesNotExistException: \(message ?? "")"
-        case .directoryLimitExceededException(let message):
-            return "DirectoryLimitExceededException: \(message ?? "")"
-        case .directoryNotSharedException(let message):
-            return "DirectoryNotSharedException: \(message ?? "")"
-        case .directoryUnavailableException(let message):
-            return "DirectoryUnavailableException: \(message ?? "")"
-        case .domainControllerLimitExceededException(let message):
-            return "DomainControllerLimitExceededException: \(message ?? "")"
-        case .entityAlreadyExistsException(let message):
-            return "EntityAlreadyExistsException: \(message ?? "")"
-        case .entityDoesNotExistException(let message):
-            return "EntityDoesNotExistException: \(message ?? "")"
-        case .insufficientPermissionsException(let message):
-            return "InsufficientPermissionsException: \(message ?? "")"
-        case .invalidCertificateException(let message):
-            return "InvalidCertificateException: \(message ?? "")"
-        case .invalidLDAPSStatusException(let message):
-            return "InvalidLDAPSStatusException: \(message ?? "")"
-        case .invalidNextTokenException(let message):
-            return "InvalidNextTokenException: \(message ?? "")"
-        case .invalidParameterException(let message):
-            return "InvalidParameterException: \(message ?? "")"
-        case .invalidPasswordException(let message):
-            return "InvalidPasswordException: \(message ?? "")"
-        case .invalidTargetException(let message):
-            return "InvalidTargetException: \(message ?? "")"
-        case .ipRouteLimitExceededException(let message):
-            return "IpRouteLimitExceededException: \(message ?? "")"
-        case .noAvailableCertificateException(let message):
-            return "NoAvailableCertificateException: \(message ?? "")"
-        case .organizationsException(let message):
-            return "OrganizationsException: \(message ?? "")"
-        case .serviceException(let message):
-            return "ServiceException: \(message ?? "")"
-        case .shareLimitExceededException(let message):
-            return "ShareLimitExceededException: \(message ?? "")"
-        case .snapshotLimitExceededException(let message):
-            return "SnapshotLimitExceededException: \(message ?? "")"
-        case .tagLimitExceededException(let message):
-            return "TagLimitExceededException: \(message ?? "")"
-        case .unsupportedOperationException(let message):
-            return "UnsupportedOperationException: \(message ?? "")"
-        case .userDoesNotExistException(let message):
-            return "UserDoesNotExistException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/DocDB/DocDB_Error.swift
+++ b/Sources/Soto/Services/DocDB/DocDB_Error.swift
@@ -17,245 +17,126 @@
 import SotoCore
 
 /// Error enum for DocDB
-public enum DocDBErrorType: AWSErrorType {
-    case authorizationNotFoundFault(message: String?)
-    case certificateNotFoundFault(message: String?)
-    case dBClusterAlreadyExistsFault(message: String?)
-    case dBClusterNotFoundFault(message: String?)
-    case dBClusterParameterGroupNotFoundFault(message: String?)
-    case dBClusterQuotaExceededFault(message: String?)
-    case dBClusterSnapshotAlreadyExistsFault(message: String?)
-    case dBClusterSnapshotNotFoundFault(message: String?)
-    case dBInstanceAlreadyExistsFault(message: String?)
-    case dBInstanceNotFoundFault(message: String?)
-    case dBParameterGroupAlreadyExistsFault(message: String?)
-    case dBParameterGroupNotFoundFault(message: String?)
-    case dBParameterGroupQuotaExceededFault(message: String?)
-    case dBSecurityGroupNotFoundFault(message: String?)
-    case dBSnapshotAlreadyExistsFault(message: String?)
-    case dBSnapshotNotFoundFault(message: String?)
-    case dBSubnetGroupAlreadyExistsFault(message: String?)
-    case dBSubnetGroupDoesNotCoverEnoughAZs(message: String?)
-    case dBSubnetGroupNotFoundFault(message: String?)
-    case dBSubnetGroupQuotaExceededFault(message: String?)
-    case dBSubnetQuotaExceededFault(message: String?)
-    case dBUpgradeDependencyFailureFault(message: String?)
-    case instanceQuotaExceededFault(message: String?)
-    case insufficientDBClusterCapacityFault(message: String?)
-    case insufficientDBInstanceCapacityFault(message: String?)
-    case insufficientStorageClusterCapacityFault(message: String?)
-    case invalidDBClusterSnapshotStateFault(message: String?)
-    case invalidDBClusterStateFault(message: String?)
-    case invalidDBInstanceStateFault(message: String?)
-    case invalidDBParameterGroupStateFault(message: String?)
-    case invalidDBSecurityGroupStateFault(message: String?)
-    case invalidDBSnapshotStateFault(message: String?)
-    case invalidDBSubnetGroupStateFault(message: String?)
-    case invalidDBSubnetStateFault(message: String?)
-    case invalidRestoreFault(message: String?)
-    case invalidSubnet(message: String?)
-    case invalidVPCNetworkStateFault(message: String?)
-    case kMSKeyNotAccessibleFault(message: String?)
-    case resourceNotFoundFault(message: String?)
-    case sharedSnapshotQuotaExceededFault(message: String?)
-    case snapshotQuotaExceededFault(message: String?)
-    case storageQuotaExceededFault(message: String?)
-    case storageTypeNotSupportedFault(message: String?)
-    case subnetAlreadyInUse(message: String?)
-}
+public struct DocDBErrorType: AWSErrorType {
+    enum Code: String {
+        case authorizationNotFoundFault = "AuthorizationNotFound"
+        case certificateNotFoundFault = "CertificateNotFound"
+        case dBClusterAlreadyExistsFault = "DBClusterAlreadyExistsFault"
+        case dBClusterNotFoundFault = "DBClusterNotFoundFault"
+        case dBClusterParameterGroupNotFoundFault = "DBClusterParameterGroupNotFound"
+        case dBClusterQuotaExceededFault = "DBClusterQuotaExceededFault"
+        case dBClusterSnapshotAlreadyExistsFault = "DBClusterSnapshotAlreadyExistsFault"
+        case dBClusterSnapshotNotFoundFault = "DBClusterSnapshotNotFoundFault"
+        case dBInstanceAlreadyExistsFault = "DBInstanceAlreadyExists"
+        case dBInstanceNotFoundFault = "DBInstanceNotFound"
+        case dBParameterGroupAlreadyExistsFault = "DBParameterGroupAlreadyExists"
+        case dBParameterGroupNotFoundFault = "DBParameterGroupNotFound"
+        case dBParameterGroupQuotaExceededFault = "DBParameterGroupQuotaExceeded"
+        case dBSecurityGroupNotFoundFault = "DBSecurityGroupNotFound"
+        case dBSnapshotAlreadyExistsFault = "DBSnapshotAlreadyExists"
+        case dBSnapshotNotFoundFault = "DBSnapshotNotFound"
+        case dBSubnetGroupAlreadyExistsFault = "DBSubnetGroupAlreadyExists"
+        case dBSubnetGroupDoesNotCoverEnoughAZs = "DBSubnetGroupDoesNotCoverEnoughAZs"
+        case dBSubnetGroupNotFoundFault = "DBSubnetGroupNotFoundFault"
+        case dBSubnetGroupQuotaExceededFault = "DBSubnetGroupQuotaExceeded"
+        case dBSubnetQuotaExceededFault = "DBSubnetQuotaExceededFault"
+        case dBUpgradeDependencyFailureFault = "DBUpgradeDependencyFailure"
+        case instanceQuotaExceededFault = "InstanceQuotaExceeded"
+        case insufficientDBClusterCapacityFault = "InsufficientDBClusterCapacityFault"
+        case insufficientDBInstanceCapacityFault = "InsufficientDBInstanceCapacity"
+        case insufficientStorageClusterCapacityFault = "InsufficientStorageClusterCapacity"
+        case invalidDBClusterSnapshotStateFault = "InvalidDBClusterSnapshotStateFault"
+        case invalidDBClusterStateFault = "InvalidDBClusterStateFault"
+        case invalidDBInstanceStateFault = "InvalidDBInstanceState"
+        case invalidDBParameterGroupStateFault = "InvalidDBParameterGroupState"
+        case invalidDBSecurityGroupStateFault = "InvalidDBSecurityGroupState"
+        case invalidDBSnapshotStateFault = "InvalidDBSnapshotState"
+        case invalidDBSubnetGroupStateFault = "InvalidDBSubnetGroupStateFault"
+        case invalidDBSubnetStateFault = "InvalidDBSubnetStateFault"
+        case invalidRestoreFault = "InvalidRestoreFault"
+        case invalidSubnet = "InvalidSubnet"
+        case invalidVPCNetworkStateFault = "InvalidVPCNetworkStateFault"
+        case kMSKeyNotAccessibleFault = "KMSKeyNotAccessibleFault"
+        case resourceNotFoundFault = "ResourceNotFoundFault"
+        case sharedSnapshotQuotaExceededFault = "SharedSnapshotQuotaExceeded"
+        case snapshotQuotaExceededFault = "SnapshotQuotaExceeded"
+        case storageQuotaExceededFault = "StorageQuotaExceeded"
+        case storageTypeNotSupportedFault = "StorageTypeNotSupported"
+        case subnetAlreadyInUse = "SubnetAlreadyInUse"
+    }
 
-extension DocDBErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AuthorizationNotFound":
-            self = .authorizationNotFoundFault(message: message)
-        case "CertificateNotFound":
-            self = .certificateNotFoundFault(message: message)
-        case "DBClusterAlreadyExistsFault":
-            self = .dBClusterAlreadyExistsFault(message: message)
-        case "DBClusterNotFoundFault":
-            self = .dBClusterNotFoundFault(message: message)
-        case "DBClusterParameterGroupNotFound":
-            self = .dBClusterParameterGroupNotFoundFault(message: message)
-        case "DBClusterQuotaExceededFault":
-            self = .dBClusterQuotaExceededFault(message: message)
-        case "DBClusterSnapshotAlreadyExistsFault":
-            self = .dBClusterSnapshotAlreadyExistsFault(message: message)
-        case "DBClusterSnapshotNotFoundFault":
-            self = .dBClusterSnapshotNotFoundFault(message: message)
-        case "DBInstanceAlreadyExists":
-            self = .dBInstanceAlreadyExistsFault(message: message)
-        case "DBInstanceNotFound":
-            self = .dBInstanceNotFoundFault(message: message)
-        case "DBParameterGroupAlreadyExists":
-            self = .dBParameterGroupAlreadyExistsFault(message: message)
-        case "DBParameterGroupNotFound":
-            self = .dBParameterGroupNotFoundFault(message: message)
-        case "DBParameterGroupQuotaExceeded":
-            self = .dBParameterGroupQuotaExceededFault(message: message)
-        case "DBSecurityGroupNotFound":
-            self = .dBSecurityGroupNotFoundFault(message: message)
-        case "DBSnapshotAlreadyExists":
-            self = .dBSnapshotAlreadyExistsFault(message: message)
-        case "DBSnapshotNotFound":
-            self = .dBSnapshotNotFoundFault(message: message)
-        case "DBSubnetGroupAlreadyExists":
-            self = .dBSubnetGroupAlreadyExistsFault(message: message)
-        case "DBSubnetGroupDoesNotCoverEnoughAZs":
-            self = .dBSubnetGroupDoesNotCoverEnoughAZs(message: message)
-        case "DBSubnetGroupNotFoundFault":
-            self = .dBSubnetGroupNotFoundFault(message: message)
-        case "DBSubnetGroupQuotaExceeded":
-            self = .dBSubnetGroupQuotaExceededFault(message: message)
-        case "DBSubnetQuotaExceededFault":
-            self = .dBSubnetQuotaExceededFault(message: message)
-        case "DBUpgradeDependencyFailure":
-            self = .dBUpgradeDependencyFailureFault(message: message)
-        case "InstanceQuotaExceeded":
-            self = .instanceQuotaExceededFault(message: message)
-        case "InsufficientDBClusterCapacityFault":
-            self = .insufficientDBClusterCapacityFault(message: message)
-        case "InsufficientDBInstanceCapacity":
-            self = .insufficientDBInstanceCapacityFault(message: message)
-        case "InsufficientStorageClusterCapacity":
-            self = .insufficientStorageClusterCapacityFault(message: message)
-        case "InvalidDBClusterSnapshotStateFault":
-            self = .invalidDBClusterSnapshotStateFault(message: message)
-        case "InvalidDBClusterStateFault":
-            self = .invalidDBClusterStateFault(message: message)
-        case "InvalidDBInstanceState":
-            self = .invalidDBInstanceStateFault(message: message)
-        case "InvalidDBParameterGroupState":
-            self = .invalidDBParameterGroupStateFault(message: message)
-        case "InvalidDBSecurityGroupState":
-            self = .invalidDBSecurityGroupStateFault(message: message)
-        case "InvalidDBSnapshotState":
-            self = .invalidDBSnapshotStateFault(message: message)
-        case "InvalidDBSubnetGroupStateFault":
-            self = .invalidDBSubnetGroupStateFault(message: message)
-        case "InvalidDBSubnetStateFault":
-            self = .invalidDBSubnetStateFault(message: message)
-        case "InvalidRestoreFault":
-            self = .invalidRestoreFault(message: message)
-        case "InvalidSubnet":
-            self = .invalidSubnet(message: message)
-        case "InvalidVPCNetworkStateFault":
-            self = .invalidVPCNetworkStateFault(message: message)
-        case "KMSKeyNotAccessibleFault":
-            self = .kMSKeyNotAccessibleFault(message: message)
-        case "ResourceNotFoundFault":
-            self = .resourceNotFoundFault(message: message)
-        case "SharedSnapshotQuotaExceeded":
-            self = .sharedSnapshotQuotaExceededFault(message: message)
-        case "SnapshotQuotaExceeded":
-            self = .snapshotQuotaExceededFault(message: message)
-        case "StorageQuotaExceeded":
-            self = .storageQuotaExceededFault(message: message)
-        case "StorageTypeNotSupported":
-            self = .storageTypeNotSupportedFault(message: message)
-        case "SubnetAlreadyInUse":
-            self = .subnetAlreadyInUse(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var authorizationNotFoundFault: Self { .init(.authorizationNotFoundFault) }
+    public static var certificateNotFoundFault: Self { .init(.certificateNotFoundFault) }
+    public static var dBClusterAlreadyExistsFault: Self { .init(.dBClusterAlreadyExistsFault) }
+    public static var dBClusterNotFoundFault: Self { .init(.dBClusterNotFoundFault) }
+    public static var dBClusterParameterGroupNotFoundFault: Self { .init(.dBClusterParameterGroupNotFoundFault) }
+    public static var dBClusterQuotaExceededFault: Self { .init(.dBClusterQuotaExceededFault) }
+    public static var dBClusterSnapshotAlreadyExistsFault: Self { .init(.dBClusterSnapshotAlreadyExistsFault) }
+    public static var dBClusterSnapshotNotFoundFault: Self { .init(.dBClusterSnapshotNotFoundFault) }
+    public static var dBInstanceAlreadyExistsFault: Self { .init(.dBInstanceAlreadyExistsFault) }
+    public static var dBInstanceNotFoundFault: Self { .init(.dBInstanceNotFoundFault) }
+    public static var dBParameterGroupAlreadyExistsFault: Self { .init(.dBParameterGroupAlreadyExistsFault) }
+    public static var dBParameterGroupNotFoundFault: Self { .init(.dBParameterGroupNotFoundFault) }
+    public static var dBParameterGroupQuotaExceededFault: Self { .init(.dBParameterGroupQuotaExceededFault) }
+    public static var dBSecurityGroupNotFoundFault: Self { .init(.dBSecurityGroupNotFoundFault) }
+    public static var dBSnapshotAlreadyExistsFault: Self { .init(.dBSnapshotAlreadyExistsFault) }
+    public static var dBSnapshotNotFoundFault: Self { .init(.dBSnapshotNotFoundFault) }
+    public static var dBSubnetGroupAlreadyExistsFault: Self { .init(.dBSubnetGroupAlreadyExistsFault) }
+    public static var dBSubnetGroupDoesNotCoverEnoughAZs: Self { .init(.dBSubnetGroupDoesNotCoverEnoughAZs) }
+    public static var dBSubnetGroupNotFoundFault: Self { .init(.dBSubnetGroupNotFoundFault) }
+    public static var dBSubnetGroupQuotaExceededFault: Self { .init(.dBSubnetGroupQuotaExceededFault) }
+    public static var dBSubnetQuotaExceededFault: Self { .init(.dBSubnetQuotaExceededFault) }
+    public static var dBUpgradeDependencyFailureFault: Self { .init(.dBUpgradeDependencyFailureFault) }
+    public static var instanceQuotaExceededFault: Self { .init(.instanceQuotaExceededFault) }
+    public static var insufficientDBClusterCapacityFault: Self { .init(.insufficientDBClusterCapacityFault) }
+    public static var insufficientDBInstanceCapacityFault: Self { .init(.insufficientDBInstanceCapacityFault) }
+    public static var insufficientStorageClusterCapacityFault: Self { .init(.insufficientStorageClusterCapacityFault) }
+    public static var invalidDBClusterSnapshotStateFault: Self { .init(.invalidDBClusterSnapshotStateFault) }
+    public static var invalidDBClusterStateFault: Self { .init(.invalidDBClusterStateFault) }
+    public static var invalidDBInstanceStateFault: Self { .init(.invalidDBInstanceStateFault) }
+    public static var invalidDBParameterGroupStateFault: Self { .init(.invalidDBParameterGroupStateFault) }
+    public static var invalidDBSecurityGroupStateFault: Self { .init(.invalidDBSecurityGroupStateFault) }
+    public static var invalidDBSnapshotStateFault: Self { .init(.invalidDBSnapshotStateFault) }
+    public static var invalidDBSubnetGroupStateFault: Self { .init(.invalidDBSubnetGroupStateFault) }
+    public static var invalidDBSubnetStateFault: Self { .init(.invalidDBSubnetStateFault) }
+    public static var invalidRestoreFault: Self { .init(.invalidRestoreFault) }
+    public static var invalidSubnet: Self { .init(.invalidSubnet) }
+    public static var invalidVPCNetworkStateFault: Self { .init(.invalidVPCNetworkStateFault) }
+    public static var kMSKeyNotAccessibleFault: Self { .init(.kMSKeyNotAccessibleFault) }
+    public static var resourceNotFoundFault: Self { .init(.resourceNotFoundFault) }
+    public static var sharedSnapshotQuotaExceededFault: Self { .init(.sharedSnapshotQuotaExceededFault) }
+    public static var snapshotQuotaExceededFault: Self { .init(.snapshotQuotaExceededFault) }
+    public static var storageQuotaExceededFault: Self { .init(.storageQuotaExceededFault) }
+    public static var storageTypeNotSupportedFault: Self { .init(.storageTypeNotSupportedFault) }
+    public static var subnetAlreadyInUse: Self { .init(.subnetAlreadyInUse) }
+}
+
+extension DocDBErrorType: Equatable {
+    public static func == (lhs: DocDBErrorType, rhs: DocDBErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension DocDBErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .authorizationNotFoundFault(let message):
-            return "AuthorizationNotFound: \(message ?? "")"
-        case .certificateNotFoundFault(let message):
-            return "CertificateNotFound: \(message ?? "")"
-        case .dBClusterAlreadyExistsFault(let message):
-            return "DBClusterAlreadyExistsFault: \(message ?? "")"
-        case .dBClusterNotFoundFault(let message):
-            return "DBClusterNotFoundFault: \(message ?? "")"
-        case .dBClusterParameterGroupNotFoundFault(let message):
-            return "DBClusterParameterGroupNotFound: \(message ?? "")"
-        case .dBClusterQuotaExceededFault(let message):
-            return "DBClusterQuotaExceededFault: \(message ?? "")"
-        case .dBClusterSnapshotAlreadyExistsFault(let message):
-            return "DBClusterSnapshotAlreadyExistsFault: \(message ?? "")"
-        case .dBClusterSnapshotNotFoundFault(let message):
-            return "DBClusterSnapshotNotFoundFault: \(message ?? "")"
-        case .dBInstanceAlreadyExistsFault(let message):
-            return "DBInstanceAlreadyExists: \(message ?? "")"
-        case .dBInstanceNotFoundFault(let message):
-            return "DBInstanceNotFound: \(message ?? "")"
-        case .dBParameterGroupAlreadyExistsFault(let message):
-            return "DBParameterGroupAlreadyExists: \(message ?? "")"
-        case .dBParameterGroupNotFoundFault(let message):
-            return "DBParameterGroupNotFound: \(message ?? "")"
-        case .dBParameterGroupQuotaExceededFault(let message):
-            return "DBParameterGroupQuotaExceeded: \(message ?? "")"
-        case .dBSecurityGroupNotFoundFault(let message):
-            return "DBSecurityGroupNotFound: \(message ?? "")"
-        case .dBSnapshotAlreadyExistsFault(let message):
-            return "DBSnapshotAlreadyExists: \(message ?? "")"
-        case .dBSnapshotNotFoundFault(let message):
-            return "DBSnapshotNotFound: \(message ?? "")"
-        case .dBSubnetGroupAlreadyExistsFault(let message):
-            return "DBSubnetGroupAlreadyExists: \(message ?? "")"
-        case .dBSubnetGroupDoesNotCoverEnoughAZs(let message):
-            return "DBSubnetGroupDoesNotCoverEnoughAZs: \(message ?? "")"
-        case .dBSubnetGroupNotFoundFault(let message):
-            return "DBSubnetGroupNotFoundFault: \(message ?? "")"
-        case .dBSubnetGroupQuotaExceededFault(let message):
-            return "DBSubnetGroupQuotaExceeded: \(message ?? "")"
-        case .dBSubnetQuotaExceededFault(let message):
-            return "DBSubnetQuotaExceededFault: \(message ?? "")"
-        case .dBUpgradeDependencyFailureFault(let message):
-            return "DBUpgradeDependencyFailure: \(message ?? "")"
-        case .instanceQuotaExceededFault(let message):
-            return "InstanceQuotaExceeded: \(message ?? "")"
-        case .insufficientDBClusterCapacityFault(let message):
-            return "InsufficientDBClusterCapacityFault: \(message ?? "")"
-        case .insufficientDBInstanceCapacityFault(let message):
-            return "InsufficientDBInstanceCapacity: \(message ?? "")"
-        case .insufficientStorageClusterCapacityFault(let message):
-            return "InsufficientStorageClusterCapacity: \(message ?? "")"
-        case .invalidDBClusterSnapshotStateFault(let message):
-            return "InvalidDBClusterSnapshotStateFault: \(message ?? "")"
-        case .invalidDBClusterStateFault(let message):
-            return "InvalidDBClusterStateFault: \(message ?? "")"
-        case .invalidDBInstanceStateFault(let message):
-            return "InvalidDBInstanceState: \(message ?? "")"
-        case .invalidDBParameterGroupStateFault(let message):
-            return "InvalidDBParameterGroupState: \(message ?? "")"
-        case .invalidDBSecurityGroupStateFault(let message):
-            return "InvalidDBSecurityGroupState: \(message ?? "")"
-        case .invalidDBSnapshotStateFault(let message):
-            return "InvalidDBSnapshotState: \(message ?? "")"
-        case .invalidDBSubnetGroupStateFault(let message):
-            return "InvalidDBSubnetGroupStateFault: \(message ?? "")"
-        case .invalidDBSubnetStateFault(let message):
-            return "InvalidDBSubnetStateFault: \(message ?? "")"
-        case .invalidRestoreFault(let message):
-            return "InvalidRestoreFault: \(message ?? "")"
-        case .invalidSubnet(let message):
-            return "InvalidSubnet: \(message ?? "")"
-        case .invalidVPCNetworkStateFault(let message):
-            return "InvalidVPCNetworkStateFault: \(message ?? "")"
-        case .kMSKeyNotAccessibleFault(let message):
-            return "KMSKeyNotAccessibleFault: \(message ?? "")"
-        case .resourceNotFoundFault(let message):
-            return "ResourceNotFoundFault: \(message ?? "")"
-        case .sharedSnapshotQuotaExceededFault(let message):
-            return "SharedSnapshotQuotaExceeded: \(message ?? "")"
-        case .snapshotQuotaExceededFault(let message):
-            return "SnapshotQuotaExceeded: \(message ?? "")"
-        case .storageQuotaExceededFault(let message):
-            return "StorageQuotaExceeded: \(message ?? "")"
-        case .storageTypeNotSupportedFault(let message):
-            return "StorageTypeNotSupported: \(message ?? "")"
-        case .subnetAlreadyInUse(let message):
-            return "SubnetAlreadyInUse: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/DynamoDB/DynamoDB_Error.swift
+++ b/Sources/Soto/Services/DynamoDB/DynamoDB_Error.swift
@@ -17,150 +17,88 @@
 import SotoCore
 
 /// Error enum for DynamoDB
-public enum DynamoDBErrorType: AWSErrorType {
-    case backupInUseException(message: String?)
-    case backupNotFoundException(message: String?)
-    case conditionalCheckFailedException(message: String?)
-    case continuousBackupsUnavailableException(message: String?)
-    case globalTableAlreadyExistsException(message: String?)
-    case globalTableNotFoundException(message: String?)
-    case idempotentParameterMismatchException(message: String?)
-    case indexNotFoundException(message: String?)
-    case internalServerError(message: String?)
-    case invalidRestoreTimeException(message: String?)
-    case itemCollectionSizeLimitExceededException(message: String?)
-    case limitExceededException(message: String?)
-    case pointInTimeRecoveryUnavailableException(message: String?)
-    case provisionedThroughputExceededException(message: String?)
-    case replicaAlreadyExistsException(message: String?)
-    case replicaNotFoundException(message: String?)
-    case requestLimitExceeded(message: String?)
-    case resourceInUseException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case tableAlreadyExistsException(message: String?)
-    case tableInUseException(message: String?)
-    case tableNotFoundException(message: String?)
-    case transactionCanceledException(message: String?)
-    case transactionConflictException(message: String?)
-    case transactionInProgressException(message: String?)
-}
+public struct DynamoDBErrorType: AWSErrorType {
+    enum Code: String {
+        case backupInUseException = "BackupInUseException"
+        case backupNotFoundException = "BackupNotFoundException"
+        case conditionalCheckFailedException = "ConditionalCheckFailedException"
+        case continuousBackupsUnavailableException = "ContinuousBackupsUnavailableException"
+        case globalTableAlreadyExistsException = "GlobalTableAlreadyExistsException"
+        case globalTableNotFoundException = "GlobalTableNotFoundException"
+        case idempotentParameterMismatchException = "IdempotentParameterMismatchException"
+        case indexNotFoundException = "IndexNotFoundException"
+        case internalServerError = "InternalServerError"
+        case invalidRestoreTimeException = "InvalidRestoreTimeException"
+        case itemCollectionSizeLimitExceededException = "ItemCollectionSizeLimitExceededException"
+        case limitExceededException = "LimitExceededException"
+        case pointInTimeRecoveryUnavailableException = "PointInTimeRecoveryUnavailableException"
+        case provisionedThroughputExceededException = "ProvisionedThroughputExceededException"
+        case replicaAlreadyExistsException = "ReplicaAlreadyExistsException"
+        case replicaNotFoundException = "ReplicaNotFoundException"
+        case requestLimitExceeded = "RequestLimitExceeded"
+        case resourceInUseException = "ResourceInUseException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case tableAlreadyExistsException = "TableAlreadyExistsException"
+        case tableInUseException = "TableInUseException"
+        case tableNotFoundException = "TableNotFoundException"
+        case transactionCanceledException = "TransactionCanceledException"
+        case transactionConflictException = "TransactionConflictException"
+        case transactionInProgressException = "TransactionInProgressException"
+    }
 
-extension DynamoDBErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "BackupInUseException":
-            self = .backupInUseException(message: message)
-        case "BackupNotFoundException":
-            self = .backupNotFoundException(message: message)
-        case "ConditionalCheckFailedException":
-            self = .conditionalCheckFailedException(message: message)
-        case "ContinuousBackupsUnavailableException":
-            self = .continuousBackupsUnavailableException(message: message)
-        case "GlobalTableAlreadyExistsException":
-            self = .globalTableAlreadyExistsException(message: message)
-        case "GlobalTableNotFoundException":
-            self = .globalTableNotFoundException(message: message)
-        case "IdempotentParameterMismatchException":
-            self = .idempotentParameterMismatchException(message: message)
-        case "IndexNotFoundException":
-            self = .indexNotFoundException(message: message)
-        case "InternalServerError":
-            self = .internalServerError(message: message)
-        case "InvalidRestoreTimeException":
-            self = .invalidRestoreTimeException(message: message)
-        case "ItemCollectionSizeLimitExceededException":
-            self = .itemCollectionSizeLimitExceededException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "PointInTimeRecoveryUnavailableException":
-            self = .pointInTimeRecoveryUnavailableException(message: message)
-        case "ProvisionedThroughputExceededException":
-            self = .provisionedThroughputExceededException(message: message)
-        case "ReplicaAlreadyExistsException":
-            self = .replicaAlreadyExistsException(message: message)
-        case "ReplicaNotFoundException":
-            self = .replicaNotFoundException(message: message)
-        case "RequestLimitExceeded":
-            self = .requestLimitExceeded(message: message)
-        case "ResourceInUseException":
-            self = .resourceInUseException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "TableAlreadyExistsException":
-            self = .tableAlreadyExistsException(message: message)
-        case "TableInUseException":
-            self = .tableInUseException(message: message)
-        case "TableNotFoundException":
-            self = .tableNotFoundException(message: message)
-        case "TransactionCanceledException":
-            self = .transactionCanceledException(message: message)
-        case "TransactionConflictException":
-            self = .transactionConflictException(message: message)
-        case "TransactionInProgressException":
-            self = .transactionInProgressException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var backupInUseException: Self { .init(.backupInUseException) }
+    public static var backupNotFoundException: Self { .init(.backupNotFoundException) }
+    public static var conditionalCheckFailedException: Self { .init(.conditionalCheckFailedException) }
+    public static var continuousBackupsUnavailableException: Self { .init(.continuousBackupsUnavailableException) }
+    public static var globalTableAlreadyExistsException: Self { .init(.globalTableAlreadyExistsException) }
+    public static var globalTableNotFoundException: Self { .init(.globalTableNotFoundException) }
+    public static var idempotentParameterMismatchException: Self { .init(.idempotentParameterMismatchException) }
+    public static var indexNotFoundException: Self { .init(.indexNotFoundException) }
+    public static var internalServerError: Self { .init(.internalServerError) }
+    public static var invalidRestoreTimeException: Self { .init(.invalidRestoreTimeException) }
+    public static var itemCollectionSizeLimitExceededException: Self { .init(.itemCollectionSizeLimitExceededException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var pointInTimeRecoveryUnavailableException: Self { .init(.pointInTimeRecoveryUnavailableException) }
+    public static var provisionedThroughputExceededException: Self { .init(.provisionedThroughputExceededException) }
+    public static var replicaAlreadyExistsException: Self { .init(.replicaAlreadyExistsException) }
+    public static var replicaNotFoundException: Self { .init(.replicaNotFoundException) }
+    public static var requestLimitExceeded: Self { .init(.requestLimitExceeded) }
+    public static var resourceInUseException: Self { .init(.resourceInUseException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var tableAlreadyExistsException: Self { .init(.tableAlreadyExistsException) }
+    public static var tableInUseException: Self { .init(.tableInUseException) }
+    public static var tableNotFoundException: Self { .init(.tableNotFoundException) }
+    public static var transactionCanceledException: Self { .init(.transactionCanceledException) }
+    public static var transactionConflictException: Self { .init(.transactionConflictException) }
+    public static var transactionInProgressException: Self { .init(.transactionInProgressException) }
+}
+
+extension DynamoDBErrorType: Equatable {
+    public static func == (lhs: DynamoDBErrorType, rhs: DynamoDBErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension DynamoDBErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .backupInUseException(let message):
-            return "BackupInUseException: \(message ?? "")"
-        case .backupNotFoundException(let message):
-            return "BackupNotFoundException: \(message ?? "")"
-        case .conditionalCheckFailedException(let message):
-            return "ConditionalCheckFailedException: \(message ?? "")"
-        case .continuousBackupsUnavailableException(let message):
-            return "ContinuousBackupsUnavailableException: \(message ?? "")"
-        case .globalTableAlreadyExistsException(let message):
-            return "GlobalTableAlreadyExistsException: \(message ?? "")"
-        case .globalTableNotFoundException(let message):
-            return "GlobalTableNotFoundException: \(message ?? "")"
-        case .idempotentParameterMismatchException(let message):
-            return "IdempotentParameterMismatchException: \(message ?? "")"
-        case .indexNotFoundException(let message):
-            return "IndexNotFoundException: \(message ?? "")"
-        case .internalServerError(let message):
-            return "InternalServerError: \(message ?? "")"
-        case .invalidRestoreTimeException(let message):
-            return "InvalidRestoreTimeException: \(message ?? "")"
-        case .itemCollectionSizeLimitExceededException(let message):
-            return "ItemCollectionSizeLimitExceededException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .pointInTimeRecoveryUnavailableException(let message):
-            return "PointInTimeRecoveryUnavailableException: \(message ?? "")"
-        case .provisionedThroughputExceededException(let message):
-            return "ProvisionedThroughputExceededException: \(message ?? "")"
-        case .replicaAlreadyExistsException(let message):
-            return "ReplicaAlreadyExistsException: \(message ?? "")"
-        case .replicaNotFoundException(let message):
-            return "ReplicaNotFoundException: \(message ?? "")"
-        case .requestLimitExceeded(let message):
-            return "RequestLimitExceeded: \(message ?? "")"
-        case .resourceInUseException(let message):
-            return "ResourceInUseException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .tableAlreadyExistsException(let message):
-            return "TableAlreadyExistsException: \(message ?? "")"
-        case .tableInUseException(let message):
-            return "TableInUseException: \(message ?? "")"
-        case .tableNotFoundException(let message):
-            return "TableNotFoundException: \(message ?? "")"
-        case .transactionCanceledException(let message):
-            return "TransactionCanceledException: \(message ?? "")"
-        case .transactionConflictException(let message):
-            return "TransactionConflictException: \(message ?? "")"
-        case .transactionInProgressException(let message):
-            return "TransactionInProgressException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/DynamoDBStreams/DynamoDBStreams_Error.swift
+++ b/Sources/Soto/Services/DynamoDBStreams/DynamoDBStreams_Error.swift
@@ -17,50 +17,48 @@
 import SotoCore
 
 /// Error enum for DynamoDBStreams
-public enum DynamoDBStreamsErrorType: AWSErrorType {
-    case expiredIteratorException(message: String?)
-    case internalServerError(message: String?)
-    case limitExceededException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case trimmedDataAccessException(message: String?)
-}
+public struct DynamoDBStreamsErrorType: AWSErrorType {
+    enum Code: String {
+        case expiredIteratorException = "ExpiredIteratorException"
+        case internalServerError = "InternalServerError"
+        case limitExceededException = "LimitExceededException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case trimmedDataAccessException = "TrimmedDataAccessException"
+    }
 
-extension DynamoDBStreamsErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ExpiredIteratorException":
-            self = .expiredIteratorException(message: message)
-        case "InternalServerError":
-            self = .internalServerError(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "TrimmedDataAccessException":
-            self = .trimmedDataAccessException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var expiredIteratorException: Self { .init(.expiredIteratorException) }
+    public static var internalServerError: Self { .init(.internalServerError) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var trimmedDataAccessException: Self { .init(.trimmedDataAccessException) }
+}
+
+extension DynamoDBStreamsErrorType: Equatable {
+    public static func == (lhs: DynamoDBStreamsErrorType, rhs: DynamoDBStreamsErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension DynamoDBStreamsErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .expiredIteratorException(let message):
-            return "ExpiredIteratorException: \(message ?? "")"
-        case .internalServerError(let message):
-            return "InternalServerError: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .trimmedDataAccessException(let message):
-            return "TrimmedDataAccessException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/EBS/EBS_Error.swift
+++ b/Sources/Soto/Services/EBS/EBS_Error.swift
@@ -17,65 +17,54 @@
 import SotoCore
 
 /// Error enum for EBS
-public enum EBSErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case concurrentLimitExceededException(message: String?)
-    case conflictException(message: String?)
-    case internalServerException(message: String?)
-    case requestThrottledException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceQuotaExceededException(message: String?)
-    case validationException(message: String?)
-}
+public struct EBSErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case concurrentLimitExceededException = "ConcurrentLimitExceededException"
+        case conflictException = "ConflictException"
+        case internalServerException = "InternalServerException"
+        case requestThrottledException = "RequestThrottledException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceQuotaExceededException = "ServiceQuotaExceededException"
+        case validationException = "ValidationException"
+    }
 
-extension EBSErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "ConcurrentLimitExceededException":
-            self = .concurrentLimitExceededException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "RequestThrottledException":
-            self = .requestThrottledException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceQuotaExceededException":
-            self = .serviceQuotaExceededException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var concurrentLimitExceededException: Self { .init(.concurrentLimitExceededException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var requestThrottledException: Self { .init(.requestThrottledException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceQuotaExceededException: Self { .init(.serviceQuotaExceededException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension EBSErrorType: Equatable {
+    public static func == (lhs: EBSErrorType, rhs: EBSErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension EBSErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .concurrentLimitExceededException(let message):
-            return "ConcurrentLimitExceededException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .requestThrottledException(let message):
-            return "RequestThrottledException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceQuotaExceededException(let message):
-            return "ServiceQuotaExceededException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/EC2InstanceConnect/EC2InstanceConnect_Error.swift
+++ b/Sources/Soto/Services/EC2InstanceConnect/EC2InstanceConnect_Error.swift
@@ -17,50 +17,48 @@
 import SotoCore
 
 /// Error enum for EC2InstanceConnect
-public enum EC2InstanceConnectErrorType: AWSErrorType {
-    case authException(message: String?)
-    case eC2InstanceNotFoundException(message: String?)
-    case invalidArgsException(message: String?)
-    case serviceException(message: String?)
-    case throttlingException(message: String?)
-}
+public struct EC2InstanceConnectErrorType: AWSErrorType {
+    enum Code: String {
+        case authException = "AuthException"
+        case eC2InstanceNotFoundException = "EC2InstanceNotFoundException"
+        case invalidArgsException = "InvalidArgsException"
+        case serviceException = "ServiceException"
+        case throttlingException = "ThrottlingException"
+    }
 
-extension EC2InstanceConnectErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AuthException":
-            self = .authException(message: message)
-        case "EC2InstanceNotFoundException":
-            self = .eC2InstanceNotFoundException(message: message)
-        case "InvalidArgsException":
-            self = .invalidArgsException(message: message)
-        case "ServiceException":
-            self = .serviceException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var authException: Self { .init(.authException) }
+    public static var eC2InstanceNotFoundException: Self { .init(.eC2InstanceNotFoundException) }
+    public static var invalidArgsException: Self { .init(.invalidArgsException) }
+    public static var serviceException: Self { .init(.serviceException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+}
+
+extension EC2InstanceConnectErrorType: Equatable {
+    public static func == (lhs: EC2InstanceConnectErrorType, rhs: EC2InstanceConnectErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension EC2InstanceConnectErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .authException(let message):
-            return "AuthException: \(message ?? "")"
-        case .eC2InstanceNotFoundException(let message):
-            return "EC2InstanceNotFoundException: \(message ?? "")"
-        case .invalidArgsException(let message):
-            return "InvalidArgsException: \(message ?? "")"
-        case .serviceException(let message):
-            return "ServiceException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/ECR/ECR_Error.swift
+++ b/Sources/Soto/Services/ECR/ECR_Error.swift
@@ -17,165 +17,94 @@
 import SotoCore
 
 /// Error enum for ECR
-public enum ECRErrorType: AWSErrorType {
-    case emptyUploadException(message: String?)
-    case imageAlreadyExistsException(message: String?)
-    case imageDigestDoesNotMatchException(message: String?)
-    case imageNotFoundException(message: String?)
-    case imageTagAlreadyExistsException(message: String?)
-    case invalidLayerException(message: String?)
-    case invalidLayerPartException(message: String?)
-    case invalidParameterException(message: String?)
-    case invalidTagParameterException(message: String?)
-    case kmsException(message: String?)
-    case layerAlreadyExistsException(message: String?)
-    case layerInaccessibleException(message: String?)
-    case layerPartTooSmallException(message: String?)
-    case layersNotFoundException(message: String?)
-    case lifecyclePolicyNotFoundException(message: String?)
-    case lifecyclePolicyPreviewInProgressException(message: String?)
-    case lifecyclePolicyPreviewNotFoundException(message: String?)
-    case limitExceededException(message: String?)
-    case referencedImagesNotFoundException(message: String?)
-    case repositoryAlreadyExistsException(message: String?)
-    case repositoryNotEmptyException(message: String?)
-    case repositoryNotFoundException(message: String?)
-    case repositoryPolicyNotFoundException(message: String?)
-    case scanNotFoundException(message: String?)
-    case serverException(message: String?)
-    case tooManyTagsException(message: String?)
-    case unsupportedImageTypeException(message: String?)
-    case uploadNotFoundException(message: String?)
-}
+public struct ECRErrorType: AWSErrorType {
+    enum Code: String {
+        case emptyUploadException = "EmptyUploadException"
+        case imageAlreadyExistsException = "ImageAlreadyExistsException"
+        case imageDigestDoesNotMatchException = "ImageDigestDoesNotMatchException"
+        case imageNotFoundException = "ImageNotFoundException"
+        case imageTagAlreadyExistsException = "ImageTagAlreadyExistsException"
+        case invalidLayerException = "InvalidLayerException"
+        case invalidLayerPartException = "InvalidLayerPartException"
+        case invalidParameterException = "InvalidParameterException"
+        case invalidTagParameterException = "InvalidTagParameterException"
+        case kmsException = "KmsException"
+        case layerAlreadyExistsException = "LayerAlreadyExistsException"
+        case layerInaccessibleException = "LayerInaccessibleException"
+        case layerPartTooSmallException = "LayerPartTooSmallException"
+        case layersNotFoundException = "LayersNotFoundException"
+        case lifecyclePolicyNotFoundException = "LifecyclePolicyNotFoundException"
+        case lifecyclePolicyPreviewInProgressException = "LifecyclePolicyPreviewInProgressException"
+        case lifecyclePolicyPreviewNotFoundException = "LifecyclePolicyPreviewNotFoundException"
+        case limitExceededException = "LimitExceededException"
+        case referencedImagesNotFoundException = "ReferencedImagesNotFoundException"
+        case repositoryAlreadyExistsException = "RepositoryAlreadyExistsException"
+        case repositoryNotEmptyException = "RepositoryNotEmptyException"
+        case repositoryNotFoundException = "RepositoryNotFoundException"
+        case repositoryPolicyNotFoundException = "RepositoryPolicyNotFoundException"
+        case scanNotFoundException = "ScanNotFoundException"
+        case serverException = "ServerException"
+        case tooManyTagsException = "TooManyTagsException"
+        case unsupportedImageTypeException = "UnsupportedImageTypeException"
+        case uploadNotFoundException = "UploadNotFoundException"
+    }
 
-extension ECRErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "EmptyUploadException":
-            self = .emptyUploadException(message: message)
-        case "ImageAlreadyExistsException":
-            self = .imageAlreadyExistsException(message: message)
-        case "ImageDigestDoesNotMatchException":
-            self = .imageDigestDoesNotMatchException(message: message)
-        case "ImageNotFoundException":
-            self = .imageNotFoundException(message: message)
-        case "ImageTagAlreadyExistsException":
-            self = .imageTagAlreadyExistsException(message: message)
-        case "InvalidLayerException":
-            self = .invalidLayerException(message: message)
-        case "InvalidLayerPartException":
-            self = .invalidLayerPartException(message: message)
-        case "InvalidParameterException":
-            self = .invalidParameterException(message: message)
-        case "InvalidTagParameterException":
-            self = .invalidTagParameterException(message: message)
-        case "KmsException":
-            self = .kmsException(message: message)
-        case "LayerAlreadyExistsException":
-            self = .layerAlreadyExistsException(message: message)
-        case "LayerInaccessibleException":
-            self = .layerInaccessibleException(message: message)
-        case "LayerPartTooSmallException":
-            self = .layerPartTooSmallException(message: message)
-        case "LayersNotFoundException":
-            self = .layersNotFoundException(message: message)
-        case "LifecyclePolicyNotFoundException":
-            self = .lifecyclePolicyNotFoundException(message: message)
-        case "LifecyclePolicyPreviewInProgressException":
-            self = .lifecyclePolicyPreviewInProgressException(message: message)
-        case "LifecyclePolicyPreviewNotFoundException":
-            self = .lifecyclePolicyPreviewNotFoundException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ReferencedImagesNotFoundException":
-            self = .referencedImagesNotFoundException(message: message)
-        case "RepositoryAlreadyExistsException":
-            self = .repositoryAlreadyExistsException(message: message)
-        case "RepositoryNotEmptyException":
-            self = .repositoryNotEmptyException(message: message)
-        case "RepositoryNotFoundException":
-            self = .repositoryNotFoundException(message: message)
-        case "RepositoryPolicyNotFoundException":
-            self = .repositoryPolicyNotFoundException(message: message)
-        case "ScanNotFoundException":
-            self = .scanNotFoundException(message: message)
-        case "ServerException":
-            self = .serverException(message: message)
-        case "TooManyTagsException":
-            self = .tooManyTagsException(message: message)
-        case "UnsupportedImageTypeException":
-            self = .unsupportedImageTypeException(message: message)
-        case "UploadNotFoundException":
-            self = .uploadNotFoundException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var emptyUploadException: Self { .init(.emptyUploadException) }
+    public static var imageAlreadyExistsException: Self { .init(.imageAlreadyExistsException) }
+    public static var imageDigestDoesNotMatchException: Self { .init(.imageDigestDoesNotMatchException) }
+    public static var imageNotFoundException: Self { .init(.imageNotFoundException) }
+    public static var imageTagAlreadyExistsException: Self { .init(.imageTagAlreadyExistsException) }
+    public static var invalidLayerException: Self { .init(.invalidLayerException) }
+    public static var invalidLayerPartException: Self { .init(.invalidLayerPartException) }
+    public static var invalidParameterException: Self { .init(.invalidParameterException) }
+    public static var invalidTagParameterException: Self { .init(.invalidTagParameterException) }
+    public static var kmsException: Self { .init(.kmsException) }
+    public static var layerAlreadyExistsException: Self { .init(.layerAlreadyExistsException) }
+    public static var layerInaccessibleException: Self { .init(.layerInaccessibleException) }
+    public static var layerPartTooSmallException: Self { .init(.layerPartTooSmallException) }
+    public static var layersNotFoundException: Self { .init(.layersNotFoundException) }
+    public static var lifecyclePolicyNotFoundException: Self { .init(.lifecyclePolicyNotFoundException) }
+    public static var lifecyclePolicyPreviewInProgressException: Self { .init(.lifecyclePolicyPreviewInProgressException) }
+    public static var lifecyclePolicyPreviewNotFoundException: Self { .init(.lifecyclePolicyPreviewNotFoundException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var referencedImagesNotFoundException: Self { .init(.referencedImagesNotFoundException) }
+    public static var repositoryAlreadyExistsException: Self { .init(.repositoryAlreadyExistsException) }
+    public static var repositoryNotEmptyException: Self { .init(.repositoryNotEmptyException) }
+    public static var repositoryNotFoundException: Self { .init(.repositoryNotFoundException) }
+    public static var repositoryPolicyNotFoundException: Self { .init(.repositoryPolicyNotFoundException) }
+    public static var scanNotFoundException: Self { .init(.scanNotFoundException) }
+    public static var serverException: Self { .init(.serverException) }
+    public static var tooManyTagsException: Self { .init(.tooManyTagsException) }
+    public static var unsupportedImageTypeException: Self { .init(.unsupportedImageTypeException) }
+    public static var uploadNotFoundException: Self { .init(.uploadNotFoundException) }
+}
+
+extension ECRErrorType: Equatable {
+    public static func == (lhs: ECRErrorType, rhs: ECRErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ECRErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .emptyUploadException(let message):
-            return "EmptyUploadException: \(message ?? "")"
-        case .imageAlreadyExistsException(let message):
-            return "ImageAlreadyExistsException: \(message ?? "")"
-        case .imageDigestDoesNotMatchException(let message):
-            return "ImageDigestDoesNotMatchException: \(message ?? "")"
-        case .imageNotFoundException(let message):
-            return "ImageNotFoundException: \(message ?? "")"
-        case .imageTagAlreadyExistsException(let message):
-            return "ImageTagAlreadyExistsException: \(message ?? "")"
-        case .invalidLayerException(let message):
-            return "InvalidLayerException: \(message ?? "")"
-        case .invalidLayerPartException(let message):
-            return "InvalidLayerPartException: \(message ?? "")"
-        case .invalidParameterException(let message):
-            return "InvalidParameterException: \(message ?? "")"
-        case .invalidTagParameterException(let message):
-            return "InvalidTagParameterException: \(message ?? "")"
-        case .kmsException(let message):
-            return "KmsException: \(message ?? "")"
-        case .layerAlreadyExistsException(let message):
-            return "LayerAlreadyExistsException: \(message ?? "")"
-        case .layerInaccessibleException(let message):
-            return "LayerInaccessibleException: \(message ?? "")"
-        case .layerPartTooSmallException(let message):
-            return "LayerPartTooSmallException: \(message ?? "")"
-        case .layersNotFoundException(let message):
-            return "LayersNotFoundException: \(message ?? "")"
-        case .lifecyclePolicyNotFoundException(let message):
-            return "LifecyclePolicyNotFoundException: \(message ?? "")"
-        case .lifecyclePolicyPreviewInProgressException(let message):
-            return "LifecyclePolicyPreviewInProgressException: \(message ?? "")"
-        case .lifecyclePolicyPreviewNotFoundException(let message):
-            return "LifecyclePolicyPreviewNotFoundException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .referencedImagesNotFoundException(let message):
-            return "ReferencedImagesNotFoundException: \(message ?? "")"
-        case .repositoryAlreadyExistsException(let message):
-            return "RepositoryAlreadyExistsException: \(message ?? "")"
-        case .repositoryNotEmptyException(let message):
-            return "RepositoryNotEmptyException: \(message ?? "")"
-        case .repositoryNotFoundException(let message):
-            return "RepositoryNotFoundException: \(message ?? "")"
-        case .repositoryPolicyNotFoundException(let message):
-            return "RepositoryPolicyNotFoundException: \(message ?? "")"
-        case .scanNotFoundException(let message):
-            return "ScanNotFoundException: \(message ?? "")"
-        case .serverException(let message):
-            return "ServerException: \(message ?? "")"
-        case .tooManyTagsException(let message):
-            return "TooManyTagsException: \(message ?? "")"
-        case .unsupportedImageTypeException(let message):
-            return "UnsupportedImageTypeException: \(message ?? "")"
-        case .uploadNotFoundException(let message):
-            return "UploadNotFoundException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/ECS/ECS_Error.swift
+++ b/Sources/Soto/Services/ECS/ECS_Error.swift
@@ -17,140 +17,84 @@
 import SotoCore
 
 /// Error enum for ECS
-public enum ECSErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case attributeLimitExceededException(message: String?)
-    case blockedException(message: String?)
-    case clientException(message: String?)
-    case clusterContainsContainerInstancesException(message: String?)
-    case clusterContainsServicesException(message: String?)
-    case clusterContainsTasksException(message: String?)
-    case clusterNotFoundException(message: String?)
-    case invalidParameterException(message: String?)
-    case limitExceededException(message: String?)
-    case missingVersionException(message: String?)
-    case noUpdateAvailableException(message: String?)
-    case platformTaskDefinitionIncompatibilityException(message: String?)
-    case platformUnknownException(message: String?)
-    case resourceInUseException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serverException(message: String?)
-    case serviceNotActiveException(message: String?)
-    case serviceNotFoundException(message: String?)
-    case targetNotFoundException(message: String?)
-    case taskSetNotFoundException(message: String?)
-    case unsupportedFeatureException(message: String?)
-    case updateInProgressException(message: String?)
-}
+public struct ECSErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case attributeLimitExceededException = "AttributeLimitExceededException"
+        case blockedException = "BlockedException"
+        case clientException = "ClientException"
+        case clusterContainsContainerInstancesException = "ClusterContainsContainerInstancesException"
+        case clusterContainsServicesException = "ClusterContainsServicesException"
+        case clusterContainsTasksException = "ClusterContainsTasksException"
+        case clusterNotFoundException = "ClusterNotFoundException"
+        case invalidParameterException = "InvalidParameterException"
+        case limitExceededException = "LimitExceededException"
+        case missingVersionException = "MissingVersionException"
+        case noUpdateAvailableException = "NoUpdateAvailableException"
+        case platformTaskDefinitionIncompatibilityException = "PlatformTaskDefinitionIncompatibilityException"
+        case platformUnknownException = "PlatformUnknownException"
+        case resourceInUseException = "ResourceInUseException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serverException = "ServerException"
+        case serviceNotActiveException = "ServiceNotActiveException"
+        case serviceNotFoundException = "ServiceNotFoundException"
+        case targetNotFoundException = "TargetNotFoundException"
+        case taskSetNotFoundException = "TaskSetNotFoundException"
+        case unsupportedFeatureException = "UnsupportedFeatureException"
+        case updateInProgressException = "UpdateInProgressException"
+    }
 
-extension ECSErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "AttributeLimitExceededException":
-            self = .attributeLimitExceededException(message: message)
-        case "BlockedException":
-            self = .blockedException(message: message)
-        case "ClientException":
-            self = .clientException(message: message)
-        case "ClusterContainsContainerInstancesException":
-            self = .clusterContainsContainerInstancesException(message: message)
-        case "ClusterContainsServicesException":
-            self = .clusterContainsServicesException(message: message)
-        case "ClusterContainsTasksException":
-            self = .clusterContainsTasksException(message: message)
-        case "ClusterNotFoundException":
-            self = .clusterNotFoundException(message: message)
-        case "InvalidParameterException":
-            self = .invalidParameterException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "MissingVersionException":
-            self = .missingVersionException(message: message)
-        case "NoUpdateAvailableException":
-            self = .noUpdateAvailableException(message: message)
-        case "PlatformTaskDefinitionIncompatibilityException":
-            self = .platformTaskDefinitionIncompatibilityException(message: message)
-        case "PlatformUnknownException":
-            self = .platformUnknownException(message: message)
-        case "ResourceInUseException":
-            self = .resourceInUseException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServerException":
-            self = .serverException(message: message)
-        case "ServiceNotActiveException":
-            self = .serviceNotActiveException(message: message)
-        case "ServiceNotFoundException":
-            self = .serviceNotFoundException(message: message)
-        case "TargetNotFoundException":
-            self = .targetNotFoundException(message: message)
-        case "TaskSetNotFoundException":
-            self = .taskSetNotFoundException(message: message)
-        case "UnsupportedFeatureException":
-            self = .unsupportedFeatureException(message: message)
-        case "UpdateInProgressException":
-            self = .updateInProgressException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var attributeLimitExceededException: Self { .init(.attributeLimitExceededException) }
+    public static var blockedException: Self { .init(.blockedException) }
+    public static var clientException: Self { .init(.clientException) }
+    public static var clusterContainsContainerInstancesException: Self { .init(.clusterContainsContainerInstancesException) }
+    public static var clusterContainsServicesException: Self { .init(.clusterContainsServicesException) }
+    public static var clusterContainsTasksException: Self { .init(.clusterContainsTasksException) }
+    public static var clusterNotFoundException: Self { .init(.clusterNotFoundException) }
+    public static var invalidParameterException: Self { .init(.invalidParameterException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var missingVersionException: Self { .init(.missingVersionException) }
+    public static var noUpdateAvailableException: Self { .init(.noUpdateAvailableException) }
+    public static var platformTaskDefinitionIncompatibilityException: Self { .init(.platformTaskDefinitionIncompatibilityException) }
+    public static var platformUnknownException: Self { .init(.platformUnknownException) }
+    public static var resourceInUseException: Self { .init(.resourceInUseException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serverException: Self { .init(.serverException) }
+    public static var serviceNotActiveException: Self { .init(.serviceNotActiveException) }
+    public static var serviceNotFoundException: Self { .init(.serviceNotFoundException) }
+    public static var targetNotFoundException: Self { .init(.targetNotFoundException) }
+    public static var taskSetNotFoundException: Self { .init(.taskSetNotFoundException) }
+    public static var unsupportedFeatureException: Self { .init(.unsupportedFeatureException) }
+    public static var updateInProgressException: Self { .init(.updateInProgressException) }
+}
+
+extension ECSErrorType: Equatable {
+    public static func == (lhs: ECSErrorType, rhs: ECSErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ECSErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .attributeLimitExceededException(let message):
-            return "AttributeLimitExceededException: \(message ?? "")"
-        case .blockedException(let message):
-            return "BlockedException: \(message ?? "")"
-        case .clientException(let message):
-            return "ClientException: \(message ?? "")"
-        case .clusterContainsContainerInstancesException(let message):
-            return "ClusterContainsContainerInstancesException: \(message ?? "")"
-        case .clusterContainsServicesException(let message):
-            return "ClusterContainsServicesException: \(message ?? "")"
-        case .clusterContainsTasksException(let message):
-            return "ClusterContainsTasksException: \(message ?? "")"
-        case .clusterNotFoundException(let message):
-            return "ClusterNotFoundException: \(message ?? "")"
-        case .invalidParameterException(let message):
-            return "InvalidParameterException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .missingVersionException(let message):
-            return "MissingVersionException: \(message ?? "")"
-        case .noUpdateAvailableException(let message):
-            return "NoUpdateAvailableException: \(message ?? "")"
-        case .platformTaskDefinitionIncompatibilityException(let message):
-            return "PlatformTaskDefinitionIncompatibilityException: \(message ?? "")"
-        case .platformUnknownException(let message):
-            return "PlatformUnknownException: \(message ?? "")"
-        case .resourceInUseException(let message):
-            return "ResourceInUseException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serverException(let message):
-            return "ServerException: \(message ?? "")"
-        case .serviceNotActiveException(let message):
-            return "ServiceNotActiveException: \(message ?? "")"
-        case .serviceNotFoundException(let message):
-            return "ServiceNotFoundException: \(message ?? "")"
-        case .targetNotFoundException(let message):
-            return "TargetNotFoundException: \(message ?? "")"
-        case .taskSetNotFoundException(let message):
-            return "TaskSetNotFoundException: \(message ?? "")"
-        case .unsupportedFeatureException(let message):
-            return "UnsupportedFeatureException: \(message ?? "")"
-        case .updateInProgressException(let message):
-            return "UpdateInProgressException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/EFS/EFS_Error.swift
+++ b/Sources/Soto/Services/EFS/EFS_Error.swift
@@ -17,160 +17,92 @@
 import SotoCore
 
 /// Error enum for EFS
-public enum EFSErrorType: AWSErrorType {
-    case accessPointAlreadyExists(message: String?)
-    case accessPointLimitExceeded(message: String?)
-    case accessPointNotFound(message: String?)
-    case badRequest(message: String?)
-    case dependencyTimeout(message: String?)
-    case fileSystemAlreadyExists(message: String?)
-    case fileSystemInUse(message: String?)
-    case fileSystemLimitExceeded(message: String?)
-    case fileSystemNotFound(message: String?)
-    case incorrectFileSystemLifeCycleState(message: String?)
-    case incorrectMountTargetState(message: String?)
-    case insufficientThroughputCapacity(message: String?)
-    case internalServerError(message: String?)
-    case invalidPolicyException(message: String?)
-    case ipAddressInUse(message: String?)
-    case mountTargetConflict(message: String?)
-    case mountTargetNotFound(message: String?)
-    case networkInterfaceLimitExceeded(message: String?)
-    case noFreeAddressesInSubnet(message: String?)
-    case policyNotFound(message: String?)
-    case securityGroupLimitExceeded(message: String?)
-    case securityGroupNotFound(message: String?)
-    case subnetNotFound(message: String?)
-    case throughputLimitExceeded(message: String?)
-    case tooManyRequests(message: String?)
-    case unsupportedAvailabilityZone(message: String?)
-    case validationException(message: String?)
-}
+public struct EFSErrorType: AWSErrorType {
+    enum Code: String {
+        case accessPointAlreadyExists = "AccessPointAlreadyExists"
+        case accessPointLimitExceeded = "AccessPointLimitExceeded"
+        case accessPointNotFound = "AccessPointNotFound"
+        case badRequest = "BadRequest"
+        case dependencyTimeout = "DependencyTimeout"
+        case fileSystemAlreadyExists = "FileSystemAlreadyExists"
+        case fileSystemInUse = "FileSystemInUse"
+        case fileSystemLimitExceeded = "FileSystemLimitExceeded"
+        case fileSystemNotFound = "FileSystemNotFound"
+        case incorrectFileSystemLifeCycleState = "IncorrectFileSystemLifeCycleState"
+        case incorrectMountTargetState = "IncorrectMountTargetState"
+        case insufficientThroughputCapacity = "InsufficientThroughputCapacity"
+        case internalServerError = "InternalServerError"
+        case invalidPolicyException = "InvalidPolicyException"
+        case ipAddressInUse = "IpAddressInUse"
+        case mountTargetConflict = "MountTargetConflict"
+        case mountTargetNotFound = "MountTargetNotFound"
+        case networkInterfaceLimitExceeded = "NetworkInterfaceLimitExceeded"
+        case noFreeAddressesInSubnet = "NoFreeAddressesInSubnet"
+        case policyNotFound = "PolicyNotFound"
+        case securityGroupLimitExceeded = "SecurityGroupLimitExceeded"
+        case securityGroupNotFound = "SecurityGroupNotFound"
+        case subnetNotFound = "SubnetNotFound"
+        case throughputLimitExceeded = "ThroughputLimitExceeded"
+        case tooManyRequests = "TooManyRequests"
+        case unsupportedAvailabilityZone = "UnsupportedAvailabilityZone"
+        case validationException = "ValidationException"
+    }
 
-extension EFSErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessPointAlreadyExists":
-            self = .accessPointAlreadyExists(message: message)
-        case "AccessPointLimitExceeded":
-            self = .accessPointLimitExceeded(message: message)
-        case "AccessPointNotFound":
-            self = .accessPointNotFound(message: message)
-        case "BadRequest":
-            self = .badRequest(message: message)
-        case "DependencyTimeout":
-            self = .dependencyTimeout(message: message)
-        case "FileSystemAlreadyExists":
-            self = .fileSystemAlreadyExists(message: message)
-        case "FileSystemInUse":
-            self = .fileSystemInUse(message: message)
-        case "FileSystemLimitExceeded":
-            self = .fileSystemLimitExceeded(message: message)
-        case "FileSystemNotFound":
-            self = .fileSystemNotFound(message: message)
-        case "IncorrectFileSystemLifeCycleState":
-            self = .incorrectFileSystemLifeCycleState(message: message)
-        case "IncorrectMountTargetState":
-            self = .incorrectMountTargetState(message: message)
-        case "InsufficientThroughputCapacity":
-            self = .insufficientThroughputCapacity(message: message)
-        case "InternalServerError":
-            self = .internalServerError(message: message)
-        case "InvalidPolicyException":
-            self = .invalidPolicyException(message: message)
-        case "IpAddressInUse":
-            self = .ipAddressInUse(message: message)
-        case "MountTargetConflict":
-            self = .mountTargetConflict(message: message)
-        case "MountTargetNotFound":
-            self = .mountTargetNotFound(message: message)
-        case "NetworkInterfaceLimitExceeded":
-            self = .networkInterfaceLimitExceeded(message: message)
-        case "NoFreeAddressesInSubnet":
-            self = .noFreeAddressesInSubnet(message: message)
-        case "PolicyNotFound":
-            self = .policyNotFound(message: message)
-        case "SecurityGroupLimitExceeded":
-            self = .securityGroupLimitExceeded(message: message)
-        case "SecurityGroupNotFound":
-            self = .securityGroupNotFound(message: message)
-        case "SubnetNotFound":
-            self = .subnetNotFound(message: message)
-        case "ThroughputLimitExceeded":
-            self = .throughputLimitExceeded(message: message)
-        case "TooManyRequests":
-            self = .tooManyRequests(message: message)
-        case "UnsupportedAvailabilityZone":
-            self = .unsupportedAvailabilityZone(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessPointAlreadyExists: Self { .init(.accessPointAlreadyExists) }
+    public static var accessPointLimitExceeded: Self { .init(.accessPointLimitExceeded) }
+    public static var accessPointNotFound: Self { .init(.accessPointNotFound) }
+    public static var badRequest: Self { .init(.badRequest) }
+    public static var dependencyTimeout: Self { .init(.dependencyTimeout) }
+    public static var fileSystemAlreadyExists: Self { .init(.fileSystemAlreadyExists) }
+    public static var fileSystemInUse: Self { .init(.fileSystemInUse) }
+    public static var fileSystemLimitExceeded: Self { .init(.fileSystemLimitExceeded) }
+    public static var fileSystemNotFound: Self { .init(.fileSystemNotFound) }
+    public static var incorrectFileSystemLifeCycleState: Self { .init(.incorrectFileSystemLifeCycleState) }
+    public static var incorrectMountTargetState: Self { .init(.incorrectMountTargetState) }
+    public static var insufficientThroughputCapacity: Self { .init(.insufficientThroughputCapacity) }
+    public static var internalServerError: Self { .init(.internalServerError) }
+    public static var invalidPolicyException: Self { .init(.invalidPolicyException) }
+    public static var ipAddressInUse: Self { .init(.ipAddressInUse) }
+    public static var mountTargetConflict: Self { .init(.mountTargetConflict) }
+    public static var mountTargetNotFound: Self { .init(.mountTargetNotFound) }
+    public static var networkInterfaceLimitExceeded: Self { .init(.networkInterfaceLimitExceeded) }
+    public static var noFreeAddressesInSubnet: Self { .init(.noFreeAddressesInSubnet) }
+    public static var policyNotFound: Self { .init(.policyNotFound) }
+    public static var securityGroupLimitExceeded: Self { .init(.securityGroupLimitExceeded) }
+    public static var securityGroupNotFound: Self { .init(.securityGroupNotFound) }
+    public static var subnetNotFound: Self { .init(.subnetNotFound) }
+    public static var throughputLimitExceeded: Self { .init(.throughputLimitExceeded) }
+    public static var tooManyRequests: Self { .init(.tooManyRequests) }
+    public static var unsupportedAvailabilityZone: Self { .init(.unsupportedAvailabilityZone) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension EFSErrorType: Equatable {
+    public static func == (lhs: EFSErrorType, rhs: EFSErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension EFSErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessPointAlreadyExists(let message):
-            return "AccessPointAlreadyExists: \(message ?? "")"
-        case .accessPointLimitExceeded(let message):
-            return "AccessPointLimitExceeded: \(message ?? "")"
-        case .accessPointNotFound(let message):
-            return "AccessPointNotFound: \(message ?? "")"
-        case .badRequest(let message):
-            return "BadRequest: \(message ?? "")"
-        case .dependencyTimeout(let message):
-            return "DependencyTimeout: \(message ?? "")"
-        case .fileSystemAlreadyExists(let message):
-            return "FileSystemAlreadyExists: \(message ?? "")"
-        case .fileSystemInUse(let message):
-            return "FileSystemInUse: \(message ?? "")"
-        case .fileSystemLimitExceeded(let message):
-            return "FileSystemLimitExceeded: \(message ?? "")"
-        case .fileSystemNotFound(let message):
-            return "FileSystemNotFound: \(message ?? "")"
-        case .incorrectFileSystemLifeCycleState(let message):
-            return "IncorrectFileSystemLifeCycleState: \(message ?? "")"
-        case .incorrectMountTargetState(let message):
-            return "IncorrectMountTargetState: \(message ?? "")"
-        case .insufficientThroughputCapacity(let message):
-            return "InsufficientThroughputCapacity: \(message ?? "")"
-        case .internalServerError(let message):
-            return "InternalServerError: \(message ?? "")"
-        case .invalidPolicyException(let message):
-            return "InvalidPolicyException: \(message ?? "")"
-        case .ipAddressInUse(let message):
-            return "IpAddressInUse: \(message ?? "")"
-        case .mountTargetConflict(let message):
-            return "MountTargetConflict: \(message ?? "")"
-        case .mountTargetNotFound(let message):
-            return "MountTargetNotFound: \(message ?? "")"
-        case .networkInterfaceLimitExceeded(let message):
-            return "NetworkInterfaceLimitExceeded: \(message ?? "")"
-        case .noFreeAddressesInSubnet(let message):
-            return "NoFreeAddressesInSubnet: \(message ?? "")"
-        case .policyNotFound(let message):
-            return "PolicyNotFound: \(message ?? "")"
-        case .securityGroupLimitExceeded(let message):
-            return "SecurityGroupLimitExceeded: \(message ?? "")"
-        case .securityGroupNotFound(let message):
-            return "SecurityGroupNotFound: \(message ?? "")"
-        case .subnetNotFound(let message):
-            return "SubnetNotFound: \(message ?? "")"
-        case .throughputLimitExceeded(let message):
-            return "ThroughputLimitExceeded: \(message ?? "")"
-        case .tooManyRequests(let message):
-            return "TooManyRequests: \(message ?? "")"
-        case .unsupportedAvailabilityZone(let message):
-            return "UnsupportedAvailabilityZone: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/EKS/EKS_Error.swift
+++ b/Sources/Soto/Services/EKS/EKS_Error.swift
@@ -17,80 +17,60 @@
 import SotoCore
 
 /// Error enum for EKS
-public enum EKSErrorType: AWSErrorType {
-    case badRequestException(message: String?)
-    case clientException(message: String?)
-    case invalidParameterException(message: String?)
-    case invalidRequestException(message: String?)
-    case notFoundException(message: String?)
-    case resourceInUseException(message: String?)
-    case resourceLimitExceededException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serverException(message: String?)
-    case serviceUnavailableException(message: String?)
-    case unsupportedAvailabilityZoneException(message: String?)
-}
+public struct EKSErrorType: AWSErrorType {
+    enum Code: String {
+        case badRequestException = "BadRequestException"
+        case clientException = "ClientException"
+        case invalidParameterException = "InvalidParameterException"
+        case invalidRequestException = "InvalidRequestException"
+        case notFoundException = "NotFoundException"
+        case resourceInUseException = "ResourceInUseException"
+        case resourceLimitExceededException = "ResourceLimitExceededException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serverException = "ServerException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+        case unsupportedAvailabilityZoneException = "UnsupportedAvailabilityZoneException"
+    }
 
-extension EKSErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        case "ClientException":
-            self = .clientException(message: message)
-        case "InvalidParameterException":
-            self = .invalidParameterException(message: message)
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "ResourceInUseException":
-            self = .resourceInUseException(message: message)
-        case "ResourceLimitExceededException":
-            self = .resourceLimitExceededException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServerException":
-            self = .serverException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        case "UnsupportedAvailabilityZoneException":
-            self = .unsupportedAvailabilityZoneException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var badRequestException: Self { .init(.badRequestException) }
+    public static var clientException: Self { .init(.clientException) }
+    public static var invalidParameterException: Self { .init(.invalidParameterException) }
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var resourceInUseException: Self { .init(.resourceInUseException) }
+    public static var resourceLimitExceededException: Self { .init(.resourceLimitExceededException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serverException: Self { .init(.serverException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+    public static var unsupportedAvailabilityZoneException: Self { .init(.unsupportedAvailabilityZoneException) }
+}
+
+extension EKSErrorType: Equatable {
+    public static func == (lhs: EKSErrorType, rhs: EKSErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension EKSErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        case .clientException(let message):
-            return "ClientException: \(message ?? "")"
-        case .invalidParameterException(let message):
-            return "InvalidParameterException: \(message ?? "")"
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .resourceInUseException(let message):
-            return "ResourceInUseException: \(message ?? "")"
-        case .resourceLimitExceededException(let message):
-            return "ResourceLimitExceededException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serverException(let message):
-            return "ServerException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        case .unsupportedAvailabilityZoneException(let message):
-            return "UnsupportedAvailabilityZoneException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/ElastiCache/ElastiCache_Error.swift
+++ b/Sources/Soto/Services/ElastiCache/ElastiCache_Error.swift
@@ -17,300 +17,148 @@
 import SotoCore
 
 /// Error enum for ElastiCache
-public enum ElastiCacheErrorType: AWSErrorType {
-    case aPICallRateForCustomerExceededFault(message: String?)
-    case authorizationAlreadyExistsFault(message: String?)
-    case authorizationNotFoundFault(message: String?)
-    case cacheClusterAlreadyExistsFault(message: String?)
-    case cacheClusterNotFoundFault(message: String?)
-    case cacheParameterGroupAlreadyExistsFault(message: String?)
-    case cacheParameterGroupNotFoundFault(message: String?)
-    case cacheParameterGroupQuotaExceededFault(message: String?)
-    case cacheSecurityGroupAlreadyExistsFault(message: String?)
-    case cacheSecurityGroupNotFoundFault(message: String?)
-    case cacheSecurityGroupQuotaExceededFault(message: String?)
-    case cacheSubnetGroupAlreadyExistsFault(message: String?)
-    case cacheSubnetGroupInUse(message: String?)
-    case cacheSubnetGroupNotFoundFault(message: String?)
-    case cacheSubnetGroupQuotaExceededFault(message: String?)
-    case cacheSubnetQuotaExceededFault(message: String?)
-    case clusterQuotaForCustomerExceededFault(message: String?)
-    case globalReplicationGroupAlreadyExistsFault(message: String?)
-    case globalReplicationGroupNotFoundFault(message: String?)
-    case insufficientCacheClusterCapacityFault(message: String?)
-    case invalidARNFault(message: String?)
-    case invalidCacheClusterStateFault(message: String?)
-    case invalidCacheParameterGroupStateFault(message: String?)
-    case invalidCacheSecurityGroupStateFault(message: String?)
-    case invalidGlobalReplicationGroupStateFault(message: String?)
-    case invalidKMSKeyFault(message: String?)
-    case invalidParameterCombinationException(message: String?)
-    case invalidParameterValueException(message: String?)
-    case invalidReplicationGroupStateFault(message: String?)
-    case invalidSnapshotStateFault(message: String?)
-    case invalidSubnet(message: String?)
-    case invalidVPCNetworkStateFault(message: String?)
-    case noOperationFault(message: String?)
-    case nodeGroupNotFoundFault(message: String?)
-    case nodeGroupsPerReplicationGroupQuotaExceededFault(message: String?)
-    case nodeQuotaForClusterExceededFault(message: String?)
-    case nodeQuotaForCustomerExceededFault(message: String?)
-    case replicationGroupAlreadyExistsFault(message: String?)
-    case replicationGroupAlreadyUnderMigrationFault(message: String?)
-    case replicationGroupNotFoundFault(message: String?)
-    case replicationGroupNotUnderMigrationFault(message: String?)
-    case reservedCacheNodeAlreadyExistsFault(message: String?)
-    case reservedCacheNodeNotFoundFault(message: String?)
-    case reservedCacheNodeQuotaExceededFault(message: String?)
-    case reservedCacheNodesOfferingNotFoundFault(message: String?)
-    case serviceLinkedRoleNotFoundFault(message: String?)
-    case serviceUpdateNotFoundFault(message: String?)
-    case snapshotAlreadyExistsFault(message: String?)
-    case snapshotFeatureNotSupportedFault(message: String?)
-    case snapshotNotFoundFault(message: String?)
-    case snapshotQuotaExceededFault(message: String?)
-    case subnetInUse(message: String?)
-    case tagNotFoundFault(message: String?)
-    case tagQuotaPerResourceExceeded(message: String?)
-    case testFailoverNotAvailableFault(message: String?)
-}
+public struct ElastiCacheErrorType: AWSErrorType {
+    enum Code: String {
+        case aPICallRateForCustomerExceededFault = "APICallRateForCustomerExceeded"
+        case authorizationAlreadyExistsFault = "AuthorizationAlreadyExists"
+        case authorizationNotFoundFault = "AuthorizationNotFound"
+        case cacheClusterAlreadyExistsFault = "CacheClusterAlreadyExists"
+        case cacheClusterNotFoundFault = "CacheClusterNotFound"
+        case cacheParameterGroupAlreadyExistsFault = "CacheParameterGroupAlreadyExists"
+        case cacheParameterGroupNotFoundFault = "CacheParameterGroupNotFound"
+        case cacheParameterGroupQuotaExceededFault = "CacheParameterGroupQuotaExceeded"
+        case cacheSecurityGroupAlreadyExistsFault = "CacheSecurityGroupAlreadyExists"
+        case cacheSecurityGroupNotFoundFault = "CacheSecurityGroupNotFound"
+        case cacheSecurityGroupQuotaExceededFault = "QuotaExceeded.CacheSecurityGroup"
+        case cacheSubnetGroupAlreadyExistsFault = "CacheSubnetGroupAlreadyExists"
+        case cacheSubnetGroupInUse = "CacheSubnetGroupInUse"
+        case cacheSubnetGroupNotFoundFault = "CacheSubnetGroupNotFoundFault"
+        case cacheSubnetGroupQuotaExceededFault = "CacheSubnetGroupQuotaExceeded"
+        case cacheSubnetQuotaExceededFault = "CacheSubnetQuotaExceededFault"
+        case clusterQuotaForCustomerExceededFault = "ClusterQuotaForCustomerExceeded"
+        case globalReplicationGroupAlreadyExistsFault = "GlobalReplicationGroupAlreadyExistsFault"
+        case globalReplicationGroupNotFoundFault = "GlobalReplicationGroupNotFoundFault"
+        case insufficientCacheClusterCapacityFault = "InsufficientCacheClusterCapacity"
+        case invalidARNFault = "InvalidARN"
+        case invalidCacheClusterStateFault = "InvalidCacheClusterState"
+        case invalidCacheParameterGroupStateFault = "InvalidCacheParameterGroupState"
+        case invalidCacheSecurityGroupStateFault = "InvalidCacheSecurityGroupState"
+        case invalidGlobalReplicationGroupStateFault = "InvalidGlobalReplicationGroupState"
+        case invalidKMSKeyFault = "InvalidKMSKeyFault"
+        case invalidParameterCombinationException = "InvalidParameterCombination"
+        case invalidParameterValueException = "InvalidParameterValue"
+        case invalidReplicationGroupStateFault = "InvalidReplicationGroupState"
+        case invalidSnapshotStateFault = "InvalidSnapshotState"
+        case invalidSubnet = "InvalidSubnet"
+        case invalidVPCNetworkStateFault = "InvalidVPCNetworkStateFault"
+        case noOperationFault = "NoOperationFault"
+        case nodeGroupNotFoundFault = "NodeGroupNotFoundFault"
+        case nodeGroupsPerReplicationGroupQuotaExceededFault = "NodeGroupsPerReplicationGroupQuotaExceeded"
+        case nodeQuotaForClusterExceededFault = "NodeQuotaForClusterExceeded"
+        case nodeQuotaForCustomerExceededFault = "NodeQuotaForCustomerExceeded"
+        case replicationGroupAlreadyExistsFault = "ReplicationGroupAlreadyExists"
+        case replicationGroupAlreadyUnderMigrationFault = "ReplicationGroupAlreadyUnderMigrationFault"
+        case replicationGroupNotFoundFault = "ReplicationGroupNotFoundFault"
+        case replicationGroupNotUnderMigrationFault = "ReplicationGroupNotUnderMigrationFault"
+        case reservedCacheNodeAlreadyExistsFault = "ReservedCacheNodeAlreadyExists"
+        case reservedCacheNodeNotFoundFault = "ReservedCacheNodeNotFound"
+        case reservedCacheNodeQuotaExceededFault = "ReservedCacheNodeQuotaExceeded"
+        case reservedCacheNodesOfferingNotFoundFault = "ReservedCacheNodesOfferingNotFound"
+        case serviceLinkedRoleNotFoundFault = "ServiceLinkedRoleNotFoundFault"
+        case serviceUpdateNotFoundFault = "ServiceUpdateNotFoundFault"
+        case snapshotAlreadyExistsFault = "SnapshotAlreadyExistsFault"
+        case snapshotFeatureNotSupportedFault = "SnapshotFeatureNotSupportedFault"
+        case snapshotNotFoundFault = "SnapshotNotFoundFault"
+        case snapshotQuotaExceededFault = "SnapshotQuotaExceededFault"
+        case subnetInUse = "SubnetInUse"
+        case tagNotFoundFault = "TagNotFound"
+        case tagQuotaPerResourceExceeded = "TagQuotaPerResourceExceeded"
+        case testFailoverNotAvailableFault = "TestFailoverNotAvailableFault"
+    }
 
-extension ElastiCacheErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "APICallRateForCustomerExceeded":
-            self = .aPICallRateForCustomerExceededFault(message: message)
-        case "AuthorizationAlreadyExists":
-            self = .authorizationAlreadyExistsFault(message: message)
-        case "AuthorizationNotFound":
-            self = .authorizationNotFoundFault(message: message)
-        case "CacheClusterAlreadyExists":
-            self = .cacheClusterAlreadyExistsFault(message: message)
-        case "CacheClusterNotFound":
-            self = .cacheClusterNotFoundFault(message: message)
-        case "CacheParameterGroupAlreadyExists":
-            self = .cacheParameterGroupAlreadyExistsFault(message: message)
-        case "CacheParameterGroupNotFound":
-            self = .cacheParameterGroupNotFoundFault(message: message)
-        case "CacheParameterGroupQuotaExceeded":
-            self = .cacheParameterGroupQuotaExceededFault(message: message)
-        case "CacheSecurityGroupAlreadyExists":
-            self = .cacheSecurityGroupAlreadyExistsFault(message: message)
-        case "CacheSecurityGroupNotFound":
-            self = .cacheSecurityGroupNotFoundFault(message: message)
-        case "QuotaExceeded.CacheSecurityGroup":
-            self = .cacheSecurityGroupQuotaExceededFault(message: message)
-        case "CacheSubnetGroupAlreadyExists":
-            self = .cacheSubnetGroupAlreadyExistsFault(message: message)
-        case "CacheSubnetGroupInUse":
-            self = .cacheSubnetGroupInUse(message: message)
-        case "CacheSubnetGroupNotFoundFault":
-            self = .cacheSubnetGroupNotFoundFault(message: message)
-        case "CacheSubnetGroupQuotaExceeded":
-            self = .cacheSubnetGroupQuotaExceededFault(message: message)
-        case "CacheSubnetQuotaExceededFault":
-            self = .cacheSubnetQuotaExceededFault(message: message)
-        case "ClusterQuotaForCustomerExceeded":
-            self = .clusterQuotaForCustomerExceededFault(message: message)
-        case "GlobalReplicationGroupAlreadyExistsFault":
-            self = .globalReplicationGroupAlreadyExistsFault(message: message)
-        case "GlobalReplicationGroupNotFoundFault":
-            self = .globalReplicationGroupNotFoundFault(message: message)
-        case "InsufficientCacheClusterCapacity":
-            self = .insufficientCacheClusterCapacityFault(message: message)
-        case "InvalidARN":
-            self = .invalidARNFault(message: message)
-        case "InvalidCacheClusterState":
-            self = .invalidCacheClusterStateFault(message: message)
-        case "InvalidCacheParameterGroupState":
-            self = .invalidCacheParameterGroupStateFault(message: message)
-        case "InvalidCacheSecurityGroupState":
-            self = .invalidCacheSecurityGroupStateFault(message: message)
-        case "InvalidGlobalReplicationGroupState":
-            self = .invalidGlobalReplicationGroupStateFault(message: message)
-        case "InvalidKMSKeyFault":
-            self = .invalidKMSKeyFault(message: message)
-        case "InvalidParameterCombination":
-            self = .invalidParameterCombinationException(message: message)
-        case "InvalidParameterValue":
-            self = .invalidParameterValueException(message: message)
-        case "InvalidReplicationGroupState":
-            self = .invalidReplicationGroupStateFault(message: message)
-        case "InvalidSnapshotState":
-            self = .invalidSnapshotStateFault(message: message)
-        case "InvalidSubnet":
-            self = .invalidSubnet(message: message)
-        case "InvalidVPCNetworkStateFault":
-            self = .invalidVPCNetworkStateFault(message: message)
-        case "NoOperationFault":
-            self = .noOperationFault(message: message)
-        case "NodeGroupNotFoundFault":
-            self = .nodeGroupNotFoundFault(message: message)
-        case "NodeGroupsPerReplicationGroupQuotaExceeded":
-            self = .nodeGroupsPerReplicationGroupQuotaExceededFault(message: message)
-        case "NodeQuotaForClusterExceeded":
-            self = .nodeQuotaForClusterExceededFault(message: message)
-        case "NodeQuotaForCustomerExceeded":
-            self = .nodeQuotaForCustomerExceededFault(message: message)
-        case "ReplicationGroupAlreadyExists":
-            self = .replicationGroupAlreadyExistsFault(message: message)
-        case "ReplicationGroupAlreadyUnderMigrationFault":
-            self = .replicationGroupAlreadyUnderMigrationFault(message: message)
-        case "ReplicationGroupNotFoundFault":
-            self = .replicationGroupNotFoundFault(message: message)
-        case "ReplicationGroupNotUnderMigrationFault":
-            self = .replicationGroupNotUnderMigrationFault(message: message)
-        case "ReservedCacheNodeAlreadyExists":
-            self = .reservedCacheNodeAlreadyExistsFault(message: message)
-        case "ReservedCacheNodeNotFound":
-            self = .reservedCacheNodeNotFoundFault(message: message)
-        case "ReservedCacheNodeQuotaExceeded":
-            self = .reservedCacheNodeQuotaExceededFault(message: message)
-        case "ReservedCacheNodesOfferingNotFound":
-            self = .reservedCacheNodesOfferingNotFoundFault(message: message)
-        case "ServiceLinkedRoleNotFoundFault":
-            self = .serviceLinkedRoleNotFoundFault(message: message)
-        case "ServiceUpdateNotFoundFault":
-            self = .serviceUpdateNotFoundFault(message: message)
-        case "SnapshotAlreadyExistsFault":
-            self = .snapshotAlreadyExistsFault(message: message)
-        case "SnapshotFeatureNotSupportedFault":
-            self = .snapshotFeatureNotSupportedFault(message: message)
-        case "SnapshotNotFoundFault":
-            self = .snapshotNotFoundFault(message: message)
-        case "SnapshotQuotaExceededFault":
-            self = .snapshotQuotaExceededFault(message: message)
-        case "SubnetInUse":
-            self = .subnetInUse(message: message)
-        case "TagNotFound":
-            self = .tagNotFoundFault(message: message)
-        case "TagQuotaPerResourceExceeded":
-            self = .tagQuotaPerResourceExceeded(message: message)
-        case "TestFailoverNotAvailableFault":
-            self = .testFailoverNotAvailableFault(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var aPICallRateForCustomerExceededFault: Self { .init(.aPICallRateForCustomerExceededFault) }
+    public static var authorizationAlreadyExistsFault: Self { .init(.authorizationAlreadyExistsFault) }
+    public static var authorizationNotFoundFault: Self { .init(.authorizationNotFoundFault) }
+    public static var cacheClusterAlreadyExistsFault: Self { .init(.cacheClusterAlreadyExistsFault) }
+    public static var cacheClusterNotFoundFault: Self { .init(.cacheClusterNotFoundFault) }
+    public static var cacheParameterGroupAlreadyExistsFault: Self { .init(.cacheParameterGroupAlreadyExistsFault) }
+    public static var cacheParameterGroupNotFoundFault: Self { .init(.cacheParameterGroupNotFoundFault) }
+    public static var cacheParameterGroupQuotaExceededFault: Self { .init(.cacheParameterGroupQuotaExceededFault) }
+    public static var cacheSecurityGroupAlreadyExistsFault: Self { .init(.cacheSecurityGroupAlreadyExistsFault) }
+    public static var cacheSecurityGroupNotFoundFault: Self { .init(.cacheSecurityGroupNotFoundFault) }
+    public static var cacheSecurityGroupQuotaExceededFault: Self { .init(.cacheSecurityGroupQuotaExceededFault) }
+    public static var cacheSubnetGroupAlreadyExistsFault: Self { .init(.cacheSubnetGroupAlreadyExistsFault) }
+    public static var cacheSubnetGroupInUse: Self { .init(.cacheSubnetGroupInUse) }
+    public static var cacheSubnetGroupNotFoundFault: Self { .init(.cacheSubnetGroupNotFoundFault) }
+    public static var cacheSubnetGroupQuotaExceededFault: Self { .init(.cacheSubnetGroupQuotaExceededFault) }
+    public static var cacheSubnetQuotaExceededFault: Self { .init(.cacheSubnetQuotaExceededFault) }
+    public static var clusterQuotaForCustomerExceededFault: Self { .init(.clusterQuotaForCustomerExceededFault) }
+    public static var globalReplicationGroupAlreadyExistsFault: Self { .init(.globalReplicationGroupAlreadyExistsFault) }
+    public static var globalReplicationGroupNotFoundFault: Self { .init(.globalReplicationGroupNotFoundFault) }
+    public static var insufficientCacheClusterCapacityFault: Self { .init(.insufficientCacheClusterCapacityFault) }
+    public static var invalidARNFault: Self { .init(.invalidARNFault) }
+    public static var invalidCacheClusterStateFault: Self { .init(.invalidCacheClusterStateFault) }
+    public static var invalidCacheParameterGroupStateFault: Self { .init(.invalidCacheParameterGroupStateFault) }
+    public static var invalidCacheSecurityGroupStateFault: Self { .init(.invalidCacheSecurityGroupStateFault) }
+    public static var invalidGlobalReplicationGroupStateFault: Self { .init(.invalidGlobalReplicationGroupStateFault) }
+    public static var invalidKMSKeyFault: Self { .init(.invalidKMSKeyFault) }
+    public static var invalidParameterCombinationException: Self { .init(.invalidParameterCombinationException) }
+    public static var invalidParameterValueException: Self { .init(.invalidParameterValueException) }
+    public static var invalidReplicationGroupStateFault: Self { .init(.invalidReplicationGroupStateFault) }
+    public static var invalidSnapshotStateFault: Self { .init(.invalidSnapshotStateFault) }
+    public static var invalidSubnet: Self { .init(.invalidSubnet) }
+    public static var invalidVPCNetworkStateFault: Self { .init(.invalidVPCNetworkStateFault) }
+    public static var noOperationFault: Self { .init(.noOperationFault) }
+    public static var nodeGroupNotFoundFault: Self { .init(.nodeGroupNotFoundFault) }
+    public static var nodeGroupsPerReplicationGroupQuotaExceededFault: Self { .init(.nodeGroupsPerReplicationGroupQuotaExceededFault) }
+    public static var nodeQuotaForClusterExceededFault: Self { .init(.nodeQuotaForClusterExceededFault) }
+    public static var nodeQuotaForCustomerExceededFault: Self { .init(.nodeQuotaForCustomerExceededFault) }
+    public static var replicationGroupAlreadyExistsFault: Self { .init(.replicationGroupAlreadyExistsFault) }
+    public static var replicationGroupAlreadyUnderMigrationFault: Self { .init(.replicationGroupAlreadyUnderMigrationFault) }
+    public static var replicationGroupNotFoundFault: Self { .init(.replicationGroupNotFoundFault) }
+    public static var replicationGroupNotUnderMigrationFault: Self { .init(.replicationGroupNotUnderMigrationFault) }
+    public static var reservedCacheNodeAlreadyExistsFault: Self { .init(.reservedCacheNodeAlreadyExistsFault) }
+    public static var reservedCacheNodeNotFoundFault: Self { .init(.reservedCacheNodeNotFoundFault) }
+    public static var reservedCacheNodeQuotaExceededFault: Self { .init(.reservedCacheNodeQuotaExceededFault) }
+    public static var reservedCacheNodesOfferingNotFoundFault: Self { .init(.reservedCacheNodesOfferingNotFoundFault) }
+    public static var serviceLinkedRoleNotFoundFault: Self { .init(.serviceLinkedRoleNotFoundFault) }
+    public static var serviceUpdateNotFoundFault: Self { .init(.serviceUpdateNotFoundFault) }
+    public static var snapshotAlreadyExistsFault: Self { .init(.snapshotAlreadyExistsFault) }
+    public static var snapshotFeatureNotSupportedFault: Self { .init(.snapshotFeatureNotSupportedFault) }
+    public static var snapshotNotFoundFault: Self { .init(.snapshotNotFoundFault) }
+    public static var snapshotQuotaExceededFault: Self { .init(.snapshotQuotaExceededFault) }
+    public static var subnetInUse: Self { .init(.subnetInUse) }
+    public static var tagNotFoundFault: Self { .init(.tagNotFoundFault) }
+    public static var tagQuotaPerResourceExceeded: Self { .init(.tagQuotaPerResourceExceeded) }
+    public static var testFailoverNotAvailableFault: Self { .init(.testFailoverNotAvailableFault) }
+}
+
+extension ElastiCacheErrorType: Equatable {
+    public static func == (lhs: ElastiCacheErrorType, rhs: ElastiCacheErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ElastiCacheErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .aPICallRateForCustomerExceededFault(let message):
-            return "APICallRateForCustomerExceeded: \(message ?? "")"
-        case .authorizationAlreadyExistsFault(let message):
-            return "AuthorizationAlreadyExists: \(message ?? "")"
-        case .authorizationNotFoundFault(let message):
-            return "AuthorizationNotFound: \(message ?? "")"
-        case .cacheClusterAlreadyExistsFault(let message):
-            return "CacheClusterAlreadyExists: \(message ?? "")"
-        case .cacheClusterNotFoundFault(let message):
-            return "CacheClusterNotFound: \(message ?? "")"
-        case .cacheParameterGroupAlreadyExistsFault(let message):
-            return "CacheParameterGroupAlreadyExists: \(message ?? "")"
-        case .cacheParameterGroupNotFoundFault(let message):
-            return "CacheParameterGroupNotFound: \(message ?? "")"
-        case .cacheParameterGroupQuotaExceededFault(let message):
-            return "CacheParameterGroupQuotaExceeded: \(message ?? "")"
-        case .cacheSecurityGroupAlreadyExistsFault(let message):
-            return "CacheSecurityGroupAlreadyExists: \(message ?? "")"
-        case .cacheSecurityGroupNotFoundFault(let message):
-            return "CacheSecurityGroupNotFound: \(message ?? "")"
-        case .cacheSecurityGroupQuotaExceededFault(let message):
-            return "QuotaExceeded.CacheSecurityGroup: \(message ?? "")"
-        case .cacheSubnetGroupAlreadyExistsFault(let message):
-            return "CacheSubnetGroupAlreadyExists: \(message ?? "")"
-        case .cacheSubnetGroupInUse(let message):
-            return "CacheSubnetGroupInUse: \(message ?? "")"
-        case .cacheSubnetGroupNotFoundFault(let message):
-            return "CacheSubnetGroupNotFoundFault: \(message ?? "")"
-        case .cacheSubnetGroupQuotaExceededFault(let message):
-            return "CacheSubnetGroupQuotaExceeded: \(message ?? "")"
-        case .cacheSubnetQuotaExceededFault(let message):
-            return "CacheSubnetQuotaExceededFault: \(message ?? "")"
-        case .clusterQuotaForCustomerExceededFault(let message):
-            return "ClusterQuotaForCustomerExceeded: \(message ?? "")"
-        case .globalReplicationGroupAlreadyExistsFault(let message):
-            return "GlobalReplicationGroupAlreadyExistsFault: \(message ?? "")"
-        case .globalReplicationGroupNotFoundFault(let message):
-            return "GlobalReplicationGroupNotFoundFault: \(message ?? "")"
-        case .insufficientCacheClusterCapacityFault(let message):
-            return "InsufficientCacheClusterCapacity: \(message ?? "")"
-        case .invalidARNFault(let message):
-            return "InvalidARN: \(message ?? "")"
-        case .invalidCacheClusterStateFault(let message):
-            return "InvalidCacheClusterState: \(message ?? "")"
-        case .invalidCacheParameterGroupStateFault(let message):
-            return "InvalidCacheParameterGroupState: \(message ?? "")"
-        case .invalidCacheSecurityGroupStateFault(let message):
-            return "InvalidCacheSecurityGroupState: \(message ?? "")"
-        case .invalidGlobalReplicationGroupStateFault(let message):
-            return "InvalidGlobalReplicationGroupState: \(message ?? "")"
-        case .invalidKMSKeyFault(let message):
-            return "InvalidKMSKeyFault: \(message ?? "")"
-        case .invalidParameterCombinationException(let message):
-            return "InvalidParameterCombination: \(message ?? "")"
-        case .invalidParameterValueException(let message):
-            return "InvalidParameterValue: \(message ?? "")"
-        case .invalidReplicationGroupStateFault(let message):
-            return "InvalidReplicationGroupState: \(message ?? "")"
-        case .invalidSnapshotStateFault(let message):
-            return "InvalidSnapshotState: \(message ?? "")"
-        case .invalidSubnet(let message):
-            return "InvalidSubnet: \(message ?? "")"
-        case .invalidVPCNetworkStateFault(let message):
-            return "InvalidVPCNetworkStateFault: \(message ?? "")"
-        case .noOperationFault(let message):
-            return "NoOperationFault: \(message ?? "")"
-        case .nodeGroupNotFoundFault(let message):
-            return "NodeGroupNotFoundFault: \(message ?? "")"
-        case .nodeGroupsPerReplicationGroupQuotaExceededFault(let message):
-            return "NodeGroupsPerReplicationGroupQuotaExceeded: \(message ?? "")"
-        case .nodeQuotaForClusterExceededFault(let message):
-            return "NodeQuotaForClusterExceeded: \(message ?? "")"
-        case .nodeQuotaForCustomerExceededFault(let message):
-            return "NodeQuotaForCustomerExceeded: \(message ?? "")"
-        case .replicationGroupAlreadyExistsFault(let message):
-            return "ReplicationGroupAlreadyExists: \(message ?? "")"
-        case .replicationGroupAlreadyUnderMigrationFault(let message):
-            return "ReplicationGroupAlreadyUnderMigrationFault: \(message ?? "")"
-        case .replicationGroupNotFoundFault(let message):
-            return "ReplicationGroupNotFoundFault: \(message ?? "")"
-        case .replicationGroupNotUnderMigrationFault(let message):
-            return "ReplicationGroupNotUnderMigrationFault: \(message ?? "")"
-        case .reservedCacheNodeAlreadyExistsFault(let message):
-            return "ReservedCacheNodeAlreadyExists: \(message ?? "")"
-        case .reservedCacheNodeNotFoundFault(let message):
-            return "ReservedCacheNodeNotFound: \(message ?? "")"
-        case .reservedCacheNodeQuotaExceededFault(let message):
-            return "ReservedCacheNodeQuotaExceeded: \(message ?? "")"
-        case .reservedCacheNodesOfferingNotFoundFault(let message):
-            return "ReservedCacheNodesOfferingNotFound: \(message ?? "")"
-        case .serviceLinkedRoleNotFoundFault(let message):
-            return "ServiceLinkedRoleNotFoundFault: \(message ?? "")"
-        case .serviceUpdateNotFoundFault(let message):
-            return "ServiceUpdateNotFoundFault: \(message ?? "")"
-        case .snapshotAlreadyExistsFault(let message):
-            return "SnapshotAlreadyExistsFault: \(message ?? "")"
-        case .snapshotFeatureNotSupportedFault(let message):
-            return "SnapshotFeatureNotSupportedFault: \(message ?? "")"
-        case .snapshotNotFoundFault(let message):
-            return "SnapshotNotFoundFault: \(message ?? "")"
-        case .snapshotQuotaExceededFault(let message):
-            return "SnapshotQuotaExceededFault: \(message ?? "")"
-        case .subnetInUse(let message):
-            return "SubnetInUse: \(message ?? "")"
-        case .tagNotFoundFault(let message):
-            return "TagNotFound: \(message ?? "")"
-        case .tagQuotaPerResourceExceeded(let message):
-            return "TagQuotaPerResourceExceeded: \(message ?? "")"
-        case .testFailoverNotAvailableFault(let message):
-            return "TestFailoverNotAvailableFault: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/ElasticBeanstalk/ElasticBeanstalk_Error.swift
+++ b/Sources/Soto/Services/ElasticBeanstalk/ElasticBeanstalk_Error.swift
@@ -17,120 +17,76 @@
 import SotoCore
 
 /// Error enum for ElasticBeanstalk
-public enum ElasticBeanstalkErrorType: AWSErrorType {
-    case codeBuildNotInServiceRegionException(message: String?)
-    case elasticBeanstalkServiceException(message: String?)
-    case insufficientPrivilegesException(message: String?)
-    case invalidRequestException(message: String?)
-    case managedActionInvalidStateException(message: String?)
-    case operationInProgressException(message: String?)
-    case platformVersionStillReferencedException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case resourceTypeNotSupportedException(message: String?)
-    case s3LocationNotInServiceRegionException(message: String?)
-    case s3SubscriptionRequiredException(message: String?)
-    case sourceBundleDeletionException(message: String?)
-    case tooManyApplicationVersionsException(message: String?)
-    case tooManyApplicationsException(message: String?)
-    case tooManyBucketsException(message: String?)
-    case tooManyConfigurationTemplatesException(message: String?)
-    case tooManyEnvironmentsException(message: String?)
-    case tooManyPlatformsException(message: String?)
-    case tooManyTagsException(message: String?)
-}
+public struct ElasticBeanstalkErrorType: AWSErrorType {
+    enum Code: String {
+        case codeBuildNotInServiceRegionException = "CodeBuildNotInServiceRegionException"
+        case elasticBeanstalkServiceException = "ElasticBeanstalkServiceException"
+        case insufficientPrivilegesException = "InsufficientPrivilegesException"
+        case invalidRequestException = "InvalidRequestException"
+        case managedActionInvalidStateException = "ManagedActionInvalidStateException"
+        case operationInProgressException = "OperationInProgressFailure"
+        case platformVersionStillReferencedException = "PlatformVersionStillReferencedException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case resourceTypeNotSupportedException = "ResourceTypeNotSupportedException"
+        case s3LocationNotInServiceRegionException = "S3LocationNotInServiceRegionException"
+        case s3SubscriptionRequiredException = "S3SubscriptionRequiredException"
+        case sourceBundleDeletionException = "SourceBundleDeletionFailure"
+        case tooManyApplicationVersionsException = "TooManyApplicationVersionsException"
+        case tooManyApplicationsException = "TooManyApplicationsException"
+        case tooManyBucketsException = "TooManyBucketsException"
+        case tooManyConfigurationTemplatesException = "TooManyConfigurationTemplatesException"
+        case tooManyEnvironmentsException = "TooManyEnvironmentsException"
+        case tooManyPlatformsException = "TooManyPlatformsException"
+        case tooManyTagsException = "TooManyTagsException"
+    }
 
-extension ElasticBeanstalkErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "CodeBuildNotInServiceRegionException":
-            self = .codeBuildNotInServiceRegionException(message: message)
-        case "ElasticBeanstalkServiceException":
-            self = .elasticBeanstalkServiceException(message: message)
-        case "InsufficientPrivilegesException":
-            self = .insufficientPrivilegesException(message: message)
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        case "ManagedActionInvalidStateException":
-            self = .managedActionInvalidStateException(message: message)
-        case "OperationInProgressFailure":
-            self = .operationInProgressException(message: message)
-        case "PlatformVersionStillReferencedException":
-            self = .platformVersionStillReferencedException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ResourceTypeNotSupportedException":
-            self = .resourceTypeNotSupportedException(message: message)
-        case "S3LocationNotInServiceRegionException":
-            self = .s3LocationNotInServiceRegionException(message: message)
-        case "S3SubscriptionRequiredException":
-            self = .s3SubscriptionRequiredException(message: message)
-        case "SourceBundleDeletionFailure":
-            self = .sourceBundleDeletionException(message: message)
-        case "TooManyApplicationVersionsException":
-            self = .tooManyApplicationVersionsException(message: message)
-        case "TooManyApplicationsException":
-            self = .tooManyApplicationsException(message: message)
-        case "TooManyBucketsException":
-            self = .tooManyBucketsException(message: message)
-        case "TooManyConfigurationTemplatesException":
-            self = .tooManyConfigurationTemplatesException(message: message)
-        case "TooManyEnvironmentsException":
-            self = .tooManyEnvironmentsException(message: message)
-        case "TooManyPlatformsException":
-            self = .tooManyPlatformsException(message: message)
-        case "TooManyTagsException":
-            self = .tooManyTagsException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var codeBuildNotInServiceRegionException: Self { .init(.codeBuildNotInServiceRegionException) }
+    public static var elasticBeanstalkServiceException: Self { .init(.elasticBeanstalkServiceException) }
+    public static var insufficientPrivilegesException: Self { .init(.insufficientPrivilegesException) }
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+    public static var managedActionInvalidStateException: Self { .init(.managedActionInvalidStateException) }
+    public static var operationInProgressException: Self { .init(.operationInProgressException) }
+    public static var platformVersionStillReferencedException: Self { .init(.platformVersionStillReferencedException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var resourceTypeNotSupportedException: Self { .init(.resourceTypeNotSupportedException) }
+    public static var s3LocationNotInServiceRegionException: Self { .init(.s3LocationNotInServiceRegionException) }
+    public static var s3SubscriptionRequiredException: Self { .init(.s3SubscriptionRequiredException) }
+    public static var sourceBundleDeletionException: Self { .init(.sourceBundleDeletionException) }
+    public static var tooManyApplicationVersionsException: Self { .init(.tooManyApplicationVersionsException) }
+    public static var tooManyApplicationsException: Self { .init(.tooManyApplicationsException) }
+    public static var tooManyBucketsException: Self { .init(.tooManyBucketsException) }
+    public static var tooManyConfigurationTemplatesException: Self { .init(.tooManyConfigurationTemplatesException) }
+    public static var tooManyEnvironmentsException: Self { .init(.tooManyEnvironmentsException) }
+    public static var tooManyPlatformsException: Self { .init(.tooManyPlatformsException) }
+    public static var tooManyTagsException: Self { .init(.tooManyTagsException) }
+}
+
+extension ElasticBeanstalkErrorType: Equatable {
+    public static func == (lhs: ElasticBeanstalkErrorType, rhs: ElasticBeanstalkErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ElasticBeanstalkErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .codeBuildNotInServiceRegionException(let message):
-            return "CodeBuildNotInServiceRegionException: \(message ?? "")"
-        case .elasticBeanstalkServiceException(let message):
-            return "ElasticBeanstalkServiceException: \(message ?? "")"
-        case .insufficientPrivilegesException(let message):
-            return "InsufficientPrivilegesException: \(message ?? "")"
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        case .managedActionInvalidStateException(let message):
-            return "ManagedActionInvalidStateException: \(message ?? "")"
-        case .operationInProgressException(let message):
-            return "OperationInProgressFailure: \(message ?? "")"
-        case .platformVersionStillReferencedException(let message):
-            return "PlatformVersionStillReferencedException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .resourceTypeNotSupportedException(let message):
-            return "ResourceTypeNotSupportedException: \(message ?? "")"
-        case .s3LocationNotInServiceRegionException(let message):
-            return "S3LocationNotInServiceRegionException: \(message ?? "")"
-        case .s3SubscriptionRequiredException(let message):
-            return "S3SubscriptionRequiredException: \(message ?? "")"
-        case .sourceBundleDeletionException(let message):
-            return "SourceBundleDeletionFailure: \(message ?? "")"
-        case .tooManyApplicationVersionsException(let message):
-            return "TooManyApplicationVersionsException: \(message ?? "")"
-        case .tooManyApplicationsException(let message):
-            return "TooManyApplicationsException: \(message ?? "")"
-        case .tooManyBucketsException(let message):
-            return "TooManyBucketsException: \(message ?? "")"
-        case .tooManyConfigurationTemplatesException(let message):
-            return "TooManyConfigurationTemplatesException: \(message ?? "")"
-        case .tooManyEnvironmentsException(let message):
-            return "TooManyEnvironmentsException: \(message ?? "")"
-        case .tooManyPlatformsException(let message):
-            return "TooManyPlatformsException: \(message ?? "")"
-        case .tooManyTagsException(let message):
-            return "TooManyTagsException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/ElasticInference/ElasticInference_Error.swift
+++ b/Sources/Soto/Services/ElasticInference/ElasticInference_Error.swift
@@ -17,40 +17,44 @@
 import SotoCore
 
 /// Error enum for ElasticInference
-public enum ElasticInferenceErrorType: AWSErrorType {
-    case badRequestException(message: String?)
-    case internalServerException(message: String?)
-    case resourceNotFoundException(message: String?)
-}
+public struct ElasticInferenceErrorType: AWSErrorType {
+    enum Code: String {
+        case badRequestException = "BadRequestException"
+        case internalServerException = "InternalServerException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+    }
 
-extension ElasticInferenceErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var badRequestException: Self { .init(.badRequestException) }
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+}
+
+extension ElasticInferenceErrorType: Equatable {
+    public static func == (lhs: ElasticInferenceErrorType, rhs: ElasticInferenceErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ElasticInferenceErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/ElasticLoadBalancing/ElasticLoadBalancing_Error.swift
+++ b/Sources/Soto/Services/ElasticLoadBalancing/ElasticLoadBalancing_Error.swift
@@ -17,135 +17,82 @@
 import SotoCore
 
 /// Error enum for ElasticLoadBalancing
-public enum ElasticLoadBalancingErrorType: AWSErrorType {
-    case accessPointNotFoundException(message: String?)
-    case certificateNotFoundException(message: String?)
-    case dependencyThrottleException(message: String?)
-    case duplicateAccessPointNameException(message: String?)
-    case duplicateListenerException(message: String?)
-    case duplicatePolicyNameException(message: String?)
-    case duplicateTagKeysException(message: String?)
-    case invalidConfigurationRequestException(message: String?)
-    case invalidEndPointException(message: String?)
-    case invalidSchemeException(message: String?)
-    case invalidSecurityGroupException(message: String?)
-    case invalidSubnetException(message: String?)
-    case listenerNotFoundException(message: String?)
-    case loadBalancerAttributeNotFoundException(message: String?)
-    case operationNotPermittedException(message: String?)
-    case policyNotFoundException(message: String?)
-    case policyTypeNotFoundException(message: String?)
-    case subnetNotFoundException(message: String?)
-    case tooManyAccessPointsException(message: String?)
-    case tooManyPoliciesException(message: String?)
-    case tooManyTagsException(message: String?)
-    case unsupportedProtocolException(message: String?)
-}
+public struct ElasticLoadBalancingErrorType: AWSErrorType {
+    enum Code: String {
+        case accessPointNotFoundException = "LoadBalancerNotFound"
+        case certificateNotFoundException = "CertificateNotFound"
+        case dependencyThrottleException = "DependencyThrottle"
+        case duplicateAccessPointNameException = "DuplicateLoadBalancerName"
+        case duplicateListenerException = "DuplicateListener"
+        case duplicatePolicyNameException = "DuplicatePolicyName"
+        case duplicateTagKeysException = "DuplicateTagKeys"
+        case invalidConfigurationRequestException = "InvalidConfigurationRequest"
+        case invalidEndPointException = "InvalidInstance"
+        case invalidSchemeException = "InvalidScheme"
+        case invalidSecurityGroupException = "InvalidSecurityGroup"
+        case invalidSubnetException = "InvalidSubnet"
+        case listenerNotFoundException = "ListenerNotFound"
+        case loadBalancerAttributeNotFoundException = "LoadBalancerAttributeNotFound"
+        case operationNotPermittedException = "OperationNotPermitted"
+        case policyNotFoundException = "PolicyNotFound"
+        case policyTypeNotFoundException = "PolicyTypeNotFound"
+        case subnetNotFoundException = "SubnetNotFound"
+        case tooManyAccessPointsException = "TooManyLoadBalancers"
+        case tooManyPoliciesException = "TooManyPolicies"
+        case tooManyTagsException = "TooManyTags"
+        case unsupportedProtocolException = "UnsupportedProtocol"
+    }
 
-extension ElasticLoadBalancingErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "LoadBalancerNotFound":
-            self = .accessPointNotFoundException(message: message)
-        case "CertificateNotFound":
-            self = .certificateNotFoundException(message: message)
-        case "DependencyThrottle":
-            self = .dependencyThrottleException(message: message)
-        case "DuplicateLoadBalancerName":
-            self = .duplicateAccessPointNameException(message: message)
-        case "DuplicateListener":
-            self = .duplicateListenerException(message: message)
-        case "DuplicatePolicyName":
-            self = .duplicatePolicyNameException(message: message)
-        case "DuplicateTagKeys":
-            self = .duplicateTagKeysException(message: message)
-        case "InvalidConfigurationRequest":
-            self = .invalidConfigurationRequestException(message: message)
-        case "InvalidInstance":
-            self = .invalidEndPointException(message: message)
-        case "InvalidScheme":
-            self = .invalidSchemeException(message: message)
-        case "InvalidSecurityGroup":
-            self = .invalidSecurityGroupException(message: message)
-        case "InvalidSubnet":
-            self = .invalidSubnetException(message: message)
-        case "ListenerNotFound":
-            self = .listenerNotFoundException(message: message)
-        case "LoadBalancerAttributeNotFound":
-            self = .loadBalancerAttributeNotFoundException(message: message)
-        case "OperationNotPermitted":
-            self = .operationNotPermittedException(message: message)
-        case "PolicyNotFound":
-            self = .policyNotFoundException(message: message)
-        case "PolicyTypeNotFound":
-            self = .policyTypeNotFoundException(message: message)
-        case "SubnetNotFound":
-            self = .subnetNotFoundException(message: message)
-        case "TooManyLoadBalancers":
-            self = .tooManyAccessPointsException(message: message)
-        case "TooManyPolicies":
-            self = .tooManyPoliciesException(message: message)
-        case "TooManyTags":
-            self = .tooManyTagsException(message: message)
-        case "UnsupportedProtocol":
-            self = .unsupportedProtocolException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessPointNotFoundException: Self { .init(.accessPointNotFoundException) }
+    public static var certificateNotFoundException: Self { .init(.certificateNotFoundException) }
+    public static var dependencyThrottleException: Self { .init(.dependencyThrottleException) }
+    public static var duplicateAccessPointNameException: Self { .init(.duplicateAccessPointNameException) }
+    public static var duplicateListenerException: Self { .init(.duplicateListenerException) }
+    public static var duplicatePolicyNameException: Self { .init(.duplicatePolicyNameException) }
+    public static var duplicateTagKeysException: Self { .init(.duplicateTagKeysException) }
+    public static var invalidConfigurationRequestException: Self { .init(.invalidConfigurationRequestException) }
+    public static var invalidEndPointException: Self { .init(.invalidEndPointException) }
+    public static var invalidSchemeException: Self { .init(.invalidSchemeException) }
+    public static var invalidSecurityGroupException: Self { .init(.invalidSecurityGroupException) }
+    public static var invalidSubnetException: Self { .init(.invalidSubnetException) }
+    public static var listenerNotFoundException: Self { .init(.listenerNotFoundException) }
+    public static var loadBalancerAttributeNotFoundException: Self { .init(.loadBalancerAttributeNotFoundException) }
+    public static var operationNotPermittedException: Self { .init(.operationNotPermittedException) }
+    public static var policyNotFoundException: Self { .init(.policyNotFoundException) }
+    public static var policyTypeNotFoundException: Self { .init(.policyTypeNotFoundException) }
+    public static var subnetNotFoundException: Self { .init(.subnetNotFoundException) }
+    public static var tooManyAccessPointsException: Self { .init(.tooManyAccessPointsException) }
+    public static var tooManyPoliciesException: Self { .init(.tooManyPoliciesException) }
+    public static var tooManyTagsException: Self { .init(.tooManyTagsException) }
+    public static var unsupportedProtocolException: Self { .init(.unsupportedProtocolException) }
+}
+
+extension ElasticLoadBalancingErrorType: Equatable {
+    public static func == (lhs: ElasticLoadBalancingErrorType, rhs: ElasticLoadBalancingErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ElasticLoadBalancingErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessPointNotFoundException(let message):
-            return "LoadBalancerNotFound: \(message ?? "")"
-        case .certificateNotFoundException(let message):
-            return "CertificateNotFound: \(message ?? "")"
-        case .dependencyThrottleException(let message):
-            return "DependencyThrottle: \(message ?? "")"
-        case .duplicateAccessPointNameException(let message):
-            return "DuplicateLoadBalancerName: \(message ?? "")"
-        case .duplicateListenerException(let message):
-            return "DuplicateListener: \(message ?? "")"
-        case .duplicatePolicyNameException(let message):
-            return "DuplicatePolicyName: \(message ?? "")"
-        case .duplicateTagKeysException(let message):
-            return "DuplicateTagKeys: \(message ?? "")"
-        case .invalidConfigurationRequestException(let message):
-            return "InvalidConfigurationRequest: \(message ?? "")"
-        case .invalidEndPointException(let message):
-            return "InvalidInstance: \(message ?? "")"
-        case .invalidSchemeException(let message):
-            return "InvalidScheme: \(message ?? "")"
-        case .invalidSecurityGroupException(let message):
-            return "InvalidSecurityGroup: \(message ?? "")"
-        case .invalidSubnetException(let message):
-            return "InvalidSubnet: \(message ?? "")"
-        case .listenerNotFoundException(let message):
-            return "ListenerNotFound: \(message ?? "")"
-        case .loadBalancerAttributeNotFoundException(let message):
-            return "LoadBalancerAttributeNotFound: \(message ?? "")"
-        case .operationNotPermittedException(let message):
-            return "OperationNotPermitted: \(message ?? "")"
-        case .policyNotFoundException(let message):
-            return "PolicyNotFound: \(message ?? "")"
-        case .policyTypeNotFoundException(let message):
-            return "PolicyTypeNotFound: \(message ?? "")"
-        case .subnetNotFoundException(let message):
-            return "SubnetNotFound: \(message ?? "")"
-        case .tooManyAccessPointsException(let message):
-            return "TooManyLoadBalancers: \(message ?? "")"
-        case .tooManyPoliciesException(let message):
-            return "TooManyPolicies: \(message ?? "")"
-        case .tooManyTagsException(let message):
-            return "TooManyTags: \(message ?? "")"
-        case .unsupportedProtocolException(let message):
-            return "UnsupportedProtocol: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/ElasticLoadBalancingv2/ElasticLoadBalancingv2_Error.swift
+++ b/Sources/Soto/Services/ElasticLoadBalancingv2/ElasticLoadBalancingv2_Error.swift
@@ -17,210 +17,112 @@
 import SotoCore
 
 /// Error enum for ElasticLoadBalancingv2
-public enum ElasticLoadBalancingv2ErrorType: AWSErrorType {
-    case aLPNPolicyNotSupportedException(message: String?)
-    case allocationIdNotFoundException(message: String?)
-    case availabilityZoneNotSupportedException(message: String?)
-    case certificateNotFoundException(message: String?)
-    case duplicateListenerException(message: String?)
-    case duplicateLoadBalancerNameException(message: String?)
-    case duplicateTagKeysException(message: String?)
-    case duplicateTargetGroupNameException(message: String?)
-    case healthUnavailableException(message: String?)
-    case incompatibleProtocolsException(message: String?)
-    case invalidConfigurationRequestException(message: String?)
-    case invalidLoadBalancerActionException(message: String?)
-    case invalidSchemeException(message: String?)
-    case invalidSecurityGroupException(message: String?)
-    case invalidSubnetException(message: String?)
-    case invalidTargetException(message: String?)
-    case listenerNotFoundException(message: String?)
-    case loadBalancerNotFoundException(message: String?)
-    case operationNotPermittedException(message: String?)
-    case priorityInUseException(message: String?)
-    case resourceInUseException(message: String?)
-    case ruleNotFoundException(message: String?)
-    case sSLPolicyNotFoundException(message: String?)
-    case subnetNotFoundException(message: String?)
-    case targetGroupAssociationLimitException(message: String?)
-    case targetGroupNotFoundException(message: String?)
-    case tooManyActionsException(message: String?)
-    case tooManyCertificatesException(message: String?)
-    case tooManyListenersException(message: String?)
-    case tooManyLoadBalancersException(message: String?)
-    case tooManyRegistrationsForTargetIdException(message: String?)
-    case tooManyRulesException(message: String?)
-    case tooManyTagsException(message: String?)
-    case tooManyTargetGroupsException(message: String?)
-    case tooManyTargetsException(message: String?)
-    case tooManyUniqueTargetGroupsPerLoadBalancerException(message: String?)
-    case unsupportedProtocolException(message: String?)
-}
+public struct ElasticLoadBalancingv2ErrorType: AWSErrorType {
+    enum Code: String {
+        case aLPNPolicyNotSupportedException = "ALPNPolicyNotFound"
+        case allocationIdNotFoundException = "AllocationIdNotFound"
+        case availabilityZoneNotSupportedException = "AvailabilityZoneNotSupported"
+        case certificateNotFoundException = "CertificateNotFound"
+        case duplicateListenerException = "DuplicateListener"
+        case duplicateLoadBalancerNameException = "DuplicateLoadBalancerName"
+        case duplicateTagKeysException = "DuplicateTagKeys"
+        case duplicateTargetGroupNameException = "DuplicateTargetGroupName"
+        case healthUnavailableException = "HealthUnavailable"
+        case incompatibleProtocolsException = "IncompatibleProtocols"
+        case invalidConfigurationRequestException = "InvalidConfigurationRequest"
+        case invalidLoadBalancerActionException = "InvalidLoadBalancerAction"
+        case invalidSchemeException = "InvalidScheme"
+        case invalidSecurityGroupException = "InvalidSecurityGroup"
+        case invalidSubnetException = "InvalidSubnet"
+        case invalidTargetException = "InvalidTarget"
+        case listenerNotFoundException = "ListenerNotFound"
+        case loadBalancerNotFoundException = "LoadBalancerNotFound"
+        case operationNotPermittedException = "OperationNotPermitted"
+        case priorityInUseException = "PriorityInUse"
+        case resourceInUseException = "ResourceInUse"
+        case ruleNotFoundException = "RuleNotFound"
+        case sSLPolicyNotFoundException = "SSLPolicyNotFound"
+        case subnetNotFoundException = "SubnetNotFound"
+        case targetGroupAssociationLimitException = "TargetGroupAssociationLimit"
+        case targetGroupNotFoundException = "TargetGroupNotFound"
+        case tooManyActionsException = "TooManyActions"
+        case tooManyCertificatesException = "TooManyCertificates"
+        case tooManyListenersException = "TooManyListeners"
+        case tooManyLoadBalancersException = "TooManyLoadBalancers"
+        case tooManyRegistrationsForTargetIdException = "TooManyRegistrationsForTargetId"
+        case tooManyRulesException = "TooManyRules"
+        case tooManyTagsException = "TooManyTags"
+        case tooManyTargetGroupsException = "TooManyTargetGroups"
+        case tooManyTargetsException = "TooManyTargets"
+        case tooManyUniqueTargetGroupsPerLoadBalancerException = "TooManyUniqueTargetGroupsPerLoadBalancer"
+        case unsupportedProtocolException = "UnsupportedProtocol"
+    }
 
-extension ElasticLoadBalancingv2ErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ALPNPolicyNotFound":
-            self = .aLPNPolicyNotSupportedException(message: message)
-        case "AllocationIdNotFound":
-            self = .allocationIdNotFoundException(message: message)
-        case "AvailabilityZoneNotSupported":
-            self = .availabilityZoneNotSupportedException(message: message)
-        case "CertificateNotFound":
-            self = .certificateNotFoundException(message: message)
-        case "DuplicateListener":
-            self = .duplicateListenerException(message: message)
-        case "DuplicateLoadBalancerName":
-            self = .duplicateLoadBalancerNameException(message: message)
-        case "DuplicateTagKeys":
-            self = .duplicateTagKeysException(message: message)
-        case "DuplicateTargetGroupName":
-            self = .duplicateTargetGroupNameException(message: message)
-        case "HealthUnavailable":
-            self = .healthUnavailableException(message: message)
-        case "IncompatibleProtocols":
-            self = .incompatibleProtocolsException(message: message)
-        case "InvalidConfigurationRequest":
-            self = .invalidConfigurationRequestException(message: message)
-        case "InvalidLoadBalancerAction":
-            self = .invalidLoadBalancerActionException(message: message)
-        case "InvalidScheme":
-            self = .invalidSchemeException(message: message)
-        case "InvalidSecurityGroup":
-            self = .invalidSecurityGroupException(message: message)
-        case "InvalidSubnet":
-            self = .invalidSubnetException(message: message)
-        case "InvalidTarget":
-            self = .invalidTargetException(message: message)
-        case "ListenerNotFound":
-            self = .listenerNotFoundException(message: message)
-        case "LoadBalancerNotFound":
-            self = .loadBalancerNotFoundException(message: message)
-        case "OperationNotPermitted":
-            self = .operationNotPermittedException(message: message)
-        case "PriorityInUse":
-            self = .priorityInUseException(message: message)
-        case "ResourceInUse":
-            self = .resourceInUseException(message: message)
-        case "RuleNotFound":
-            self = .ruleNotFoundException(message: message)
-        case "SSLPolicyNotFound":
-            self = .sSLPolicyNotFoundException(message: message)
-        case "SubnetNotFound":
-            self = .subnetNotFoundException(message: message)
-        case "TargetGroupAssociationLimit":
-            self = .targetGroupAssociationLimitException(message: message)
-        case "TargetGroupNotFound":
-            self = .targetGroupNotFoundException(message: message)
-        case "TooManyActions":
-            self = .tooManyActionsException(message: message)
-        case "TooManyCertificates":
-            self = .tooManyCertificatesException(message: message)
-        case "TooManyListeners":
-            self = .tooManyListenersException(message: message)
-        case "TooManyLoadBalancers":
-            self = .tooManyLoadBalancersException(message: message)
-        case "TooManyRegistrationsForTargetId":
-            self = .tooManyRegistrationsForTargetIdException(message: message)
-        case "TooManyRules":
-            self = .tooManyRulesException(message: message)
-        case "TooManyTags":
-            self = .tooManyTagsException(message: message)
-        case "TooManyTargetGroups":
-            self = .tooManyTargetGroupsException(message: message)
-        case "TooManyTargets":
-            self = .tooManyTargetsException(message: message)
-        case "TooManyUniqueTargetGroupsPerLoadBalancer":
-            self = .tooManyUniqueTargetGroupsPerLoadBalancerException(message: message)
-        case "UnsupportedProtocol":
-            self = .unsupportedProtocolException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var aLPNPolicyNotSupportedException: Self { .init(.aLPNPolicyNotSupportedException) }
+    public static var allocationIdNotFoundException: Self { .init(.allocationIdNotFoundException) }
+    public static var availabilityZoneNotSupportedException: Self { .init(.availabilityZoneNotSupportedException) }
+    public static var certificateNotFoundException: Self { .init(.certificateNotFoundException) }
+    public static var duplicateListenerException: Self { .init(.duplicateListenerException) }
+    public static var duplicateLoadBalancerNameException: Self { .init(.duplicateLoadBalancerNameException) }
+    public static var duplicateTagKeysException: Self { .init(.duplicateTagKeysException) }
+    public static var duplicateTargetGroupNameException: Self { .init(.duplicateTargetGroupNameException) }
+    public static var healthUnavailableException: Self { .init(.healthUnavailableException) }
+    public static var incompatibleProtocolsException: Self { .init(.incompatibleProtocolsException) }
+    public static var invalidConfigurationRequestException: Self { .init(.invalidConfigurationRequestException) }
+    public static var invalidLoadBalancerActionException: Self { .init(.invalidLoadBalancerActionException) }
+    public static var invalidSchemeException: Self { .init(.invalidSchemeException) }
+    public static var invalidSecurityGroupException: Self { .init(.invalidSecurityGroupException) }
+    public static var invalidSubnetException: Self { .init(.invalidSubnetException) }
+    public static var invalidTargetException: Self { .init(.invalidTargetException) }
+    public static var listenerNotFoundException: Self { .init(.listenerNotFoundException) }
+    public static var loadBalancerNotFoundException: Self { .init(.loadBalancerNotFoundException) }
+    public static var operationNotPermittedException: Self { .init(.operationNotPermittedException) }
+    public static var priorityInUseException: Self { .init(.priorityInUseException) }
+    public static var resourceInUseException: Self { .init(.resourceInUseException) }
+    public static var ruleNotFoundException: Self { .init(.ruleNotFoundException) }
+    public static var sSLPolicyNotFoundException: Self { .init(.sSLPolicyNotFoundException) }
+    public static var subnetNotFoundException: Self { .init(.subnetNotFoundException) }
+    public static var targetGroupAssociationLimitException: Self { .init(.targetGroupAssociationLimitException) }
+    public static var targetGroupNotFoundException: Self { .init(.targetGroupNotFoundException) }
+    public static var tooManyActionsException: Self { .init(.tooManyActionsException) }
+    public static var tooManyCertificatesException: Self { .init(.tooManyCertificatesException) }
+    public static var tooManyListenersException: Self { .init(.tooManyListenersException) }
+    public static var tooManyLoadBalancersException: Self { .init(.tooManyLoadBalancersException) }
+    public static var tooManyRegistrationsForTargetIdException: Self { .init(.tooManyRegistrationsForTargetIdException) }
+    public static var tooManyRulesException: Self { .init(.tooManyRulesException) }
+    public static var tooManyTagsException: Self { .init(.tooManyTagsException) }
+    public static var tooManyTargetGroupsException: Self { .init(.tooManyTargetGroupsException) }
+    public static var tooManyTargetsException: Self { .init(.tooManyTargetsException) }
+    public static var tooManyUniqueTargetGroupsPerLoadBalancerException: Self { .init(.tooManyUniqueTargetGroupsPerLoadBalancerException) }
+    public static var unsupportedProtocolException: Self { .init(.unsupportedProtocolException) }
+}
+
+extension ElasticLoadBalancingv2ErrorType: Equatable {
+    public static func == (lhs: ElasticLoadBalancingv2ErrorType, rhs: ElasticLoadBalancingv2ErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ElasticLoadBalancingv2ErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .aLPNPolicyNotSupportedException(let message):
-            return "ALPNPolicyNotFound: \(message ?? "")"
-        case .allocationIdNotFoundException(let message):
-            return "AllocationIdNotFound: \(message ?? "")"
-        case .availabilityZoneNotSupportedException(let message):
-            return "AvailabilityZoneNotSupported: \(message ?? "")"
-        case .certificateNotFoundException(let message):
-            return "CertificateNotFound: \(message ?? "")"
-        case .duplicateListenerException(let message):
-            return "DuplicateListener: \(message ?? "")"
-        case .duplicateLoadBalancerNameException(let message):
-            return "DuplicateLoadBalancerName: \(message ?? "")"
-        case .duplicateTagKeysException(let message):
-            return "DuplicateTagKeys: \(message ?? "")"
-        case .duplicateTargetGroupNameException(let message):
-            return "DuplicateTargetGroupName: \(message ?? "")"
-        case .healthUnavailableException(let message):
-            return "HealthUnavailable: \(message ?? "")"
-        case .incompatibleProtocolsException(let message):
-            return "IncompatibleProtocols: \(message ?? "")"
-        case .invalidConfigurationRequestException(let message):
-            return "InvalidConfigurationRequest: \(message ?? "")"
-        case .invalidLoadBalancerActionException(let message):
-            return "InvalidLoadBalancerAction: \(message ?? "")"
-        case .invalidSchemeException(let message):
-            return "InvalidScheme: \(message ?? "")"
-        case .invalidSecurityGroupException(let message):
-            return "InvalidSecurityGroup: \(message ?? "")"
-        case .invalidSubnetException(let message):
-            return "InvalidSubnet: \(message ?? "")"
-        case .invalidTargetException(let message):
-            return "InvalidTarget: \(message ?? "")"
-        case .listenerNotFoundException(let message):
-            return "ListenerNotFound: \(message ?? "")"
-        case .loadBalancerNotFoundException(let message):
-            return "LoadBalancerNotFound: \(message ?? "")"
-        case .operationNotPermittedException(let message):
-            return "OperationNotPermitted: \(message ?? "")"
-        case .priorityInUseException(let message):
-            return "PriorityInUse: \(message ?? "")"
-        case .resourceInUseException(let message):
-            return "ResourceInUse: \(message ?? "")"
-        case .ruleNotFoundException(let message):
-            return "RuleNotFound: \(message ?? "")"
-        case .sSLPolicyNotFoundException(let message):
-            return "SSLPolicyNotFound: \(message ?? "")"
-        case .subnetNotFoundException(let message):
-            return "SubnetNotFound: \(message ?? "")"
-        case .targetGroupAssociationLimitException(let message):
-            return "TargetGroupAssociationLimit: \(message ?? "")"
-        case .targetGroupNotFoundException(let message):
-            return "TargetGroupNotFound: \(message ?? "")"
-        case .tooManyActionsException(let message):
-            return "TooManyActions: \(message ?? "")"
-        case .tooManyCertificatesException(let message):
-            return "TooManyCertificates: \(message ?? "")"
-        case .tooManyListenersException(let message):
-            return "TooManyListeners: \(message ?? "")"
-        case .tooManyLoadBalancersException(let message):
-            return "TooManyLoadBalancers: \(message ?? "")"
-        case .tooManyRegistrationsForTargetIdException(let message):
-            return "TooManyRegistrationsForTargetId: \(message ?? "")"
-        case .tooManyRulesException(let message):
-            return "TooManyRules: \(message ?? "")"
-        case .tooManyTagsException(let message):
-            return "TooManyTags: \(message ?? "")"
-        case .tooManyTargetGroupsException(let message):
-            return "TooManyTargetGroups: \(message ?? "")"
-        case .tooManyTargetsException(let message):
-            return "TooManyTargets: \(message ?? "")"
-        case .tooManyUniqueTargetGroupsPerLoadBalancerException(let message):
-            return "TooManyUniqueTargetGroupsPerLoadBalancer: \(message ?? "")"
-        case .unsupportedProtocolException(let message):
-            return "UnsupportedProtocol: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/ElasticTranscoder/ElasticTranscoder_Error.swift
+++ b/Sources/Soto/Services/ElasticTranscoder/ElasticTranscoder_Error.swift
@@ -17,60 +17,52 @@
 import SotoCore
 
 /// Error enum for ElasticTranscoder
-public enum ElasticTranscoderErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case incompatibleVersionException(message: String?)
-    case internalServiceException(message: String?)
-    case limitExceededException(message: String?)
-    case resourceInUseException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case validationException(message: String?)
-}
+public struct ElasticTranscoderErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case incompatibleVersionException = "IncompatibleVersionException"
+        case internalServiceException = "InternalServiceException"
+        case limitExceededException = "LimitExceededException"
+        case resourceInUseException = "ResourceInUseException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case validationException = "ValidationException"
+    }
 
-extension ElasticTranscoderErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "IncompatibleVersionException":
-            self = .incompatibleVersionException(message: message)
-        case "InternalServiceException":
-            self = .internalServiceException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ResourceInUseException":
-            self = .resourceInUseException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var incompatibleVersionException: Self { .init(.incompatibleVersionException) }
+    public static var internalServiceException: Self { .init(.internalServiceException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var resourceInUseException: Self { .init(.resourceInUseException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension ElasticTranscoderErrorType: Equatable {
+    public static func == (lhs: ElasticTranscoderErrorType, rhs: ElasticTranscoderErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ElasticTranscoderErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .incompatibleVersionException(let message):
-            return "IncompatibleVersionException: \(message ?? "")"
-        case .internalServiceException(let message):
-            return "InternalServiceException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .resourceInUseException(let message):
-            return "ResourceInUseException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/ElasticsearchService/ElasticsearchService_Error.swift
+++ b/Sources/Soto/Services/ElasticsearchService/ElasticsearchService_Error.swift
@@ -17,80 +17,60 @@
 import SotoCore
 
 /// Error enum for ElasticsearchService
-public enum ElasticsearchServiceErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case baseException(message: String?)
-    case conflictException(message: String?)
-    case disabledOperationException(message: String?)
-    case internalException(message: String?)
-    case invalidPaginationTokenException(message: String?)
-    case invalidTypeException(message: String?)
-    case limitExceededException(message: String?)
-    case resourceAlreadyExistsException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case validationException(message: String?)
-}
+public struct ElasticsearchServiceErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case baseException = "BaseException"
+        case conflictException = "ConflictException"
+        case disabledOperationException = "DisabledOperationException"
+        case internalException = "InternalException"
+        case invalidPaginationTokenException = "InvalidPaginationTokenException"
+        case invalidTypeException = "InvalidTypeException"
+        case limitExceededException = "LimitExceededException"
+        case resourceAlreadyExistsException = "ResourceAlreadyExistsException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case validationException = "ValidationException"
+    }
 
-extension ElasticsearchServiceErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "BaseException":
-            self = .baseException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "DisabledOperationException":
-            self = .disabledOperationException(message: message)
-        case "InternalException":
-            self = .internalException(message: message)
-        case "InvalidPaginationTokenException":
-            self = .invalidPaginationTokenException(message: message)
-        case "InvalidTypeException":
-            self = .invalidTypeException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ResourceAlreadyExistsException":
-            self = .resourceAlreadyExistsException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var baseException: Self { .init(.baseException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var disabledOperationException: Self { .init(.disabledOperationException) }
+    public static var internalException: Self { .init(.internalException) }
+    public static var invalidPaginationTokenException: Self { .init(.invalidPaginationTokenException) }
+    public static var invalidTypeException: Self { .init(.invalidTypeException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var resourceAlreadyExistsException: Self { .init(.resourceAlreadyExistsException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension ElasticsearchServiceErrorType: Equatable {
+    public static func == (lhs: ElasticsearchServiceErrorType, rhs: ElasticsearchServiceErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ElasticsearchServiceErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .baseException(let message):
-            return "BaseException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .disabledOperationException(let message):
-            return "DisabledOperationException: \(message ?? "")"
-        case .internalException(let message):
-            return "InternalException: \(message ?? "")"
-        case .invalidPaginationTokenException(let message):
-            return "InvalidPaginationTokenException: \(message ?? "")"
-        case .invalidTypeException(let message):
-            return "InvalidTypeException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .resourceAlreadyExistsException(let message):
-            return "ResourceAlreadyExistsException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/EventBridge/EventBridge_Error.swift
+++ b/Sources/Soto/Services/EventBridge/EventBridge_Error.swift
@@ -17,75 +17,58 @@
 import SotoCore
 
 /// Error enum for EventBridge
-public enum EventBridgeErrorType: AWSErrorType {
-    case concurrentModificationException(message: String?)
-    case internalException(message: String?)
-    case invalidEventPatternException(message: String?)
-    case invalidStateException(message: String?)
-    case limitExceededException(message: String?)
-    case managedRuleException(message: String?)
-    case operationDisabledException(message: String?)
-    case policyLengthExceededException(message: String?)
-    case resourceAlreadyExistsException(message: String?)
-    case resourceNotFoundException(message: String?)
-}
+public struct EventBridgeErrorType: AWSErrorType {
+    enum Code: String {
+        case concurrentModificationException = "ConcurrentModificationException"
+        case internalException = "InternalException"
+        case invalidEventPatternException = "InvalidEventPatternException"
+        case invalidStateException = "InvalidStateException"
+        case limitExceededException = "LimitExceededException"
+        case managedRuleException = "ManagedRuleException"
+        case operationDisabledException = "OperationDisabledException"
+        case policyLengthExceededException = "PolicyLengthExceededException"
+        case resourceAlreadyExistsException = "ResourceAlreadyExistsException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+    }
 
-extension EventBridgeErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ConcurrentModificationException":
-            self = .concurrentModificationException(message: message)
-        case "InternalException":
-            self = .internalException(message: message)
-        case "InvalidEventPatternException":
-            self = .invalidEventPatternException(message: message)
-        case "InvalidStateException":
-            self = .invalidStateException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ManagedRuleException":
-            self = .managedRuleException(message: message)
-        case "OperationDisabledException":
-            self = .operationDisabledException(message: message)
-        case "PolicyLengthExceededException":
-            self = .policyLengthExceededException(message: message)
-        case "ResourceAlreadyExistsException":
-            self = .resourceAlreadyExistsException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var concurrentModificationException: Self { .init(.concurrentModificationException) }
+    public static var internalException: Self { .init(.internalException) }
+    public static var invalidEventPatternException: Self { .init(.invalidEventPatternException) }
+    public static var invalidStateException: Self { .init(.invalidStateException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var managedRuleException: Self { .init(.managedRuleException) }
+    public static var operationDisabledException: Self { .init(.operationDisabledException) }
+    public static var policyLengthExceededException: Self { .init(.policyLengthExceededException) }
+    public static var resourceAlreadyExistsException: Self { .init(.resourceAlreadyExistsException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+}
+
+extension EventBridgeErrorType: Equatable {
+    public static func == (lhs: EventBridgeErrorType, rhs: EventBridgeErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension EventBridgeErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .concurrentModificationException(let message):
-            return "ConcurrentModificationException: \(message ?? "")"
-        case .internalException(let message):
-            return "InternalException: \(message ?? "")"
-        case .invalidEventPatternException(let message):
-            return "InvalidEventPatternException: \(message ?? "")"
-        case .invalidStateException(let message):
-            return "InvalidStateException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .managedRuleException(let message):
-            return "ManagedRuleException: \(message ?? "")"
-        case .operationDisabledException(let message):
-            return "OperationDisabledException: \(message ?? "")"
-        case .policyLengthExceededException(let message):
-            return "PolicyLengthExceededException: \(message ?? "")"
-        case .resourceAlreadyExistsException(let message):
-            return "ResourceAlreadyExistsException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/FMS/FMS_Error.swift
+++ b/Sources/Soto/Services/FMS/FMS_Error.swift
@@ -17,55 +17,50 @@
 import SotoCore
 
 /// Error enum for FMS
-public enum FMSErrorType: AWSErrorType {
-    case internalErrorException(message: String?)
-    case invalidInputException(message: String?)
-    case invalidOperationException(message: String?)
-    case invalidTypeException(message: String?)
-    case limitExceededException(message: String?)
-    case resourceNotFoundException(message: String?)
-}
+public struct FMSErrorType: AWSErrorType {
+    enum Code: String {
+        case internalErrorException = "InternalErrorException"
+        case invalidInputException = "InvalidInputException"
+        case invalidOperationException = "InvalidOperationException"
+        case invalidTypeException = "InvalidTypeException"
+        case limitExceededException = "LimitExceededException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+    }
 
-extension FMSErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "InternalErrorException":
-            self = .internalErrorException(message: message)
-        case "InvalidInputException":
-            self = .invalidInputException(message: message)
-        case "InvalidOperationException":
-            self = .invalidOperationException(message: message)
-        case "InvalidTypeException":
-            self = .invalidTypeException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var internalErrorException: Self { .init(.internalErrorException) }
+    public static var invalidInputException: Self { .init(.invalidInputException) }
+    public static var invalidOperationException: Self { .init(.invalidOperationException) }
+    public static var invalidTypeException: Self { .init(.invalidTypeException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+}
+
+extension FMSErrorType: Equatable {
+    public static func == (lhs: FMSErrorType, rhs: FMSErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension FMSErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .internalErrorException(let message):
-            return "InternalErrorException: \(message ?? "")"
-        case .invalidInputException(let message):
-            return "InvalidInputException: \(message ?? "")"
-        case .invalidOperationException(let message):
-            return "InvalidOperationException: \(message ?? "")"
-        case .invalidTypeException(let message):
-            return "InvalidTypeException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/FSx/FSx_Error.swift
+++ b/Sources/Soto/Services/FSx/FSx_Error.swift
@@ -17,130 +17,80 @@
 import SotoCore
 
 /// Error enum for FSx
-public enum FSxErrorType: AWSErrorType {
-    case activeDirectoryError(message: String?)
-    case backupInProgress(message: String?)
-    case backupNotFound(message: String?)
-    case backupRestoring(message: String?)
-    case badRequest(message: String?)
-    case dataRepositoryTaskEnded(message: String?)
-    case dataRepositoryTaskExecuting(message: String?)
-    case dataRepositoryTaskNotFound(message: String?)
-    case fileSystemNotFound(message: String?)
-    case incompatibleParameterError(message: String?)
-    case internalServerError(message: String?)
-    case invalidExportPath(message: String?)
-    case invalidImportPath(message: String?)
-    case invalidNetworkSettings(message: String?)
-    case invalidPerUnitStorageThroughput(message: String?)
-    case missingFileSystemConfiguration(message: String?)
-    case notServiceResourceError(message: String?)
-    case resourceDoesNotSupportTagging(message: String?)
-    case resourceNotFound(message: String?)
-    case serviceLimitExceeded(message: String?)
-    case unsupportedOperation(message: String?)
-}
+public struct FSxErrorType: AWSErrorType {
+    enum Code: String {
+        case activeDirectoryError = "ActiveDirectoryError"
+        case backupInProgress = "BackupInProgress"
+        case backupNotFound = "BackupNotFound"
+        case backupRestoring = "BackupRestoring"
+        case badRequest = "BadRequest"
+        case dataRepositoryTaskEnded = "DataRepositoryTaskEnded"
+        case dataRepositoryTaskExecuting = "DataRepositoryTaskExecuting"
+        case dataRepositoryTaskNotFound = "DataRepositoryTaskNotFound"
+        case fileSystemNotFound = "FileSystemNotFound"
+        case incompatibleParameterError = "IncompatibleParameterError"
+        case internalServerError = "InternalServerError"
+        case invalidExportPath = "InvalidExportPath"
+        case invalidImportPath = "InvalidImportPath"
+        case invalidNetworkSettings = "InvalidNetworkSettings"
+        case invalidPerUnitStorageThroughput = "InvalidPerUnitStorageThroughput"
+        case missingFileSystemConfiguration = "MissingFileSystemConfiguration"
+        case notServiceResourceError = "NotServiceResourceError"
+        case resourceDoesNotSupportTagging = "ResourceDoesNotSupportTagging"
+        case resourceNotFound = "ResourceNotFound"
+        case serviceLimitExceeded = "ServiceLimitExceeded"
+        case unsupportedOperation = "UnsupportedOperation"
+    }
 
-extension FSxErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ActiveDirectoryError":
-            self = .activeDirectoryError(message: message)
-        case "BackupInProgress":
-            self = .backupInProgress(message: message)
-        case "BackupNotFound":
-            self = .backupNotFound(message: message)
-        case "BackupRestoring":
-            self = .backupRestoring(message: message)
-        case "BadRequest":
-            self = .badRequest(message: message)
-        case "DataRepositoryTaskEnded":
-            self = .dataRepositoryTaskEnded(message: message)
-        case "DataRepositoryTaskExecuting":
-            self = .dataRepositoryTaskExecuting(message: message)
-        case "DataRepositoryTaskNotFound":
-            self = .dataRepositoryTaskNotFound(message: message)
-        case "FileSystemNotFound":
-            self = .fileSystemNotFound(message: message)
-        case "IncompatibleParameterError":
-            self = .incompatibleParameterError(message: message)
-        case "InternalServerError":
-            self = .internalServerError(message: message)
-        case "InvalidExportPath":
-            self = .invalidExportPath(message: message)
-        case "InvalidImportPath":
-            self = .invalidImportPath(message: message)
-        case "InvalidNetworkSettings":
-            self = .invalidNetworkSettings(message: message)
-        case "InvalidPerUnitStorageThroughput":
-            self = .invalidPerUnitStorageThroughput(message: message)
-        case "MissingFileSystemConfiguration":
-            self = .missingFileSystemConfiguration(message: message)
-        case "NotServiceResourceError":
-            self = .notServiceResourceError(message: message)
-        case "ResourceDoesNotSupportTagging":
-            self = .resourceDoesNotSupportTagging(message: message)
-        case "ResourceNotFound":
-            self = .resourceNotFound(message: message)
-        case "ServiceLimitExceeded":
-            self = .serviceLimitExceeded(message: message)
-        case "UnsupportedOperation":
-            self = .unsupportedOperation(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var activeDirectoryError: Self { .init(.activeDirectoryError) }
+    public static var backupInProgress: Self { .init(.backupInProgress) }
+    public static var backupNotFound: Self { .init(.backupNotFound) }
+    public static var backupRestoring: Self { .init(.backupRestoring) }
+    public static var badRequest: Self { .init(.badRequest) }
+    public static var dataRepositoryTaskEnded: Self { .init(.dataRepositoryTaskEnded) }
+    public static var dataRepositoryTaskExecuting: Self { .init(.dataRepositoryTaskExecuting) }
+    public static var dataRepositoryTaskNotFound: Self { .init(.dataRepositoryTaskNotFound) }
+    public static var fileSystemNotFound: Self { .init(.fileSystemNotFound) }
+    public static var incompatibleParameterError: Self { .init(.incompatibleParameterError) }
+    public static var internalServerError: Self { .init(.internalServerError) }
+    public static var invalidExportPath: Self { .init(.invalidExportPath) }
+    public static var invalidImportPath: Self { .init(.invalidImportPath) }
+    public static var invalidNetworkSettings: Self { .init(.invalidNetworkSettings) }
+    public static var invalidPerUnitStorageThroughput: Self { .init(.invalidPerUnitStorageThroughput) }
+    public static var missingFileSystemConfiguration: Self { .init(.missingFileSystemConfiguration) }
+    public static var notServiceResourceError: Self { .init(.notServiceResourceError) }
+    public static var resourceDoesNotSupportTagging: Self { .init(.resourceDoesNotSupportTagging) }
+    public static var resourceNotFound: Self { .init(.resourceNotFound) }
+    public static var serviceLimitExceeded: Self { .init(.serviceLimitExceeded) }
+    public static var unsupportedOperation: Self { .init(.unsupportedOperation) }
+}
+
+extension FSxErrorType: Equatable {
+    public static func == (lhs: FSxErrorType, rhs: FSxErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension FSxErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .activeDirectoryError(let message):
-            return "ActiveDirectoryError: \(message ?? "")"
-        case .backupInProgress(let message):
-            return "BackupInProgress: \(message ?? "")"
-        case .backupNotFound(let message):
-            return "BackupNotFound: \(message ?? "")"
-        case .backupRestoring(let message):
-            return "BackupRestoring: \(message ?? "")"
-        case .badRequest(let message):
-            return "BadRequest: \(message ?? "")"
-        case .dataRepositoryTaskEnded(let message):
-            return "DataRepositoryTaskEnded: \(message ?? "")"
-        case .dataRepositoryTaskExecuting(let message):
-            return "DataRepositoryTaskExecuting: \(message ?? "")"
-        case .dataRepositoryTaskNotFound(let message):
-            return "DataRepositoryTaskNotFound: \(message ?? "")"
-        case .fileSystemNotFound(let message):
-            return "FileSystemNotFound: \(message ?? "")"
-        case .incompatibleParameterError(let message):
-            return "IncompatibleParameterError: \(message ?? "")"
-        case .internalServerError(let message):
-            return "InternalServerError: \(message ?? "")"
-        case .invalidExportPath(let message):
-            return "InvalidExportPath: \(message ?? "")"
-        case .invalidImportPath(let message):
-            return "InvalidImportPath: \(message ?? "")"
-        case .invalidNetworkSettings(let message):
-            return "InvalidNetworkSettings: \(message ?? "")"
-        case .invalidPerUnitStorageThroughput(let message):
-            return "InvalidPerUnitStorageThroughput: \(message ?? "")"
-        case .missingFileSystemConfiguration(let message):
-            return "MissingFileSystemConfiguration: \(message ?? "")"
-        case .notServiceResourceError(let message):
-            return "NotServiceResourceError: \(message ?? "")"
-        case .resourceDoesNotSupportTagging(let message):
-            return "ResourceDoesNotSupportTagging: \(message ?? "")"
-        case .resourceNotFound(let message):
-            return "ResourceNotFound: \(message ?? "")"
-        case .serviceLimitExceeded(let message):
-            return "ServiceLimitExceeded: \(message ?? "")"
-        case .unsupportedOperation(let message):
-            return "UnsupportedOperation: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Firehose/Firehose_Error.swift
+++ b/Sources/Soto/Services/Firehose/Firehose_Error.swift
@@ -17,60 +17,52 @@
 import SotoCore
 
 /// Error enum for Firehose
-public enum FirehoseErrorType: AWSErrorType {
-    case concurrentModificationException(message: String?)
-    case invalidArgumentException(message: String?)
-    case invalidKMSResourceException(message: String?)
-    case limitExceededException(message: String?)
-    case resourceInUseException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceUnavailableException(message: String?)
-}
+public struct FirehoseErrorType: AWSErrorType {
+    enum Code: String {
+        case concurrentModificationException = "ConcurrentModificationException"
+        case invalidArgumentException = "InvalidArgumentException"
+        case invalidKMSResourceException = "InvalidKMSResourceException"
+        case limitExceededException = "LimitExceededException"
+        case resourceInUseException = "ResourceInUseException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+    }
 
-extension FirehoseErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ConcurrentModificationException":
-            self = .concurrentModificationException(message: message)
-        case "InvalidArgumentException":
-            self = .invalidArgumentException(message: message)
-        case "InvalidKMSResourceException":
-            self = .invalidKMSResourceException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ResourceInUseException":
-            self = .resourceInUseException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var concurrentModificationException: Self { .init(.concurrentModificationException) }
+    public static var invalidArgumentException: Self { .init(.invalidArgumentException) }
+    public static var invalidKMSResourceException: Self { .init(.invalidKMSResourceException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var resourceInUseException: Self { .init(.resourceInUseException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+}
+
+extension FirehoseErrorType: Equatable {
+    public static func == (lhs: FirehoseErrorType, rhs: FirehoseErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension FirehoseErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .concurrentModificationException(let message):
-            return "ConcurrentModificationException: \(message ?? "")"
-        case .invalidArgumentException(let message):
-            return "InvalidArgumentException: \(message ?? "")"
-        case .invalidKMSResourceException(let message):
-            return "InvalidKMSResourceException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .resourceInUseException(let message):
-            return "ResourceInUseException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/ForecastQueryService/ForecastQueryService_Error.swift
+++ b/Sources/Soto/Services/ForecastQueryService/ForecastQueryService_Error.swift
@@ -17,50 +17,48 @@
 import SotoCore
 
 /// Error enum for ForecastQueryService
-public enum ForecastQueryServiceErrorType: AWSErrorType {
-    case invalidInputException(message: String?)
-    case invalidNextTokenException(message: String?)
-    case limitExceededException(message: String?)
-    case resourceInUseException(message: String?)
-    case resourceNotFoundException(message: String?)
-}
+public struct ForecastQueryServiceErrorType: AWSErrorType {
+    enum Code: String {
+        case invalidInputException = "InvalidInputException"
+        case invalidNextTokenException = "InvalidNextTokenException"
+        case limitExceededException = "LimitExceededException"
+        case resourceInUseException = "ResourceInUseException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+    }
 
-extension ForecastQueryServiceErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "InvalidInputException":
-            self = .invalidInputException(message: message)
-        case "InvalidNextTokenException":
-            self = .invalidNextTokenException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ResourceInUseException":
-            self = .resourceInUseException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var invalidInputException: Self { .init(.invalidInputException) }
+    public static var invalidNextTokenException: Self { .init(.invalidNextTokenException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var resourceInUseException: Self { .init(.resourceInUseException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+}
+
+extension ForecastQueryServiceErrorType: Equatable {
+    public static func == (lhs: ForecastQueryServiceErrorType, rhs: ForecastQueryServiceErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ForecastQueryServiceErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .invalidInputException(let message):
-            return "InvalidInputException: \(message ?? "")"
-        case .invalidNextTokenException(let message):
-            return "InvalidNextTokenException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .resourceInUseException(let message):
-            return "ResourceInUseException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/ForecastService/ForecastService_Error.swift
+++ b/Sources/Soto/Services/ForecastService/ForecastService_Error.swift
@@ -17,55 +17,50 @@
 import SotoCore
 
 /// Error enum for ForecastService
-public enum ForecastServiceErrorType: AWSErrorType {
-    case invalidInputException(message: String?)
-    case invalidNextTokenException(message: String?)
-    case limitExceededException(message: String?)
-    case resourceAlreadyExistsException(message: String?)
-    case resourceInUseException(message: String?)
-    case resourceNotFoundException(message: String?)
-}
+public struct ForecastServiceErrorType: AWSErrorType {
+    enum Code: String {
+        case invalidInputException = "InvalidInputException"
+        case invalidNextTokenException = "InvalidNextTokenException"
+        case limitExceededException = "LimitExceededException"
+        case resourceAlreadyExistsException = "ResourceAlreadyExistsException"
+        case resourceInUseException = "ResourceInUseException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+    }
 
-extension ForecastServiceErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "InvalidInputException":
-            self = .invalidInputException(message: message)
-        case "InvalidNextTokenException":
-            self = .invalidNextTokenException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ResourceAlreadyExistsException":
-            self = .resourceAlreadyExistsException(message: message)
-        case "ResourceInUseException":
-            self = .resourceInUseException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var invalidInputException: Self { .init(.invalidInputException) }
+    public static var invalidNextTokenException: Self { .init(.invalidNextTokenException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var resourceAlreadyExistsException: Self { .init(.resourceAlreadyExistsException) }
+    public static var resourceInUseException: Self { .init(.resourceInUseException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+}
+
+extension ForecastServiceErrorType: Equatable {
+    public static func == (lhs: ForecastServiceErrorType, rhs: ForecastServiceErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ForecastServiceErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .invalidInputException(let message):
-            return "InvalidInputException: \(message ?? "")"
-        case .invalidNextTokenException(let message):
-            return "InvalidNextTokenException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .resourceAlreadyExistsException(let message):
-            return "ResourceAlreadyExistsException: \(message ?? "")"
-        case .resourceInUseException(let message):
-            return "ResourceInUseException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/FraudDetector/FraudDetector_Error.swift
+++ b/Sources/Soto/Services/FraudDetector/FraudDetector_Error.swift
@@ -17,55 +17,50 @@
 import SotoCore
 
 /// Error enum for FraudDetector
-public enum FraudDetectorErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case conflictException(message: String?)
-    case internalServerException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case throttlingException(message: String?)
-    case validationException(message: String?)
-}
+public struct FraudDetectorErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case conflictException = "ConflictException"
+        case internalServerException = "InternalServerException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case throttlingException = "ThrottlingException"
+        case validationException = "ValidationException"
+    }
 
-extension FraudDetectorErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension FraudDetectorErrorType: Equatable {
+    public static func == (lhs: FraudDetectorErrorType, rhs: FraudDetectorErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension FraudDetectorErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/GameLift/GameLift_Error.swift
+++ b/Sources/Soto/Services/GameLift/GameLift_Error.swift
@@ -17,100 +17,68 @@
 import SotoCore
 
 /// Error enum for GameLift
-public enum GameLiftErrorType: AWSErrorType {
-    case conflictException(message: String?)
-    case fleetCapacityExceededException(message: String?)
-    case gameSessionFullException(message: String?)
-    case idempotentParameterMismatchException(message: String?)
-    case internalServiceException(message: String?)
-    case invalidFleetStatusException(message: String?)
-    case invalidGameSessionStatusException(message: String?)
-    case invalidRequestException(message: String?)
-    case limitExceededException(message: String?)
-    case notFoundException(message: String?)
-    case outOfCapacityException(message: String?)
-    case taggingFailedException(message: String?)
-    case terminalRoutingStrategyException(message: String?)
-    case unauthorizedException(message: String?)
-    case unsupportedRegionException(message: String?)
-}
+public struct GameLiftErrorType: AWSErrorType {
+    enum Code: String {
+        case conflictException = "ConflictException"
+        case fleetCapacityExceededException = "FleetCapacityExceededException"
+        case gameSessionFullException = "GameSessionFullException"
+        case idempotentParameterMismatchException = "IdempotentParameterMismatchException"
+        case internalServiceException = "InternalServiceException"
+        case invalidFleetStatusException = "InvalidFleetStatusException"
+        case invalidGameSessionStatusException = "InvalidGameSessionStatusException"
+        case invalidRequestException = "InvalidRequestException"
+        case limitExceededException = "LimitExceededException"
+        case notFoundException = "NotFoundException"
+        case outOfCapacityException = "OutOfCapacityException"
+        case taggingFailedException = "TaggingFailedException"
+        case terminalRoutingStrategyException = "TerminalRoutingStrategyException"
+        case unauthorizedException = "UnauthorizedException"
+        case unsupportedRegionException = "UnsupportedRegionException"
+    }
 
-extension GameLiftErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "FleetCapacityExceededException":
-            self = .fleetCapacityExceededException(message: message)
-        case "GameSessionFullException":
-            self = .gameSessionFullException(message: message)
-        case "IdempotentParameterMismatchException":
-            self = .idempotentParameterMismatchException(message: message)
-        case "InternalServiceException":
-            self = .internalServiceException(message: message)
-        case "InvalidFleetStatusException":
-            self = .invalidFleetStatusException(message: message)
-        case "InvalidGameSessionStatusException":
-            self = .invalidGameSessionStatusException(message: message)
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "OutOfCapacityException":
-            self = .outOfCapacityException(message: message)
-        case "TaggingFailedException":
-            self = .taggingFailedException(message: message)
-        case "TerminalRoutingStrategyException":
-            self = .terminalRoutingStrategyException(message: message)
-        case "UnauthorizedException":
-            self = .unauthorizedException(message: message)
-        case "UnsupportedRegionException":
-            self = .unsupportedRegionException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var fleetCapacityExceededException: Self { .init(.fleetCapacityExceededException) }
+    public static var gameSessionFullException: Self { .init(.gameSessionFullException) }
+    public static var idempotentParameterMismatchException: Self { .init(.idempotentParameterMismatchException) }
+    public static var internalServiceException: Self { .init(.internalServiceException) }
+    public static var invalidFleetStatusException: Self { .init(.invalidFleetStatusException) }
+    public static var invalidGameSessionStatusException: Self { .init(.invalidGameSessionStatusException) }
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var outOfCapacityException: Self { .init(.outOfCapacityException) }
+    public static var taggingFailedException: Self { .init(.taggingFailedException) }
+    public static var terminalRoutingStrategyException: Self { .init(.terminalRoutingStrategyException) }
+    public static var unauthorizedException: Self { .init(.unauthorizedException) }
+    public static var unsupportedRegionException: Self { .init(.unsupportedRegionException) }
+}
+
+extension GameLiftErrorType: Equatable {
+    public static func == (lhs: GameLiftErrorType, rhs: GameLiftErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension GameLiftErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .fleetCapacityExceededException(let message):
-            return "FleetCapacityExceededException: \(message ?? "")"
-        case .gameSessionFullException(let message):
-            return "GameSessionFullException: \(message ?? "")"
-        case .idempotentParameterMismatchException(let message):
-            return "IdempotentParameterMismatchException: \(message ?? "")"
-        case .internalServiceException(let message):
-            return "InternalServiceException: \(message ?? "")"
-        case .invalidFleetStatusException(let message):
-            return "InvalidFleetStatusException: \(message ?? "")"
-        case .invalidGameSessionStatusException(let message):
-            return "InvalidGameSessionStatusException: \(message ?? "")"
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .outOfCapacityException(let message):
-            return "OutOfCapacityException: \(message ?? "")"
-        case .taggingFailedException(let message):
-            return "TaggingFailedException: \(message ?? "")"
-        case .terminalRoutingStrategyException(let message):
-            return "TerminalRoutingStrategyException: \(message ?? "")"
-        case .unauthorizedException(let message):
-            return "UnauthorizedException: \(message ?? "")"
-        case .unsupportedRegionException(let message):
-            return "UnsupportedRegionException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Glacier/Glacier_Error.swift
+++ b/Sources/Soto/Services/Glacier/Glacier_Error.swift
@@ -17,65 +17,54 @@
 import SotoCore
 
 /// Error enum for Glacier
-public enum GlacierErrorType: AWSErrorType {
-    case insufficientCapacityException(message: String?)
-    case invalidParameterValueException(message: String?)
-    case limitExceededException(message: String?)
-    case missingParameterValueException(message: String?)
-    case policyEnforcedException(message: String?)
-    case requestTimeoutException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceUnavailableException(message: String?)
-}
+public struct GlacierErrorType: AWSErrorType {
+    enum Code: String {
+        case insufficientCapacityException = "InsufficientCapacityException"
+        case invalidParameterValueException = "InvalidParameterValueException"
+        case limitExceededException = "LimitExceededException"
+        case missingParameterValueException = "MissingParameterValueException"
+        case policyEnforcedException = "PolicyEnforcedException"
+        case requestTimeoutException = "RequestTimeoutException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+    }
 
-extension GlacierErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "InsufficientCapacityException":
-            self = .insufficientCapacityException(message: message)
-        case "InvalidParameterValueException":
-            self = .invalidParameterValueException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "MissingParameterValueException":
-            self = .missingParameterValueException(message: message)
-        case "PolicyEnforcedException":
-            self = .policyEnforcedException(message: message)
-        case "RequestTimeoutException":
-            self = .requestTimeoutException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var insufficientCapacityException: Self { .init(.insufficientCapacityException) }
+    public static var invalidParameterValueException: Self { .init(.invalidParameterValueException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var missingParameterValueException: Self { .init(.missingParameterValueException) }
+    public static var policyEnforcedException: Self { .init(.policyEnforcedException) }
+    public static var requestTimeoutException: Self { .init(.requestTimeoutException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+}
+
+extension GlacierErrorType: Equatable {
+    public static func == (lhs: GlacierErrorType, rhs: GlacierErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension GlacierErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .insufficientCapacityException(let message):
-            return "InsufficientCapacityException: \(message ?? "")"
-        case .invalidParameterValueException(let message):
-            return "InvalidParameterValueException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .missingParameterValueException(let message):
-            return "MissingParameterValueException: \(message ?? "")"
-        case .policyEnforcedException(let message):
-            return "PolicyEnforcedException: \(message ?? "")"
-        case .requestTimeoutException(let message):
-            return "RequestTimeoutException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/GlobalAccelerator/GlobalAccelerator_Error.swift
+++ b/Sources/Soto/Services/GlobalAccelerator/GlobalAccelerator_Error.swift
@@ -17,100 +17,68 @@
 import SotoCore
 
 /// Error enum for GlobalAccelerator
-public enum GlobalAcceleratorErrorType: AWSErrorType {
-    case acceleratorNotDisabledException(message: String?)
-    case acceleratorNotFoundException(message: String?)
-    case accessDeniedException(message: String?)
-    case associatedEndpointGroupFoundException(message: String?)
-    case associatedListenerFoundException(message: String?)
-    case byoipCidrNotFoundException(message: String?)
-    case endpointGroupAlreadyExistsException(message: String?)
-    case endpointGroupNotFoundException(message: String?)
-    case incorrectCidrStateException(message: String?)
-    case internalServiceErrorException(message: String?)
-    case invalidArgumentException(message: String?)
-    case invalidNextTokenException(message: String?)
-    case invalidPortRangeException(message: String?)
-    case limitExceededException(message: String?)
-    case listenerNotFoundException(message: String?)
-}
+public struct GlobalAcceleratorErrorType: AWSErrorType {
+    enum Code: String {
+        case acceleratorNotDisabledException = "AcceleratorNotDisabledException"
+        case acceleratorNotFoundException = "AcceleratorNotFoundException"
+        case accessDeniedException = "AccessDeniedException"
+        case associatedEndpointGroupFoundException = "AssociatedEndpointGroupFoundException"
+        case associatedListenerFoundException = "AssociatedListenerFoundException"
+        case byoipCidrNotFoundException = "ByoipCidrNotFoundException"
+        case endpointGroupAlreadyExistsException = "EndpointGroupAlreadyExistsException"
+        case endpointGroupNotFoundException = "EndpointGroupNotFoundException"
+        case incorrectCidrStateException = "IncorrectCidrStateException"
+        case internalServiceErrorException = "InternalServiceErrorException"
+        case invalidArgumentException = "InvalidArgumentException"
+        case invalidNextTokenException = "InvalidNextTokenException"
+        case invalidPortRangeException = "InvalidPortRangeException"
+        case limitExceededException = "LimitExceededException"
+        case listenerNotFoundException = "ListenerNotFoundException"
+    }
 
-extension GlobalAcceleratorErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AcceleratorNotDisabledException":
-            self = .acceleratorNotDisabledException(message: message)
-        case "AcceleratorNotFoundException":
-            self = .acceleratorNotFoundException(message: message)
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "AssociatedEndpointGroupFoundException":
-            self = .associatedEndpointGroupFoundException(message: message)
-        case "AssociatedListenerFoundException":
-            self = .associatedListenerFoundException(message: message)
-        case "ByoipCidrNotFoundException":
-            self = .byoipCidrNotFoundException(message: message)
-        case "EndpointGroupAlreadyExistsException":
-            self = .endpointGroupAlreadyExistsException(message: message)
-        case "EndpointGroupNotFoundException":
-            self = .endpointGroupNotFoundException(message: message)
-        case "IncorrectCidrStateException":
-            self = .incorrectCidrStateException(message: message)
-        case "InternalServiceErrorException":
-            self = .internalServiceErrorException(message: message)
-        case "InvalidArgumentException":
-            self = .invalidArgumentException(message: message)
-        case "InvalidNextTokenException":
-            self = .invalidNextTokenException(message: message)
-        case "InvalidPortRangeException":
-            self = .invalidPortRangeException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ListenerNotFoundException":
-            self = .listenerNotFoundException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var acceleratorNotDisabledException: Self { .init(.acceleratorNotDisabledException) }
+    public static var acceleratorNotFoundException: Self { .init(.acceleratorNotFoundException) }
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var associatedEndpointGroupFoundException: Self { .init(.associatedEndpointGroupFoundException) }
+    public static var associatedListenerFoundException: Self { .init(.associatedListenerFoundException) }
+    public static var byoipCidrNotFoundException: Self { .init(.byoipCidrNotFoundException) }
+    public static var endpointGroupAlreadyExistsException: Self { .init(.endpointGroupAlreadyExistsException) }
+    public static var endpointGroupNotFoundException: Self { .init(.endpointGroupNotFoundException) }
+    public static var incorrectCidrStateException: Self { .init(.incorrectCidrStateException) }
+    public static var internalServiceErrorException: Self { .init(.internalServiceErrorException) }
+    public static var invalidArgumentException: Self { .init(.invalidArgumentException) }
+    public static var invalidNextTokenException: Self { .init(.invalidNextTokenException) }
+    public static var invalidPortRangeException: Self { .init(.invalidPortRangeException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var listenerNotFoundException: Self { .init(.listenerNotFoundException) }
+}
+
+extension GlobalAcceleratorErrorType: Equatable {
+    public static func == (lhs: GlobalAcceleratorErrorType, rhs: GlobalAcceleratorErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension GlobalAcceleratorErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .acceleratorNotDisabledException(let message):
-            return "AcceleratorNotDisabledException: \(message ?? "")"
-        case .acceleratorNotFoundException(let message):
-            return "AcceleratorNotFoundException: \(message ?? "")"
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .associatedEndpointGroupFoundException(let message):
-            return "AssociatedEndpointGroupFoundException: \(message ?? "")"
-        case .associatedListenerFoundException(let message):
-            return "AssociatedListenerFoundException: \(message ?? "")"
-        case .byoipCidrNotFoundException(let message):
-            return "ByoipCidrNotFoundException: \(message ?? "")"
-        case .endpointGroupAlreadyExistsException(let message):
-            return "EndpointGroupAlreadyExistsException: \(message ?? "")"
-        case .endpointGroupNotFoundException(let message):
-            return "EndpointGroupNotFoundException: \(message ?? "")"
-        case .incorrectCidrStateException(let message):
-            return "IncorrectCidrStateException: \(message ?? "")"
-        case .internalServiceErrorException(let message):
-            return "InternalServiceErrorException: \(message ?? "")"
-        case .invalidArgumentException(let message):
-            return "InvalidArgumentException: \(message ?? "")"
-        case .invalidNextTokenException(let message):
-            return "InvalidNextTokenException: \(message ?? "")"
-        case .invalidPortRangeException(let message):
-            return "InvalidPortRangeException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .listenerNotFoundException(let message):
-            return "ListenerNotFoundException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Glue/Glue_Error.swift
+++ b/Sources/Soto/Services/Glue/Glue_Error.swift
@@ -17,145 +17,86 @@
 import SotoCore
 
 /// Error enum for Glue
-public enum GlueErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case alreadyExistsException(message: String?)
-    case concurrentModificationException(message: String?)
-    case concurrentRunsExceededException(message: String?)
-    case conditionCheckFailureException(message: String?)
-    case conflictException(message: String?)
-    case crawlerNotRunningException(message: String?)
-    case crawlerRunningException(message: String?)
-    case crawlerStoppingException(message: String?)
-    case entityNotFoundException(message: String?)
-    case glueEncryptionException(message: String?)
-    case idempotentParameterMismatchException(message: String?)
-    case illegalWorkflowStateException(message: String?)
-    case internalServiceException(message: String?)
-    case invalidInputException(message: String?)
-    case mLTransformNotReadyException(message: String?)
-    case noScheduleException(message: String?)
-    case operationTimeoutException(message: String?)
-    case resourceNumberLimitExceededException(message: String?)
-    case schedulerNotRunningException(message: String?)
-    case schedulerRunningException(message: String?)
-    case schedulerTransitioningException(message: String?)
-    case validationException(message: String?)
-    case versionMismatchException(message: String?)
-}
+public struct GlueErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case alreadyExistsException = "AlreadyExistsException"
+        case concurrentModificationException = "ConcurrentModificationException"
+        case concurrentRunsExceededException = "ConcurrentRunsExceededException"
+        case conditionCheckFailureException = "ConditionCheckFailureException"
+        case conflictException = "ConflictException"
+        case crawlerNotRunningException = "CrawlerNotRunningException"
+        case crawlerRunningException = "CrawlerRunningException"
+        case crawlerStoppingException = "CrawlerStoppingException"
+        case entityNotFoundException = "EntityNotFoundException"
+        case glueEncryptionException = "GlueEncryptionException"
+        case idempotentParameterMismatchException = "IdempotentParameterMismatchException"
+        case illegalWorkflowStateException = "IllegalWorkflowStateException"
+        case internalServiceException = "InternalServiceException"
+        case invalidInputException = "InvalidInputException"
+        case mLTransformNotReadyException = "MLTransformNotReadyException"
+        case noScheduleException = "NoScheduleException"
+        case operationTimeoutException = "OperationTimeoutException"
+        case resourceNumberLimitExceededException = "ResourceNumberLimitExceededException"
+        case schedulerNotRunningException = "SchedulerNotRunningException"
+        case schedulerRunningException = "SchedulerRunningException"
+        case schedulerTransitioningException = "SchedulerTransitioningException"
+        case validationException = "ValidationException"
+        case versionMismatchException = "VersionMismatchException"
+    }
 
-extension GlueErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "AlreadyExistsException":
-            self = .alreadyExistsException(message: message)
-        case "ConcurrentModificationException":
-            self = .concurrentModificationException(message: message)
-        case "ConcurrentRunsExceededException":
-            self = .concurrentRunsExceededException(message: message)
-        case "ConditionCheckFailureException":
-            self = .conditionCheckFailureException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "CrawlerNotRunningException":
-            self = .crawlerNotRunningException(message: message)
-        case "CrawlerRunningException":
-            self = .crawlerRunningException(message: message)
-        case "CrawlerStoppingException":
-            self = .crawlerStoppingException(message: message)
-        case "EntityNotFoundException":
-            self = .entityNotFoundException(message: message)
-        case "GlueEncryptionException":
-            self = .glueEncryptionException(message: message)
-        case "IdempotentParameterMismatchException":
-            self = .idempotentParameterMismatchException(message: message)
-        case "IllegalWorkflowStateException":
-            self = .illegalWorkflowStateException(message: message)
-        case "InternalServiceException":
-            self = .internalServiceException(message: message)
-        case "InvalidInputException":
-            self = .invalidInputException(message: message)
-        case "MLTransformNotReadyException":
-            self = .mLTransformNotReadyException(message: message)
-        case "NoScheduleException":
-            self = .noScheduleException(message: message)
-        case "OperationTimeoutException":
-            self = .operationTimeoutException(message: message)
-        case "ResourceNumberLimitExceededException":
-            self = .resourceNumberLimitExceededException(message: message)
-        case "SchedulerNotRunningException":
-            self = .schedulerNotRunningException(message: message)
-        case "SchedulerRunningException":
-            self = .schedulerRunningException(message: message)
-        case "SchedulerTransitioningException":
-            self = .schedulerTransitioningException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        case "VersionMismatchException":
-            self = .versionMismatchException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var alreadyExistsException: Self { .init(.alreadyExistsException) }
+    public static var concurrentModificationException: Self { .init(.concurrentModificationException) }
+    public static var concurrentRunsExceededException: Self { .init(.concurrentRunsExceededException) }
+    public static var conditionCheckFailureException: Self { .init(.conditionCheckFailureException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var crawlerNotRunningException: Self { .init(.crawlerNotRunningException) }
+    public static var crawlerRunningException: Self { .init(.crawlerRunningException) }
+    public static var crawlerStoppingException: Self { .init(.crawlerStoppingException) }
+    public static var entityNotFoundException: Self { .init(.entityNotFoundException) }
+    public static var glueEncryptionException: Self { .init(.glueEncryptionException) }
+    public static var idempotentParameterMismatchException: Self { .init(.idempotentParameterMismatchException) }
+    public static var illegalWorkflowStateException: Self { .init(.illegalWorkflowStateException) }
+    public static var internalServiceException: Self { .init(.internalServiceException) }
+    public static var invalidInputException: Self { .init(.invalidInputException) }
+    public static var mLTransformNotReadyException: Self { .init(.mLTransformNotReadyException) }
+    public static var noScheduleException: Self { .init(.noScheduleException) }
+    public static var operationTimeoutException: Self { .init(.operationTimeoutException) }
+    public static var resourceNumberLimitExceededException: Self { .init(.resourceNumberLimitExceededException) }
+    public static var schedulerNotRunningException: Self { .init(.schedulerNotRunningException) }
+    public static var schedulerRunningException: Self { .init(.schedulerRunningException) }
+    public static var schedulerTransitioningException: Self { .init(.schedulerTransitioningException) }
+    public static var validationException: Self { .init(.validationException) }
+    public static var versionMismatchException: Self { .init(.versionMismatchException) }
+}
+
+extension GlueErrorType: Equatable {
+    public static func == (lhs: GlueErrorType, rhs: GlueErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension GlueErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .alreadyExistsException(let message):
-            return "AlreadyExistsException: \(message ?? "")"
-        case .concurrentModificationException(let message):
-            return "ConcurrentModificationException: \(message ?? "")"
-        case .concurrentRunsExceededException(let message):
-            return "ConcurrentRunsExceededException: \(message ?? "")"
-        case .conditionCheckFailureException(let message):
-            return "ConditionCheckFailureException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .crawlerNotRunningException(let message):
-            return "CrawlerNotRunningException: \(message ?? "")"
-        case .crawlerRunningException(let message):
-            return "CrawlerRunningException: \(message ?? "")"
-        case .crawlerStoppingException(let message):
-            return "CrawlerStoppingException: \(message ?? "")"
-        case .entityNotFoundException(let message):
-            return "EntityNotFoundException: \(message ?? "")"
-        case .glueEncryptionException(let message):
-            return "GlueEncryptionException: \(message ?? "")"
-        case .idempotentParameterMismatchException(let message):
-            return "IdempotentParameterMismatchException: \(message ?? "")"
-        case .illegalWorkflowStateException(let message):
-            return "IllegalWorkflowStateException: \(message ?? "")"
-        case .internalServiceException(let message):
-            return "InternalServiceException: \(message ?? "")"
-        case .invalidInputException(let message):
-            return "InvalidInputException: \(message ?? "")"
-        case .mLTransformNotReadyException(let message):
-            return "MLTransformNotReadyException: \(message ?? "")"
-        case .noScheduleException(let message):
-            return "NoScheduleException: \(message ?? "")"
-        case .operationTimeoutException(let message):
-            return "OperationTimeoutException: \(message ?? "")"
-        case .resourceNumberLimitExceededException(let message):
-            return "ResourceNumberLimitExceededException: \(message ?? "")"
-        case .schedulerNotRunningException(let message):
-            return "SchedulerNotRunningException: \(message ?? "")"
-        case .schedulerRunningException(let message):
-            return "SchedulerRunningException: \(message ?? "")"
-        case .schedulerTransitioningException(let message):
-            return "SchedulerTransitioningException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        case .versionMismatchException(let message):
-            return "VersionMismatchException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/GroundStation/GroundStation_Error.swift
+++ b/Sources/Soto/Services/GroundStation/GroundStation_Error.swift
@@ -17,45 +17,46 @@
 import SotoCore
 
 /// Error enum for GroundStation
-public enum GroundStationErrorType: AWSErrorType {
-    case dependencyException(message: String?)
-    case invalidParameterException(message: String?)
-    case resourceLimitExceededException(message: String?)
-    case resourceNotFoundException(message: String?)
-}
+public struct GroundStationErrorType: AWSErrorType {
+    enum Code: String {
+        case dependencyException = "DependencyException"
+        case invalidParameterException = "InvalidParameterException"
+        case resourceLimitExceededException = "ResourceLimitExceededException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+    }
 
-extension GroundStationErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "DependencyException":
-            self = .dependencyException(message: message)
-        case "InvalidParameterException":
-            self = .invalidParameterException(message: message)
-        case "ResourceLimitExceededException":
-            self = .resourceLimitExceededException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var dependencyException: Self { .init(.dependencyException) }
+    public static var invalidParameterException: Self { .init(.invalidParameterException) }
+    public static var resourceLimitExceededException: Self { .init(.resourceLimitExceededException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+}
+
+extension GroundStationErrorType: Equatable {
+    public static func == (lhs: GroundStationErrorType, rhs: GroundStationErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension GroundStationErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .dependencyException(let message):
-            return "DependencyException: \(message ?? "")"
-        case .invalidParameterException(let message):
-            return "InvalidParameterException: \(message ?? "")"
-        case .resourceLimitExceededException(let message):
-            return "ResourceLimitExceededException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/GuardDuty/GuardDuty_Error.swift
+++ b/Sources/Soto/Services/GuardDuty/GuardDuty_Error.swift
@@ -17,35 +17,42 @@
 import SotoCore
 
 /// Error enum for GuardDuty
-public enum GuardDutyErrorType: AWSErrorType {
-    case badRequestException(message: String?)
-    case internalServerErrorException(message: String?)
-}
+public struct GuardDutyErrorType: AWSErrorType {
+    enum Code: String {
+        case badRequestException = "BadRequestException"
+        case internalServerErrorException = "InternalServerErrorException"
+    }
 
-extension GuardDutyErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        case "InternalServerErrorException":
-            self = .internalServerErrorException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var badRequestException: Self { .init(.badRequestException) }
+    public static var internalServerErrorException: Self { .init(.internalServerErrorException) }
+}
+
+extension GuardDutyErrorType: Equatable {
+    public static func == (lhs: GuardDutyErrorType, rhs: GuardDutyErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension GuardDutyErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        case .internalServerErrorException(let message):
-            return "InternalServerErrorException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Honeycode/Honeycode_Error.swift
+++ b/Sources/Soto/Services/Honeycode/Honeycode_Error.swift
@@ -17,70 +17,56 @@
 import SotoCore
 
 /// Error enum for Honeycode
-public enum HoneycodeErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case automationExecutionException(message: String?)
-    case automationExecutionTimeoutException(message: String?)
-    case internalServerException(message: String?)
-    case requestTimeoutException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceUnavailableException(message: String?)
-    case throttlingException(message: String?)
-    case validationException(message: String?)
-}
+public struct HoneycodeErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case automationExecutionException = "AutomationExecutionException"
+        case automationExecutionTimeoutException = "AutomationExecutionTimeoutException"
+        case internalServerException = "InternalServerException"
+        case requestTimeoutException = "RequestTimeoutException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+        case throttlingException = "ThrottlingException"
+        case validationException = "ValidationException"
+    }
 
-extension HoneycodeErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "AutomationExecutionException":
-            self = .automationExecutionException(message: message)
-        case "AutomationExecutionTimeoutException":
-            self = .automationExecutionTimeoutException(message: message)
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "RequestTimeoutException":
-            self = .requestTimeoutException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var automationExecutionException: Self { .init(.automationExecutionException) }
+    public static var automationExecutionTimeoutException: Self { .init(.automationExecutionTimeoutException) }
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var requestTimeoutException: Self { .init(.requestTimeoutException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension HoneycodeErrorType: Equatable {
+    public static func == (lhs: HoneycodeErrorType, rhs: HoneycodeErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension HoneycodeErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .automationExecutionException(let message):
-            return "AutomationExecutionException: \(message ?? "")"
-        case .automationExecutionTimeoutException(let message):
-            return "AutomationExecutionTimeoutException: \(message ?? "")"
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .requestTimeoutException(let message):
-            return "RequestTimeoutException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/IAM/IAM_Error.swift
+++ b/Sources/Soto/Services/IAM/IAM_Error.swift
@@ -17,160 +17,92 @@
 import SotoCore
 
 /// Error enum for IAM
-public enum IAMErrorType: AWSErrorType {
-    case concurrentModificationException(message: String?)
-    case credentialReportExpiredException(message: String?)
-    case credentialReportNotPresentException(message: String?)
-    case credentialReportNotReadyException(message: String?)
-    case deleteConflictException(message: String?)
-    case duplicateCertificateException(message: String?)
-    case duplicateSSHPublicKeyException(message: String?)
-    case entityAlreadyExistsException(message: String?)
-    case entityTemporarilyUnmodifiableException(message: String?)
-    case invalidAuthenticationCodeException(message: String?)
-    case invalidCertificateException(message: String?)
-    case invalidInputException(message: String?)
-    case invalidPublicKeyException(message: String?)
-    case invalidUserTypeException(message: String?)
-    case keyPairMismatchException(message: String?)
-    case limitExceededException(message: String?)
-    case malformedCertificateException(message: String?)
-    case malformedPolicyDocumentException(message: String?)
-    case noSuchEntityException(message: String?)
-    case passwordPolicyViolationException(message: String?)
-    case policyEvaluationException(message: String?)
-    case policyNotAttachableException(message: String?)
-    case reportGenerationLimitExceededException(message: String?)
-    case serviceFailureException(message: String?)
-    case serviceNotSupportedException(message: String?)
-    case unmodifiableEntityException(message: String?)
-    case unrecognizedPublicKeyEncodingException(message: String?)
-}
+public struct IAMErrorType: AWSErrorType {
+    enum Code: String {
+        case concurrentModificationException = "ConcurrentModification"
+        case credentialReportExpiredException = "ReportExpired"
+        case credentialReportNotPresentException = "ReportNotPresent"
+        case credentialReportNotReadyException = "ReportInProgress"
+        case deleteConflictException = "DeleteConflict"
+        case duplicateCertificateException = "DuplicateCertificate"
+        case duplicateSSHPublicKeyException = "DuplicateSSHPublicKey"
+        case entityAlreadyExistsException = "EntityAlreadyExists"
+        case entityTemporarilyUnmodifiableException = "EntityTemporarilyUnmodifiable"
+        case invalidAuthenticationCodeException = "InvalidAuthenticationCode"
+        case invalidCertificateException = "InvalidCertificate"
+        case invalidInputException = "InvalidInput"
+        case invalidPublicKeyException = "InvalidPublicKey"
+        case invalidUserTypeException = "InvalidUserType"
+        case keyPairMismatchException = "KeyPairMismatch"
+        case limitExceededException = "LimitExceeded"
+        case malformedCertificateException = "MalformedCertificate"
+        case malformedPolicyDocumentException = "MalformedPolicyDocument"
+        case noSuchEntityException = "NoSuchEntity"
+        case passwordPolicyViolationException = "PasswordPolicyViolation"
+        case policyEvaluationException = "PolicyEvaluation"
+        case policyNotAttachableException = "PolicyNotAttachable"
+        case reportGenerationLimitExceededException = "ReportGenerationLimitExceeded"
+        case serviceFailureException = "ServiceFailure"
+        case serviceNotSupportedException = "NotSupportedService"
+        case unmodifiableEntityException = "UnmodifiableEntity"
+        case unrecognizedPublicKeyEncodingException = "UnrecognizedPublicKeyEncoding"
+    }
 
-extension IAMErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ConcurrentModification":
-            self = .concurrentModificationException(message: message)
-        case "ReportExpired":
-            self = .credentialReportExpiredException(message: message)
-        case "ReportNotPresent":
-            self = .credentialReportNotPresentException(message: message)
-        case "ReportInProgress":
-            self = .credentialReportNotReadyException(message: message)
-        case "DeleteConflict":
-            self = .deleteConflictException(message: message)
-        case "DuplicateCertificate":
-            self = .duplicateCertificateException(message: message)
-        case "DuplicateSSHPublicKey":
-            self = .duplicateSSHPublicKeyException(message: message)
-        case "EntityAlreadyExists":
-            self = .entityAlreadyExistsException(message: message)
-        case "EntityTemporarilyUnmodifiable":
-            self = .entityTemporarilyUnmodifiableException(message: message)
-        case "InvalidAuthenticationCode":
-            self = .invalidAuthenticationCodeException(message: message)
-        case "InvalidCertificate":
-            self = .invalidCertificateException(message: message)
-        case "InvalidInput":
-            self = .invalidInputException(message: message)
-        case "InvalidPublicKey":
-            self = .invalidPublicKeyException(message: message)
-        case "InvalidUserType":
-            self = .invalidUserTypeException(message: message)
-        case "KeyPairMismatch":
-            self = .keyPairMismatchException(message: message)
-        case "LimitExceeded":
-            self = .limitExceededException(message: message)
-        case "MalformedCertificate":
-            self = .malformedCertificateException(message: message)
-        case "MalformedPolicyDocument":
-            self = .malformedPolicyDocumentException(message: message)
-        case "NoSuchEntity":
-            self = .noSuchEntityException(message: message)
-        case "PasswordPolicyViolation":
-            self = .passwordPolicyViolationException(message: message)
-        case "PolicyEvaluation":
-            self = .policyEvaluationException(message: message)
-        case "PolicyNotAttachable":
-            self = .policyNotAttachableException(message: message)
-        case "ReportGenerationLimitExceeded":
-            self = .reportGenerationLimitExceededException(message: message)
-        case "ServiceFailure":
-            self = .serviceFailureException(message: message)
-        case "NotSupportedService":
-            self = .serviceNotSupportedException(message: message)
-        case "UnmodifiableEntity":
-            self = .unmodifiableEntityException(message: message)
-        case "UnrecognizedPublicKeyEncoding":
-            self = .unrecognizedPublicKeyEncodingException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var concurrentModificationException: Self { .init(.concurrentModificationException) }
+    public static var credentialReportExpiredException: Self { .init(.credentialReportExpiredException) }
+    public static var credentialReportNotPresentException: Self { .init(.credentialReportNotPresentException) }
+    public static var credentialReportNotReadyException: Self { .init(.credentialReportNotReadyException) }
+    public static var deleteConflictException: Self { .init(.deleteConflictException) }
+    public static var duplicateCertificateException: Self { .init(.duplicateCertificateException) }
+    public static var duplicateSSHPublicKeyException: Self { .init(.duplicateSSHPublicKeyException) }
+    public static var entityAlreadyExistsException: Self { .init(.entityAlreadyExistsException) }
+    public static var entityTemporarilyUnmodifiableException: Self { .init(.entityTemporarilyUnmodifiableException) }
+    public static var invalidAuthenticationCodeException: Self { .init(.invalidAuthenticationCodeException) }
+    public static var invalidCertificateException: Self { .init(.invalidCertificateException) }
+    public static var invalidInputException: Self { .init(.invalidInputException) }
+    public static var invalidPublicKeyException: Self { .init(.invalidPublicKeyException) }
+    public static var invalidUserTypeException: Self { .init(.invalidUserTypeException) }
+    public static var keyPairMismatchException: Self { .init(.keyPairMismatchException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var malformedCertificateException: Self { .init(.malformedCertificateException) }
+    public static var malformedPolicyDocumentException: Self { .init(.malformedPolicyDocumentException) }
+    public static var noSuchEntityException: Self { .init(.noSuchEntityException) }
+    public static var passwordPolicyViolationException: Self { .init(.passwordPolicyViolationException) }
+    public static var policyEvaluationException: Self { .init(.policyEvaluationException) }
+    public static var policyNotAttachableException: Self { .init(.policyNotAttachableException) }
+    public static var reportGenerationLimitExceededException: Self { .init(.reportGenerationLimitExceededException) }
+    public static var serviceFailureException: Self { .init(.serviceFailureException) }
+    public static var serviceNotSupportedException: Self { .init(.serviceNotSupportedException) }
+    public static var unmodifiableEntityException: Self { .init(.unmodifiableEntityException) }
+    public static var unrecognizedPublicKeyEncodingException: Self { .init(.unrecognizedPublicKeyEncodingException) }
+}
+
+extension IAMErrorType: Equatable {
+    public static func == (lhs: IAMErrorType, rhs: IAMErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension IAMErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .concurrentModificationException(let message):
-            return "ConcurrentModification: \(message ?? "")"
-        case .credentialReportExpiredException(let message):
-            return "ReportExpired: \(message ?? "")"
-        case .credentialReportNotPresentException(let message):
-            return "ReportNotPresent: \(message ?? "")"
-        case .credentialReportNotReadyException(let message):
-            return "ReportInProgress: \(message ?? "")"
-        case .deleteConflictException(let message):
-            return "DeleteConflict: \(message ?? "")"
-        case .duplicateCertificateException(let message):
-            return "DuplicateCertificate: \(message ?? "")"
-        case .duplicateSSHPublicKeyException(let message):
-            return "DuplicateSSHPublicKey: \(message ?? "")"
-        case .entityAlreadyExistsException(let message):
-            return "EntityAlreadyExists: \(message ?? "")"
-        case .entityTemporarilyUnmodifiableException(let message):
-            return "EntityTemporarilyUnmodifiable: \(message ?? "")"
-        case .invalidAuthenticationCodeException(let message):
-            return "InvalidAuthenticationCode: \(message ?? "")"
-        case .invalidCertificateException(let message):
-            return "InvalidCertificate: \(message ?? "")"
-        case .invalidInputException(let message):
-            return "InvalidInput: \(message ?? "")"
-        case .invalidPublicKeyException(let message):
-            return "InvalidPublicKey: \(message ?? "")"
-        case .invalidUserTypeException(let message):
-            return "InvalidUserType: \(message ?? "")"
-        case .keyPairMismatchException(let message):
-            return "KeyPairMismatch: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceeded: \(message ?? "")"
-        case .malformedCertificateException(let message):
-            return "MalformedCertificate: \(message ?? "")"
-        case .malformedPolicyDocumentException(let message):
-            return "MalformedPolicyDocument: \(message ?? "")"
-        case .noSuchEntityException(let message):
-            return "NoSuchEntity: \(message ?? "")"
-        case .passwordPolicyViolationException(let message):
-            return "PasswordPolicyViolation: \(message ?? "")"
-        case .policyEvaluationException(let message):
-            return "PolicyEvaluation: \(message ?? "")"
-        case .policyNotAttachableException(let message):
-            return "PolicyNotAttachable: \(message ?? "")"
-        case .reportGenerationLimitExceededException(let message):
-            return "ReportGenerationLimitExceeded: \(message ?? "")"
-        case .serviceFailureException(let message):
-            return "ServiceFailure: \(message ?? "")"
-        case .serviceNotSupportedException(let message):
-            return "NotSupportedService: \(message ?? "")"
-        case .unmodifiableEntityException(let message):
-            return "UnmodifiableEntity: \(message ?? "")"
-        case .unrecognizedPublicKeyEncodingException(let message):
-            return "UnrecognizedPublicKeyEncoding: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/IVS/IVS_Error.swift
+++ b/Sources/Soto/Services/IVS/IVS_Error.swift
@@ -17,75 +17,58 @@
 import SotoCore
 
 /// Error enum for IVS
-public enum IVSErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case channelNotBroadcasting(message: String?)
-    case conflictException(message: String?)
-    case internalServerException(message: String?)
-    case pendingVerification(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceQuotaExceededException(message: String?)
-    case streamUnavailable(message: String?)
-    case throttlingException(message: String?)
-    case validationException(message: String?)
-}
+public struct IVSErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case channelNotBroadcasting = "ChannelNotBroadcasting"
+        case conflictException = "ConflictException"
+        case internalServerException = "InternalServerException"
+        case pendingVerification = "PendingVerification"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceQuotaExceededException = "ServiceQuotaExceededException"
+        case streamUnavailable = "StreamUnavailable"
+        case throttlingException = "ThrottlingException"
+        case validationException = "ValidationException"
+    }
 
-extension IVSErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "ChannelNotBroadcasting":
-            self = .channelNotBroadcasting(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "PendingVerification":
-            self = .pendingVerification(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceQuotaExceededException":
-            self = .serviceQuotaExceededException(message: message)
-        case "StreamUnavailable":
-            self = .streamUnavailable(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var channelNotBroadcasting: Self { .init(.channelNotBroadcasting) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var pendingVerification: Self { .init(.pendingVerification) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceQuotaExceededException: Self { .init(.serviceQuotaExceededException) }
+    public static var streamUnavailable: Self { .init(.streamUnavailable) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension IVSErrorType: Equatable {
+    public static func == (lhs: IVSErrorType, rhs: IVSErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension IVSErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .channelNotBroadcasting(let message):
-            return "ChannelNotBroadcasting: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .pendingVerification(let message):
-            return "PendingVerification: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceQuotaExceededException(let message):
-            return "ServiceQuotaExceededException: \(message ?? "")"
-        case .streamUnavailable(let message):
-            return "StreamUnavailable: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/IdentityStore/IdentityStore_Error.swift
+++ b/Sources/Soto/Services/IdentityStore/IdentityStore_Error.swift
@@ -17,50 +17,48 @@
 import SotoCore
 
 /// Error enum for IdentityStore
-public enum IdentityStoreErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case internalServerException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case throttlingException(message: String?)
-    case validationException(message: String?)
-}
+public struct IdentityStoreErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case internalServerException = "InternalServerException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case throttlingException = "ThrottlingException"
+        case validationException = "ValidationException"
+    }
 
-extension IdentityStoreErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension IdentityStoreErrorType: Equatable {
+    public static func == (lhs: IdentityStoreErrorType, rhs: IdentityStoreErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension IdentityStoreErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Imagebuilder/Imagebuilder_Error.swift
+++ b/Sources/Soto/Services/Imagebuilder/Imagebuilder_Error.swift
@@ -17,110 +17,72 @@
 import SotoCore
 
 /// Error enum for Imagebuilder
-public enum ImagebuilderErrorType: AWSErrorType {
-    case callRateLimitExceededException(message: String?)
-    case clientException(message: String?)
-    case forbiddenException(message: String?)
-    case idempotentParameterMismatchException(message: String?)
-    case invalidPaginationTokenException(message: String?)
-    case invalidParameterCombinationException(message: String?)
-    case invalidParameterException(message: String?)
-    case invalidParameterValueException(message: String?)
-    case invalidRequestException(message: String?)
-    case invalidVersionNumberException(message: String?)
-    case resourceAlreadyExistsException(message: String?)
-    case resourceDependencyException(message: String?)
-    case resourceInUseException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceException(message: String?)
-    case serviceQuotaExceededException(message: String?)
-    case serviceUnavailableException(message: String?)
-}
+public struct ImagebuilderErrorType: AWSErrorType {
+    enum Code: String {
+        case callRateLimitExceededException = "CallRateLimitExceededException"
+        case clientException = "ClientException"
+        case forbiddenException = "ForbiddenException"
+        case idempotentParameterMismatchException = "IdempotentParameterMismatchException"
+        case invalidPaginationTokenException = "InvalidPaginationTokenException"
+        case invalidParameterCombinationException = "InvalidParameterCombinationException"
+        case invalidParameterException = "InvalidParameterException"
+        case invalidParameterValueException = "InvalidParameterValueException"
+        case invalidRequestException = "InvalidRequestException"
+        case invalidVersionNumberException = "InvalidVersionNumberException"
+        case resourceAlreadyExistsException = "ResourceAlreadyExistsException"
+        case resourceDependencyException = "ResourceDependencyException"
+        case resourceInUseException = "ResourceInUseException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceException = "ServiceException"
+        case serviceQuotaExceededException = "ServiceQuotaExceededException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+    }
 
-extension ImagebuilderErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "CallRateLimitExceededException":
-            self = .callRateLimitExceededException(message: message)
-        case "ClientException":
-            self = .clientException(message: message)
-        case "ForbiddenException":
-            self = .forbiddenException(message: message)
-        case "IdempotentParameterMismatchException":
-            self = .idempotentParameterMismatchException(message: message)
-        case "InvalidPaginationTokenException":
-            self = .invalidPaginationTokenException(message: message)
-        case "InvalidParameterCombinationException":
-            self = .invalidParameterCombinationException(message: message)
-        case "InvalidParameterException":
-            self = .invalidParameterException(message: message)
-        case "InvalidParameterValueException":
-            self = .invalidParameterValueException(message: message)
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        case "InvalidVersionNumberException":
-            self = .invalidVersionNumberException(message: message)
-        case "ResourceAlreadyExistsException":
-            self = .resourceAlreadyExistsException(message: message)
-        case "ResourceDependencyException":
-            self = .resourceDependencyException(message: message)
-        case "ResourceInUseException":
-            self = .resourceInUseException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceException":
-            self = .serviceException(message: message)
-        case "ServiceQuotaExceededException":
-            self = .serviceQuotaExceededException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var callRateLimitExceededException: Self { .init(.callRateLimitExceededException) }
+    public static var clientException: Self { .init(.clientException) }
+    public static var forbiddenException: Self { .init(.forbiddenException) }
+    public static var idempotentParameterMismatchException: Self { .init(.idempotentParameterMismatchException) }
+    public static var invalidPaginationTokenException: Self { .init(.invalidPaginationTokenException) }
+    public static var invalidParameterCombinationException: Self { .init(.invalidParameterCombinationException) }
+    public static var invalidParameterException: Self { .init(.invalidParameterException) }
+    public static var invalidParameterValueException: Self { .init(.invalidParameterValueException) }
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+    public static var invalidVersionNumberException: Self { .init(.invalidVersionNumberException) }
+    public static var resourceAlreadyExistsException: Self { .init(.resourceAlreadyExistsException) }
+    public static var resourceDependencyException: Self { .init(.resourceDependencyException) }
+    public static var resourceInUseException: Self { .init(.resourceInUseException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceException: Self { .init(.serviceException) }
+    public static var serviceQuotaExceededException: Self { .init(.serviceQuotaExceededException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+}
+
+extension ImagebuilderErrorType: Equatable {
+    public static func == (lhs: ImagebuilderErrorType, rhs: ImagebuilderErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ImagebuilderErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .callRateLimitExceededException(let message):
-            return "CallRateLimitExceededException: \(message ?? "")"
-        case .clientException(let message):
-            return "ClientException: \(message ?? "")"
-        case .forbiddenException(let message):
-            return "ForbiddenException: \(message ?? "")"
-        case .idempotentParameterMismatchException(let message):
-            return "IdempotentParameterMismatchException: \(message ?? "")"
-        case .invalidPaginationTokenException(let message):
-            return "InvalidPaginationTokenException: \(message ?? "")"
-        case .invalidParameterCombinationException(let message):
-            return "InvalidParameterCombinationException: \(message ?? "")"
-        case .invalidParameterException(let message):
-            return "InvalidParameterException: \(message ?? "")"
-        case .invalidParameterValueException(let message):
-            return "InvalidParameterValueException: \(message ?? "")"
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        case .invalidVersionNumberException(let message):
-            return "InvalidVersionNumberException: \(message ?? "")"
-        case .resourceAlreadyExistsException(let message):
-            return "ResourceAlreadyExistsException: \(message ?? "")"
-        case .resourceDependencyException(let message):
-            return "ResourceDependencyException: \(message ?? "")"
-        case .resourceInUseException(let message):
-            return "ResourceInUseException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceException(let message):
-            return "ServiceException: \(message ?? "")"
-        case .serviceQuotaExceededException(let message):
-            return "ServiceQuotaExceededException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/ImportExport/ImportExport_Error.swift
+++ b/Sources/Soto/Services/ImportExport/ImportExport_Error.swift
@@ -17,125 +17,78 @@
 import SotoCore
 
 /// Error enum for ImportExport
-public enum ImportExportErrorType: AWSErrorType {
-    case bucketPermissionException(message: String?)
-    case canceledJobIdException(message: String?)
-    case createJobQuotaExceededException(message: String?)
-    case expiredJobIdException(message: String?)
-    case invalidAccessKeyIdException(message: String?)
-    case invalidAddressException(message: String?)
-    case invalidCustomsException(message: String?)
-    case invalidFileSystemException(message: String?)
-    case invalidJobIdException(message: String?)
-    case invalidManifestFieldException(message: String?)
-    case invalidParameterException(message: String?)
-    case invalidVersionException(message: String?)
-    case malformedManifestException(message: String?)
-    case missingCustomsException(message: String?)
-    case missingManifestFieldException(message: String?)
-    case missingParameterException(message: String?)
-    case multipleRegionsException(message: String?)
-    case noSuchBucketException(message: String?)
-    case unableToCancelJobIdException(message: String?)
-    case unableToUpdateJobIdException(message: String?)
-}
+public struct ImportExportErrorType: AWSErrorType {
+    enum Code: String {
+        case bucketPermissionException = "BucketPermissionException"
+        case canceledJobIdException = "CanceledJobIdException"
+        case createJobQuotaExceededException = "CreateJobQuotaExceededException"
+        case expiredJobIdException = "ExpiredJobIdException"
+        case invalidAccessKeyIdException = "InvalidAccessKeyIdException"
+        case invalidAddressException = "InvalidAddressException"
+        case invalidCustomsException = "InvalidCustomsException"
+        case invalidFileSystemException = "InvalidFileSystemException"
+        case invalidJobIdException = "InvalidJobIdException"
+        case invalidManifestFieldException = "InvalidManifestFieldException"
+        case invalidParameterException = "InvalidParameterException"
+        case invalidVersionException = "InvalidVersionException"
+        case malformedManifestException = "MalformedManifestException"
+        case missingCustomsException = "MissingCustomsException"
+        case missingManifestFieldException = "MissingManifestFieldException"
+        case missingParameterException = "MissingParameterException"
+        case multipleRegionsException = "MultipleRegionsException"
+        case noSuchBucketException = "NoSuchBucketException"
+        case unableToCancelJobIdException = "UnableToCancelJobIdException"
+        case unableToUpdateJobIdException = "UnableToUpdateJobIdException"
+    }
 
-extension ImportExportErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "BucketPermissionException":
-            self = .bucketPermissionException(message: message)
-        case "CanceledJobIdException":
-            self = .canceledJobIdException(message: message)
-        case "CreateJobQuotaExceededException":
-            self = .createJobQuotaExceededException(message: message)
-        case "ExpiredJobIdException":
-            self = .expiredJobIdException(message: message)
-        case "InvalidAccessKeyIdException":
-            self = .invalidAccessKeyIdException(message: message)
-        case "InvalidAddressException":
-            self = .invalidAddressException(message: message)
-        case "InvalidCustomsException":
-            self = .invalidCustomsException(message: message)
-        case "InvalidFileSystemException":
-            self = .invalidFileSystemException(message: message)
-        case "InvalidJobIdException":
-            self = .invalidJobIdException(message: message)
-        case "InvalidManifestFieldException":
-            self = .invalidManifestFieldException(message: message)
-        case "InvalidParameterException":
-            self = .invalidParameterException(message: message)
-        case "InvalidVersionException":
-            self = .invalidVersionException(message: message)
-        case "MalformedManifestException":
-            self = .malformedManifestException(message: message)
-        case "MissingCustomsException":
-            self = .missingCustomsException(message: message)
-        case "MissingManifestFieldException":
-            self = .missingManifestFieldException(message: message)
-        case "MissingParameterException":
-            self = .missingParameterException(message: message)
-        case "MultipleRegionsException":
-            self = .multipleRegionsException(message: message)
-        case "NoSuchBucketException":
-            self = .noSuchBucketException(message: message)
-        case "UnableToCancelJobIdException":
-            self = .unableToCancelJobIdException(message: message)
-        case "UnableToUpdateJobIdException":
-            self = .unableToUpdateJobIdException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var bucketPermissionException: Self { .init(.bucketPermissionException) }
+    public static var canceledJobIdException: Self { .init(.canceledJobIdException) }
+    public static var createJobQuotaExceededException: Self { .init(.createJobQuotaExceededException) }
+    public static var expiredJobIdException: Self { .init(.expiredJobIdException) }
+    public static var invalidAccessKeyIdException: Self { .init(.invalidAccessKeyIdException) }
+    public static var invalidAddressException: Self { .init(.invalidAddressException) }
+    public static var invalidCustomsException: Self { .init(.invalidCustomsException) }
+    public static var invalidFileSystemException: Self { .init(.invalidFileSystemException) }
+    public static var invalidJobIdException: Self { .init(.invalidJobIdException) }
+    public static var invalidManifestFieldException: Self { .init(.invalidManifestFieldException) }
+    public static var invalidParameterException: Self { .init(.invalidParameterException) }
+    public static var invalidVersionException: Self { .init(.invalidVersionException) }
+    public static var malformedManifestException: Self { .init(.malformedManifestException) }
+    public static var missingCustomsException: Self { .init(.missingCustomsException) }
+    public static var missingManifestFieldException: Self { .init(.missingManifestFieldException) }
+    public static var missingParameterException: Self { .init(.missingParameterException) }
+    public static var multipleRegionsException: Self { .init(.multipleRegionsException) }
+    public static var noSuchBucketException: Self { .init(.noSuchBucketException) }
+    public static var unableToCancelJobIdException: Self { .init(.unableToCancelJobIdException) }
+    public static var unableToUpdateJobIdException: Self { .init(.unableToUpdateJobIdException) }
+}
+
+extension ImportExportErrorType: Equatable {
+    public static func == (lhs: ImportExportErrorType, rhs: ImportExportErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ImportExportErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .bucketPermissionException(let message):
-            return "BucketPermissionException: \(message ?? "")"
-        case .canceledJobIdException(let message):
-            return "CanceledJobIdException: \(message ?? "")"
-        case .createJobQuotaExceededException(let message):
-            return "CreateJobQuotaExceededException: \(message ?? "")"
-        case .expiredJobIdException(let message):
-            return "ExpiredJobIdException: \(message ?? "")"
-        case .invalidAccessKeyIdException(let message):
-            return "InvalidAccessKeyIdException: \(message ?? "")"
-        case .invalidAddressException(let message):
-            return "InvalidAddressException: \(message ?? "")"
-        case .invalidCustomsException(let message):
-            return "InvalidCustomsException: \(message ?? "")"
-        case .invalidFileSystemException(let message):
-            return "InvalidFileSystemException: \(message ?? "")"
-        case .invalidJobIdException(let message):
-            return "InvalidJobIdException: \(message ?? "")"
-        case .invalidManifestFieldException(let message):
-            return "InvalidManifestFieldException: \(message ?? "")"
-        case .invalidParameterException(let message):
-            return "InvalidParameterException: \(message ?? "")"
-        case .invalidVersionException(let message):
-            return "InvalidVersionException: \(message ?? "")"
-        case .malformedManifestException(let message):
-            return "MalformedManifestException: \(message ?? "")"
-        case .missingCustomsException(let message):
-            return "MissingCustomsException: \(message ?? "")"
-        case .missingManifestFieldException(let message):
-            return "MissingManifestFieldException: \(message ?? "")"
-        case .missingParameterException(let message):
-            return "MissingParameterException: \(message ?? "")"
-        case .multipleRegionsException(let message):
-            return "MultipleRegionsException: \(message ?? "")"
-        case .noSuchBucketException(let message):
-            return "NoSuchBucketException: \(message ?? "")"
-        case .unableToCancelJobIdException(let message):
-            return "UnableToCancelJobIdException: \(message ?? "")"
-        case .unableToUpdateJobIdException(let message):
-            return "UnableToUpdateJobIdException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Inspector/Inspector_Error.swift
+++ b/Sources/Soto/Services/Inspector/Inspector_Error.swift
@@ -17,80 +17,60 @@
 import SotoCore
 
 /// Error enum for Inspector
-public enum InspectorErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case agentsAlreadyRunningAssessmentException(message: String?)
-    case assessmentRunInProgressException(message: String?)
-    case internalException(message: String?)
-    case invalidCrossAccountRoleException(message: String?)
-    case invalidInputException(message: String?)
-    case limitExceededException(message: String?)
-    case noSuchEntityException(message: String?)
-    case previewGenerationInProgressException(message: String?)
-    case serviceTemporarilyUnavailableException(message: String?)
-    case unsupportedFeatureException(message: String?)
-}
+public struct InspectorErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case agentsAlreadyRunningAssessmentException = "AgentsAlreadyRunningAssessmentException"
+        case assessmentRunInProgressException = "AssessmentRunInProgressException"
+        case internalException = "InternalException"
+        case invalidCrossAccountRoleException = "InvalidCrossAccountRoleException"
+        case invalidInputException = "InvalidInputException"
+        case limitExceededException = "LimitExceededException"
+        case noSuchEntityException = "NoSuchEntityException"
+        case previewGenerationInProgressException = "PreviewGenerationInProgressException"
+        case serviceTemporarilyUnavailableException = "ServiceTemporarilyUnavailableException"
+        case unsupportedFeatureException = "UnsupportedFeatureException"
+    }
 
-extension InspectorErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "AgentsAlreadyRunningAssessmentException":
-            self = .agentsAlreadyRunningAssessmentException(message: message)
-        case "AssessmentRunInProgressException":
-            self = .assessmentRunInProgressException(message: message)
-        case "InternalException":
-            self = .internalException(message: message)
-        case "InvalidCrossAccountRoleException":
-            self = .invalidCrossAccountRoleException(message: message)
-        case "InvalidInputException":
-            self = .invalidInputException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "NoSuchEntityException":
-            self = .noSuchEntityException(message: message)
-        case "PreviewGenerationInProgressException":
-            self = .previewGenerationInProgressException(message: message)
-        case "ServiceTemporarilyUnavailableException":
-            self = .serviceTemporarilyUnavailableException(message: message)
-        case "UnsupportedFeatureException":
-            self = .unsupportedFeatureException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var agentsAlreadyRunningAssessmentException: Self { .init(.agentsAlreadyRunningAssessmentException) }
+    public static var assessmentRunInProgressException: Self { .init(.assessmentRunInProgressException) }
+    public static var internalException: Self { .init(.internalException) }
+    public static var invalidCrossAccountRoleException: Self { .init(.invalidCrossAccountRoleException) }
+    public static var invalidInputException: Self { .init(.invalidInputException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var noSuchEntityException: Self { .init(.noSuchEntityException) }
+    public static var previewGenerationInProgressException: Self { .init(.previewGenerationInProgressException) }
+    public static var serviceTemporarilyUnavailableException: Self { .init(.serviceTemporarilyUnavailableException) }
+    public static var unsupportedFeatureException: Self { .init(.unsupportedFeatureException) }
+}
+
+extension InspectorErrorType: Equatable {
+    public static func == (lhs: InspectorErrorType, rhs: InspectorErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension InspectorErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .agentsAlreadyRunningAssessmentException(let message):
-            return "AgentsAlreadyRunningAssessmentException: \(message ?? "")"
-        case .assessmentRunInProgressException(let message):
-            return "AssessmentRunInProgressException: \(message ?? "")"
-        case .internalException(let message):
-            return "InternalException: \(message ?? "")"
-        case .invalidCrossAccountRoleException(let message):
-            return "InvalidCrossAccountRoleException: \(message ?? "")"
-        case .invalidInputException(let message):
-            return "InvalidInputException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .noSuchEntityException(let message):
-            return "NoSuchEntityException: \(message ?? "")"
-        case .previewGenerationInProgressException(let message):
-            return "PreviewGenerationInProgressException: \(message ?? "")"
-        case .serviceTemporarilyUnavailableException(let message):
-            return "ServiceTemporarilyUnavailableException: \(message ?? "")"
-        case .unsupportedFeatureException(let message):
-            return "UnsupportedFeatureException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/IoT/IoT_Error.swift
+++ b/Sources/Soto/Services/IoT/IoT_Error.swift
@@ -17,170 +17,96 @@
 import SotoCore
 
 /// Error enum for IoT
-public enum IoTErrorType: AWSErrorType {
-    case certificateConflictException(message: String?)
-    case certificateStateException(message: String?)
-    case certificateValidationException(message: String?)
-    case conflictingResourceUpdateException(message: String?)
-    case deleteConflictException(message: String?)
-    case indexNotReadyException(message: String?)
-    case internalException(message: String?)
-    case internalFailureException(message: String?)
-    case invalidAggregationException(message: String?)
-    case invalidQueryException(message: String?)
-    case invalidRequestException(message: String?)
-    case invalidResponseException(message: String?)
-    case invalidStateTransitionException(message: String?)
-    case limitExceededException(message: String?)
-    case malformedPolicyException(message: String?)
-    case notConfiguredException(message: String?)
-    case registrationCodeValidationException(message: String?)
-    case resourceAlreadyExistsException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case resourceRegistrationFailureException(message: String?)
-    case serviceUnavailableException(message: String?)
-    case sqlParseException(message: String?)
-    case taskAlreadyExistsException(message: String?)
-    case throttlingException(message: String?)
-    case transferAlreadyCompletedException(message: String?)
-    case transferConflictException(message: String?)
-    case unauthorizedException(message: String?)
-    case versionConflictException(message: String?)
-    case versionsLimitExceededException(message: String?)
-}
+public struct IoTErrorType: AWSErrorType {
+    enum Code: String {
+        case certificateConflictException = "CertificateConflictException"
+        case certificateStateException = "CertificateStateException"
+        case certificateValidationException = "CertificateValidationException"
+        case conflictingResourceUpdateException = "ConflictingResourceUpdateException"
+        case deleteConflictException = "DeleteConflictException"
+        case indexNotReadyException = "IndexNotReadyException"
+        case internalException = "InternalException"
+        case internalFailureException = "InternalFailureException"
+        case invalidAggregationException = "InvalidAggregationException"
+        case invalidQueryException = "InvalidQueryException"
+        case invalidRequestException = "InvalidRequestException"
+        case invalidResponseException = "InvalidResponseException"
+        case invalidStateTransitionException = "InvalidStateTransitionException"
+        case limitExceededException = "LimitExceededException"
+        case malformedPolicyException = "MalformedPolicyException"
+        case notConfiguredException = "NotConfiguredException"
+        case registrationCodeValidationException = "RegistrationCodeValidationException"
+        case resourceAlreadyExistsException = "ResourceAlreadyExistsException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case resourceRegistrationFailureException = "ResourceRegistrationFailureException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+        case sqlParseException = "SqlParseException"
+        case taskAlreadyExistsException = "TaskAlreadyExistsException"
+        case throttlingException = "ThrottlingException"
+        case transferAlreadyCompletedException = "TransferAlreadyCompletedException"
+        case transferConflictException = "TransferConflictException"
+        case unauthorizedException = "UnauthorizedException"
+        case versionConflictException = "VersionConflictException"
+        case versionsLimitExceededException = "VersionsLimitExceededException"
+    }
 
-extension IoTErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "CertificateConflictException":
-            self = .certificateConflictException(message: message)
-        case "CertificateStateException":
-            self = .certificateStateException(message: message)
-        case "CertificateValidationException":
-            self = .certificateValidationException(message: message)
-        case "ConflictingResourceUpdateException":
-            self = .conflictingResourceUpdateException(message: message)
-        case "DeleteConflictException":
-            self = .deleteConflictException(message: message)
-        case "IndexNotReadyException":
-            self = .indexNotReadyException(message: message)
-        case "InternalException":
-            self = .internalException(message: message)
-        case "InternalFailureException":
-            self = .internalFailureException(message: message)
-        case "InvalidAggregationException":
-            self = .invalidAggregationException(message: message)
-        case "InvalidQueryException":
-            self = .invalidQueryException(message: message)
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        case "InvalidResponseException":
-            self = .invalidResponseException(message: message)
-        case "InvalidStateTransitionException":
-            self = .invalidStateTransitionException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "MalformedPolicyException":
-            self = .malformedPolicyException(message: message)
-        case "NotConfiguredException":
-            self = .notConfiguredException(message: message)
-        case "RegistrationCodeValidationException":
-            self = .registrationCodeValidationException(message: message)
-        case "ResourceAlreadyExistsException":
-            self = .resourceAlreadyExistsException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ResourceRegistrationFailureException":
-            self = .resourceRegistrationFailureException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        case "SqlParseException":
-            self = .sqlParseException(message: message)
-        case "TaskAlreadyExistsException":
-            self = .taskAlreadyExistsException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        case "TransferAlreadyCompletedException":
-            self = .transferAlreadyCompletedException(message: message)
-        case "TransferConflictException":
-            self = .transferConflictException(message: message)
-        case "UnauthorizedException":
-            self = .unauthorizedException(message: message)
-        case "VersionConflictException":
-            self = .versionConflictException(message: message)
-        case "VersionsLimitExceededException":
-            self = .versionsLimitExceededException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var certificateConflictException: Self { .init(.certificateConflictException) }
+    public static var certificateStateException: Self { .init(.certificateStateException) }
+    public static var certificateValidationException: Self { .init(.certificateValidationException) }
+    public static var conflictingResourceUpdateException: Self { .init(.conflictingResourceUpdateException) }
+    public static var deleteConflictException: Self { .init(.deleteConflictException) }
+    public static var indexNotReadyException: Self { .init(.indexNotReadyException) }
+    public static var internalException: Self { .init(.internalException) }
+    public static var internalFailureException: Self { .init(.internalFailureException) }
+    public static var invalidAggregationException: Self { .init(.invalidAggregationException) }
+    public static var invalidQueryException: Self { .init(.invalidQueryException) }
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+    public static var invalidResponseException: Self { .init(.invalidResponseException) }
+    public static var invalidStateTransitionException: Self { .init(.invalidStateTransitionException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var malformedPolicyException: Self { .init(.malformedPolicyException) }
+    public static var notConfiguredException: Self { .init(.notConfiguredException) }
+    public static var registrationCodeValidationException: Self { .init(.registrationCodeValidationException) }
+    public static var resourceAlreadyExistsException: Self { .init(.resourceAlreadyExistsException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var resourceRegistrationFailureException: Self { .init(.resourceRegistrationFailureException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+    public static var sqlParseException: Self { .init(.sqlParseException) }
+    public static var taskAlreadyExistsException: Self { .init(.taskAlreadyExistsException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+    public static var transferAlreadyCompletedException: Self { .init(.transferAlreadyCompletedException) }
+    public static var transferConflictException: Self { .init(.transferConflictException) }
+    public static var unauthorizedException: Self { .init(.unauthorizedException) }
+    public static var versionConflictException: Self { .init(.versionConflictException) }
+    public static var versionsLimitExceededException: Self { .init(.versionsLimitExceededException) }
+}
+
+extension IoTErrorType: Equatable {
+    public static func == (lhs: IoTErrorType, rhs: IoTErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension IoTErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .certificateConflictException(let message):
-            return "CertificateConflictException: \(message ?? "")"
-        case .certificateStateException(let message):
-            return "CertificateStateException: \(message ?? "")"
-        case .certificateValidationException(let message):
-            return "CertificateValidationException: \(message ?? "")"
-        case .conflictingResourceUpdateException(let message):
-            return "ConflictingResourceUpdateException: \(message ?? "")"
-        case .deleteConflictException(let message):
-            return "DeleteConflictException: \(message ?? "")"
-        case .indexNotReadyException(let message):
-            return "IndexNotReadyException: \(message ?? "")"
-        case .internalException(let message):
-            return "InternalException: \(message ?? "")"
-        case .internalFailureException(let message):
-            return "InternalFailureException: \(message ?? "")"
-        case .invalidAggregationException(let message):
-            return "InvalidAggregationException: \(message ?? "")"
-        case .invalidQueryException(let message):
-            return "InvalidQueryException: \(message ?? "")"
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        case .invalidResponseException(let message):
-            return "InvalidResponseException: \(message ?? "")"
-        case .invalidStateTransitionException(let message):
-            return "InvalidStateTransitionException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .malformedPolicyException(let message):
-            return "MalformedPolicyException: \(message ?? "")"
-        case .notConfiguredException(let message):
-            return "NotConfiguredException: \(message ?? "")"
-        case .registrationCodeValidationException(let message):
-            return "RegistrationCodeValidationException: \(message ?? "")"
-        case .resourceAlreadyExistsException(let message):
-            return "ResourceAlreadyExistsException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .resourceRegistrationFailureException(let message):
-            return "ResourceRegistrationFailureException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        case .sqlParseException(let message):
-            return "SqlParseException: \(message ?? "")"
-        case .taskAlreadyExistsException(let message):
-            return "TaskAlreadyExistsException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        case .transferAlreadyCompletedException(let message):
-            return "TransferAlreadyCompletedException: \(message ?? "")"
-        case .transferConflictException(let message):
-            return "TransferConflictException: \(message ?? "")"
-        case .unauthorizedException(let message):
-            return "UnauthorizedException: \(message ?? "")"
-        case .versionConflictException(let message):
-            return "VersionConflictException: \(message ?? "")"
-        case .versionsLimitExceededException(let message):
-            return "VersionsLimitExceededException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/IoT1ClickDevicesService/IoT1ClickDevicesService_Error.swift
+++ b/Sources/Soto/Services/IoT1ClickDevicesService/IoT1ClickDevicesService_Error.swift
@@ -17,60 +17,52 @@
 import SotoCore
 
 /// Error enum for IoT1ClickDevicesService
-public enum IoT1ClickDevicesServiceErrorType: AWSErrorType {
-    case forbiddenException(message: String?)
-    case internalFailureException(message: String?)
-    case invalidRequestException(message: String?)
-    case preconditionFailedException(message: String?)
-    case rangeNotSatisfiableException(message: String?)
-    case resourceConflictException(message: String?)
-    case resourceNotFoundException(message: String?)
-}
+public struct IoT1ClickDevicesServiceErrorType: AWSErrorType {
+    enum Code: String {
+        case forbiddenException = "ForbiddenException"
+        case internalFailureException = "InternalFailureException"
+        case invalidRequestException = "InvalidRequestException"
+        case preconditionFailedException = "PreconditionFailedException"
+        case rangeNotSatisfiableException = "RangeNotSatisfiableException"
+        case resourceConflictException = "ResourceConflictException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+    }
 
-extension IoT1ClickDevicesServiceErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ForbiddenException":
-            self = .forbiddenException(message: message)
-        case "InternalFailureException":
-            self = .internalFailureException(message: message)
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        case "PreconditionFailedException":
-            self = .preconditionFailedException(message: message)
-        case "RangeNotSatisfiableException":
-            self = .rangeNotSatisfiableException(message: message)
-        case "ResourceConflictException":
-            self = .resourceConflictException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var forbiddenException: Self { .init(.forbiddenException) }
+    public static var internalFailureException: Self { .init(.internalFailureException) }
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+    public static var preconditionFailedException: Self { .init(.preconditionFailedException) }
+    public static var rangeNotSatisfiableException: Self { .init(.rangeNotSatisfiableException) }
+    public static var resourceConflictException: Self { .init(.resourceConflictException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+}
+
+extension IoT1ClickDevicesServiceErrorType: Equatable {
+    public static func == (lhs: IoT1ClickDevicesServiceErrorType, rhs: IoT1ClickDevicesServiceErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension IoT1ClickDevicesServiceErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .forbiddenException(let message):
-            return "ForbiddenException: \(message ?? "")"
-        case .internalFailureException(let message):
-            return "InternalFailureException: \(message ?? "")"
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        case .preconditionFailedException(let message):
-            return "PreconditionFailedException: \(message ?? "")"
-        case .rangeNotSatisfiableException(let message):
-            return "RangeNotSatisfiableException: \(message ?? "")"
-        case .resourceConflictException(let message):
-            return "ResourceConflictException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/IoT1ClickProjects/IoT1ClickProjects_Error.swift
+++ b/Sources/Soto/Services/IoT1ClickProjects/IoT1ClickProjects_Error.swift
@@ -17,50 +17,48 @@
 import SotoCore
 
 /// Error enum for IoT1ClickProjects
-public enum IoT1ClickProjectsErrorType: AWSErrorType {
-    case internalFailureException(message: String?)
-    case invalidRequestException(message: String?)
-    case resourceConflictException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case tooManyRequestsException(message: String?)
-}
+public struct IoT1ClickProjectsErrorType: AWSErrorType {
+    enum Code: String {
+        case internalFailureException = "InternalFailureException"
+        case invalidRequestException = "InvalidRequestException"
+        case resourceConflictException = "ResourceConflictException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case tooManyRequestsException = "TooManyRequestsException"
+    }
 
-extension IoT1ClickProjectsErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "InternalFailureException":
-            self = .internalFailureException(message: message)
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        case "ResourceConflictException":
-            self = .resourceConflictException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "TooManyRequestsException":
-            self = .tooManyRequestsException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var internalFailureException: Self { .init(.internalFailureException) }
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+    public static var resourceConflictException: Self { .init(.resourceConflictException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var tooManyRequestsException: Self { .init(.tooManyRequestsException) }
+}
+
+extension IoT1ClickProjectsErrorType: Equatable {
+    public static func == (lhs: IoT1ClickProjectsErrorType, rhs: IoT1ClickProjectsErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension IoT1ClickProjectsErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .internalFailureException(let message):
-            return "InternalFailureException: \(message ?? "")"
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        case .resourceConflictException(let message):
-            return "ResourceConflictException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .tooManyRequestsException(let message):
-            return "TooManyRequestsException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/IoTAnalytics/IoTAnalytics_Error.swift
+++ b/Sources/Soto/Services/IoTAnalytics/IoTAnalytics_Error.swift
@@ -17,60 +17,52 @@
 import SotoCore
 
 /// Error enum for IoTAnalytics
-public enum IoTAnalyticsErrorType: AWSErrorType {
-    case internalFailureException(message: String?)
-    case invalidRequestException(message: String?)
-    case limitExceededException(message: String?)
-    case resourceAlreadyExistsException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceUnavailableException(message: String?)
-    case throttlingException(message: String?)
-}
+public struct IoTAnalyticsErrorType: AWSErrorType {
+    enum Code: String {
+        case internalFailureException = "InternalFailureException"
+        case invalidRequestException = "InvalidRequestException"
+        case limitExceededException = "LimitExceededException"
+        case resourceAlreadyExistsException = "ResourceAlreadyExistsException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+        case throttlingException = "ThrottlingException"
+    }
 
-extension IoTAnalyticsErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "InternalFailureException":
-            self = .internalFailureException(message: message)
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ResourceAlreadyExistsException":
-            self = .resourceAlreadyExistsException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var internalFailureException: Self { .init(.internalFailureException) }
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var resourceAlreadyExistsException: Self { .init(.resourceAlreadyExistsException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+}
+
+extension IoTAnalyticsErrorType: Equatable {
+    public static func == (lhs: IoTAnalyticsErrorType, rhs: IoTAnalyticsErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension IoTAnalyticsErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .internalFailureException(let message):
-            return "InternalFailureException: \(message ?? "")"
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .resourceAlreadyExistsException(let message):
-            return "ResourceAlreadyExistsException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/IoTDataPlane/IoTDataPlane_Error.swift
+++ b/Sources/Soto/Services/IoTDataPlane/IoTDataPlane_Error.swift
@@ -17,75 +17,58 @@
 import SotoCore
 
 /// Error enum for IoTDataPlane
-public enum IoTDataPlaneErrorType: AWSErrorType {
-    case conflictException(message: String?)
-    case internalFailureException(message: String?)
-    case invalidRequestException(message: String?)
-    case methodNotAllowedException(message: String?)
-    case requestEntityTooLargeException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceUnavailableException(message: String?)
-    case throttlingException(message: String?)
-    case unauthorizedException(message: String?)
-    case unsupportedDocumentEncodingException(message: String?)
-}
+public struct IoTDataPlaneErrorType: AWSErrorType {
+    enum Code: String {
+        case conflictException = "ConflictException"
+        case internalFailureException = "InternalFailureException"
+        case invalidRequestException = "InvalidRequestException"
+        case methodNotAllowedException = "MethodNotAllowedException"
+        case requestEntityTooLargeException = "RequestEntityTooLargeException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+        case throttlingException = "ThrottlingException"
+        case unauthorizedException = "UnauthorizedException"
+        case unsupportedDocumentEncodingException = "UnsupportedDocumentEncodingException"
+    }
 
-extension IoTDataPlaneErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "InternalFailureException":
-            self = .internalFailureException(message: message)
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        case "MethodNotAllowedException":
-            self = .methodNotAllowedException(message: message)
-        case "RequestEntityTooLargeException":
-            self = .requestEntityTooLargeException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        case "UnauthorizedException":
-            self = .unauthorizedException(message: message)
-        case "UnsupportedDocumentEncodingException":
-            self = .unsupportedDocumentEncodingException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var internalFailureException: Self { .init(.internalFailureException) }
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+    public static var methodNotAllowedException: Self { .init(.methodNotAllowedException) }
+    public static var requestEntityTooLargeException: Self { .init(.requestEntityTooLargeException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+    public static var unauthorizedException: Self { .init(.unauthorizedException) }
+    public static var unsupportedDocumentEncodingException: Self { .init(.unsupportedDocumentEncodingException) }
+}
+
+extension IoTDataPlaneErrorType: Equatable {
+    public static func == (lhs: IoTDataPlaneErrorType, rhs: IoTDataPlaneErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension IoTDataPlaneErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .internalFailureException(let message):
-            return "InternalFailureException: \(message ?? "")"
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        case .methodNotAllowedException(let message):
-            return "MethodNotAllowedException: \(message ?? "")"
-        case .requestEntityTooLargeException(let message):
-            return "RequestEntityTooLargeException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        case .unauthorizedException(let message):
-            return "UnauthorizedException: \(message ?? "")"
-        case .unsupportedDocumentEncodingException(let message):
-            return "UnsupportedDocumentEncodingException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/IoTEvents/IoTEvents_Error.swift
+++ b/Sources/Soto/Services/IoTEvents/IoTEvents_Error.swift
@@ -17,70 +17,56 @@
 import SotoCore
 
 /// Error enum for IoTEvents
-public enum IoTEventsErrorType: AWSErrorType {
-    case internalFailureException(message: String?)
-    case invalidRequestException(message: String?)
-    case limitExceededException(message: String?)
-    case resourceAlreadyExistsException(message: String?)
-    case resourceInUseException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceUnavailableException(message: String?)
-    case throttlingException(message: String?)
-    case unsupportedOperationException(message: String?)
-}
+public struct IoTEventsErrorType: AWSErrorType {
+    enum Code: String {
+        case internalFailureException = "InternalFailureException"
+        case invalidRequestException = "InvalidRequestException"
+        case limitExceededException = "LimitExceededException"
+        case resourceAlreadyExistsException = "ResourceAlreadyExistsException"
+        case resourceInUseException = "ResourceInUseException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+        case throttlingException = "ThrottlingException"
+        case unsupportedOperationException = "UnsupportedOperationException"
+    }
 
-extension IoTEventsErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "InternalFailureException":
-            self = .internalFailureException(message: message)
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ResourceAlreadyExistsException":
-            self = .resourceAlreadyExistsException(message: message)
-        case "ResourceInUseException":
-            self = .resourceInUseException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        case "UnsupportedOperationException":
-            self = .unsupportedOperationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var internalFailureException: Self { .init(.internalFailureException) }
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var resourceAlreadyExistsException: Self { .init(.resourceAlreadyExistsException) }
+    public static var resourceInUseException: Self { .init(.resourceInUseException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+    public static var unsupportedOperationException: Self { .init(.unsupportedOperationException) }
+}
+
+extension IoTEventsErrorType: Equatable {
+    public static func == (lhs: IoTEventsErrorType, rhs: IoTEventsErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension IoTEventsErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .internalFailureException(let message):
-            return "InternalFailureException: \(message ?? "")"
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .resourceAlreadyExistsException(let message):
-            return "ResourceAlreadyExistsException: \(message ?? "")"
-        case .resourceInUseException(let message):
-            return "ResourceInUseException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        case .unsupportedOperationException(let message):
-            return "UnsupportedOperationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/IoTEventsData/IoTEventsData_Error.swift
+++ b/Sources/Soto/Services/IoTEventsData/IoTEventsData_Error.swift
@@ -17,50 +17,48 @@
 import SotoCore
 
 /// Error enum for IoTEventsData
-public enum IoTEventsDataErrorType: AWSErrorType {
-    case internalFailureException(message: String?)
-    case invalidRequestException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceUnavailableException(message: String?)
-    case throttlingException(message: String?)
-}
+public struct IoTEventsDataErrorType: AWSErrorType {
+    enum Code: String {
+        case internalFailureException = "InternalFailureException"
+        case invalidRequestException = "InvalidRequestException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+        case throttlingException = "ThrottlingException"
+    }
 
-extension IoTEventsDataErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "InternalFailureException":
-            self = .internalFailureException(message: message)
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var internalFailureException: Self { .init(.internalFailureException) }
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+}
+
+extension IoTEventsDataErrorType: Equatable {
+    public static func == (lhs: IoTEventsDataErrorType, rhs: IoTEventsDataErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension IoTEventsDataErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .internalFailureException(let message):
-            return "InternalFailureException: \(message ?? "")"
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/IoTJobsDataPlane/IoTJobsDataPlane_Error.swift
+++ b/Sources/Soto/Services/IoTJobsDataPlane/IoTJobsDataPlane_Error.swift
@@ -17,60 +17,52 @@
 import SotoCore
 
 /// Error enum for IoTJobsDataPlane
-public enum IoTJobsDataPlaneErrorType: AWSErrorType {
-    case certificateValidationException(message: String?)
-    case invalidRequestException(message: String?)
-    case invalidStateTransitionException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceUnavailableException(message: String?)
-    case terminalStateException(message: String?)
-    case throttlingException(message: String?)
-}
+public struct IoTJobsDataPlaneErrorType: AWSErrorType {
+    enum Code: String {
+        case certificateValidationException = "CertificateValidationException"
+        case invalidRequestException = "InvalidRequestException"
+        case invalidStateTransitionException = "InvalidStateTransitionException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+        case terminalStateException = "TerminalStateException"
+        case throttlingException = "ThrottlingException"
+    }
 
-extension IoTJobsDataPlaneErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "CertificateValidationException":
-            self = .certificateValidationException(message: message)
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        case "InvalidStateTransitionException":
-            self = .invalidStateTransitionException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        case "TerminalStateException":
-            self = .terminalStateException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var certificateValidationException: Self { .init(.certificateValidationException) }
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+    public static var invalidStateTransitionException: Self { .init(.invalidStateTransitionException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+    public static var terminalStateException: Self { .init(.terminalStateException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+}
+
+extension IoTJobsDataPlaneErrorType: Equatable {
+    public static func == (lhs: IoTJobsDataPlaneErrorType, rhs: IoTJobsDataPlaneErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension IoTJobsDataPlaneErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .certificateValidationException(let message):
-            return "CertificateValidationException: \(message ?? "")"
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        case .invalidStateTransitionException(let message):
-            return "InvalidStateTransitionException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        case .terminalStateException(let message):
-            return "TerminalStateException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/IoTSecureTunneling/IoTSecureTunneling_Error.swift
+++ b/Sources/Soto/Services/IoTSecureTunneling/IoTSecureTunneling_Error.swift
@@ -17,35 +17,42 @@
 import SotoCore
 
 /// Error enum for IoTSecureTunneling
-public enum IoTSecureTunnelingErrorType: AWSErrorType {
-    case limitExceededException(message: String?)
-    case resourceNotFoundException(message: String?)
-}
+public struct IoTSecureTunnelingErrorType: AWSErrorType {
+    enum Code: String {
+        case limitExceededException = "LimitExceededException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+    }
 
-extension IoTSecureTunnelingErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+}
+
+extension IoTSecureTunnelingErrorType: Equatable {
+    public static func == (lhs: IoTSecureTunnelingErrorType, rhs: IoTSecureTunnelingErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension IoTSecureTunnelingErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/IoTSiteWise/IoTSiteWise_Error.swift
+++ b/Sources/Soto/Services/IoTSiteWise/IoTSiteWise_Error.swift
@@ -17,70 +17,56 @@
 import SotoCore
 
 /// Error enum for IoTSiteWise
-public enum IoTSiteWiseErrorType: AWSErrorType {
-    case conflictingOperationException(message: String?)
-    case internalFailureException(message: String?)
-    case invalidRequestException(message: String?)
-    case limitExceededException(message: String?)
-    case resourceAlreadyExistsException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceUnavailableException(message: String?)
-    case throttlingException(message: String?)
-    case tooManyTagsException(message: String?)
-}
+public struct IoTSiteWiseErrorType: AWSErrorType {
+    enum Code: String {
+        case conflictingOperationException = "ConflictingOperationException"
+        case internalFailureException = "InternalFailureException"
+        case invalidRequestException = "InvalidRequestException"
+        case limitExceededException = "LimitExceededException"
+        case resourceAlreadyExistsException = "ResourceAlreadyExistsException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+        case throttlingException = "ThrottlingException"
+        case tooManyTagsException = "TooManyTagsException"
+    }
 
-extension IoTSiteWiseErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ConflictingOperationException":
-            self = .conflictingOperationException(message: message)
-        case "InternalFailureException":
-            self = .internalFailureException(message: message)
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ResourceAlreadyExistsException":
-            self = .resourceAlreadyExistsException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        case "TooManyTagsException":
-            self = .tooManyTagsException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var conflictingOperationException: Self { .init(.conflictingOperationException) }
+    public static var internalFailureException: Self { .init(.internalFailureException) }
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var resourceAlreadyExistsException: Self { .init(.resourceAlreadyExistsException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+    public static var tooManyTagsException: Self { .init(.tooManyTagsException) }
+}
+
+extension IoTSiteWiseErrorType: Equatable {
+    public static func == (lhs: IoTSiteWiseErrorType, rhs: IoTSiteWiseErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension IoTSiteWiseErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .conflictingOperationException(let message):
-            return "ConflictingOperationException: \(message ?? "")"
-        case .internalFailureException(let message):
-            return "InternalFailureException: \(message ?? "")"
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .resourceAlreadyExistsException(let message):
-            return "ResourceAlreadyExistsException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        case .tooManyTagsException(let message):
-            return "TooManyTagsException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/IoTThingsGraph/IoTThingsGraph_Error.swift
+++ b/Sources/Soto/Services/IoTThingsGraph/IoTThingsGraph_Error.swift
@@ -17,60 +17,52 @@
 import SotoCore
 
 /// Error enum for IoTThingsGraph
-public enum IoTThingsGraphErrorType: AWSErrorType {
-    case internalFailureException(message: String?)
-    case invalidRequestException(message: String?)
-    case limitExceededException(message: String?)
-    case resourceAlreadyExistsException(message: String?)
-    case resourceInUseException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case throttlingException(message: String?)
-}
+public struct IoTThingsGraphErrorType: AWSErrorType {
+    enum Code: String {
+        case internalFailureException = "InternalFailureException"
+        case invalidRequestException = "InvalidRequestException"
+        case limitExceededException = "LimitExceededException"
+        case resourceAlreadyExistsException = "ResourceAlreadyExistsException"
+        case resourceInUseException = "ResourceInUseException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case throttlingException = "ThrottlingException"
+    }
 
-extension IoTThingsGraphErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "InternalFailureException":
-            self = .internalFailureException(message: message)
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ResourceAlreadyExistsException":
-            self = .resourceAlreadyExistsException(message: message)
-        case "ResourceInUseException":
-            self = .resourceInUseException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var internalFailureException: Self { .init(.internalFailureException) }
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var resourceAlreadyExistsException: Self { .init(.resourceAlreadyExistsException) }
+    public static var resourceInUseException: Self { .init(.resourceInUseException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+}
+
+extension IoTThingsGraphErrorType: Equatable {
+    public static func == (lhs: IoTThingsGraphErrorType, rhs: IoTThingsGraphErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension IoTThingsGraphErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .internalFailureException(let message):
-            return "InternalFailureException: \(message ?? "")"
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .resourceAlreadyExistsException(let message):
-            return "ResourceAlreadyExistsException: \(message ?? "")"
-        case .resourceInUseException(let message):
-            return "ResourceInUseException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/KMS/KMS_Error.swift
+++ b/Sources/Soto/Services/KMS/KMS_Error.swift
@@ -17,190 +17,104 @@
 import SotoCore
 
 /// Error enum for KMS
-public enum KMSErrorType: AWSErrorType {
-    case alreadyExistsException(message: String?)
-    case cloudHsmClusterInUseException(message: String?)
-    case cloudHsmClusterInvalidConfigurationException(message: String?)
-    case cloudHsmClusterNotActiveException(message: String?)
-    case cloudHsmClusterNotFoundException(message: String?)
-    case cloudHsmClusterNotRelatedException(message: String?)
-    case customKeyStoreHasCMKsException(message: String?)
-    case customKeyStoreInvalidStateException(message: String?)
-    case customKeyStoreNameInUseException(message: String?)
-    case customKeyStoreNotFoundException(message: String?)
-    case dependencyTimeoutException(message: String?)
-    case disabledException(message: String?)
-    case expiredImportTokenException(message: String?)
-    case incorrectKeyException(message: String?)
-    case incorrectKeyMaterialException(message: String?)
-    case incorrectTrustAnchorException(message: String?)
-    case invalidAliasNameException(message: String?)
-    case invalidArnException(message: String?)
-    case invalidCiphertextException(message: String?)
-    case invalidGrantIdException(message: String?)
-    case invalidGrantTokenException(message: String?)
-    case invalidImportTokenException(message: String?)
-    case invalidKeyUsageException(message: String?)
-    case invalidMarkerException(message: String?)
-    case kMSInternalException(message: String?)
-    case kMSInvalidSignatureException(message: String?)
-    case kMSInvalidStateException(message: String?)
-    case keyUnavailableException(message: String?)
-    case limitExceededException(message: String?)
-    case malformedPolicyDocumentException(message: String?)
-    case notFoundException(message: String?)
-    case tagException(message: String?)
-    case unsupportedOperationException(message: String?)
-}
+public struct KMSErrorType: AWSErrorType {
+    enum Code: String {
+        case alreadyExistsException = "AlreadyExistsException"
+        case cloudHsmClusterInUseException = "CloudHsmClusterInUseException"
+        case cloudHsmClusterInvalidConfigurationException = "CloudHsmClusterInvalidConfigurationException"
+        case cloudHsmClusterNotActiveException = "CloudHsmClusterNotActiveException"
+        case cloudHsmClusterNotFoundException = "CloudHsmClusterNotFoundException"
+        case cloudHsmClusterNotRelatedException = "CloudHsmClusterNotRelatedException"
+        case customKeyStoreHasCMKsException = "CustomKeyStoreHasCMKsException"
+        case customKeyStoreInvalidStateException = "CustomKeyStoreInvalidStateException"
+        case customKeyStoreNameInUseException = "CustomKeyStoreNameInUseException"
+        case customKeyStoreNotFoundException = "CustomKeyStoreNotFoundException"
+        case dependencyTimeoutException = "DependencyTimeoutException"
+        case disabledException = "DisabledException"
+        case expiredImportTokenException = "ExpiredImportTokenException"
+        case incorrectKeyException = "IncorrectKeyException"
+        case incorrectKeyMaterialException = "IncorrectKeyMaterialException"
+        case incorrectTrustAnchorException = "IncorrectTrustAnchorException"
+        case invalidAliasNameException = "InvalidAliasNameException"
+        case invalidArnException = "InvalidArnException"
+        case invalidCiphertextException = "InvalidCiphertextException"
+        case invalidGrantIdException = "InvalidGrantIdException"
+        case invalidGrantTokenException = "InvalidGrantTokenException"
+        case invalidImportTokenException = "InvalidImportTokenException"
+        case invalidKeyUsageException = "InvalidKeyUsageException"
+        case invalidMarkerException = "InvalidMarkerException"
+        case kMSInternalException = "KMSInternalException"
+        case kMSInvalidSignatureException = "KMSInvalidSignatureException"
+        case kMSInvalidStateException = "KMSInvalidStateException"
+        case keyUnavailableException = "KeyUnavailableException"
+        case limitExceededException = "LimitExceededException"
+        case malformedPolicyDocumentException = "MalformedPolicyDocumentException"
+        case notFoundException = "NotFoundException"
+        case tagException = "TagException"
+        case unsupportedOperationException = "UnsupportedOperationException"
+    }
 
-extension KMSErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AlreadyExistsException":
-            self = .alreadyExistsException(message: message)
-        case "CloudHsmClusterInUseException":
-            self = .cloudHsmClusterInUseException(message: message)
-        case "CloudHsmClusterInvalidConfigurationException":
-            self = .cloudHsmClusterInvalidConfigurationException(message: message)
-        case "CloudHsmClusterNotActiveException":
-            self = .cloudHsmClusterNotActiveException(message: message)
-        case "CloudHsmClusterNotFoundException":
-            self = .cloudHsmClusterNotFoundException(message: message)
-        case "CloudHsmClusterNotRelatedException":
-            self = .cloudHsmClusterNotRelatedException(message: message)
-        case "CustomKeyStoreHasCMKsException":
-            self = .customKeyStoreHasCMKsException(message: message)
-        case "CustomKeyStoreInvalidStateException":
-            self = .customKeyStoreInvalidStateException(message: message)
-        case "CustomKeyStoreNameInUseException":
-            self = .customKeyStoreNameInUseException(message: message)
-        case "CustomKeyStoreNotFoundException":
-            self = .customKeyStoreNotFoundException(message: message)
-        case "DependencyTimeoutException":
-            self = .dependencyTimeoutException(message: message)
-        case "DisabledException":
-            self = .disabledException(message: message)
-        case "ExpiredImportTokenException":
-            self = .expiredImportTokenException(message: message)
-        case "IncorrectKeyException":
-            self = .incorrectKeyException(message: message)
-        case "IncorrectKeyMaterialException":
-            self = .incorrectKeyMaterialException(message: message)
-        case "IncorrectTrustAnchorException":
-            self = .incorrectTrustAnchorException(message: message)
-        case "InvalidAliasNameException":
-            self = .invalidAliasNameException(message: message)
-        case "InvalidArnException":
-            self = .invalidArnException(message: message)
-        case "InvalidCiphertextException":
-            self = .invalidCiphertextException(message: message)
-        case "InvalidGrantIdException":
-            self = .invalidGrantIdException(message: message)
-        case "InvalidGrantTokenException":
-            self = .invalidGrantTokenException(message: message)
-        case "InvalidImportTokenException":
-            self = .invalidImportTokenException(message: message)
-        case "InvalidKeyUsageException":
-            self = .invalidKeyUsageException(message: message)
-        case "InvalidMarkerException":
-            self = .invalidMarkerException(message: message)
-        case "KMSInternalException":
-            self = .kMSInternalException(message: message)
-        case "KMSInvalidSignatureException":
-            self = .kMSInvalidSignatureException(message: message)
-        case "KMSInvalidStateException":
-            self = .kMSInvalidStateException(message: message)
-        case "KeyUnavailableException":
-            self = .keyUnavailableException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "MalformedPolicyDocumentException":
-            self = .malformedPolicyDocumentException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "TagException":
-            self = .tagException(message: message)
-        case "UnsupportedOperationException":
-            self = .unsupportedOperationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var alreadyExistsException: Self { .init(.alreadyExistsException) }
+    public static var cloudHsmClusterInUseException: Self { .init(.cloudHsmClusterInUseException) }
+    public static var cloudHsmClusterInvalidConfigurationException: Self { .init(.cloudHsmClusterInvalidConfigurationException) }
+    public static var cloudHsmClusterNotActiveException: Self { .init(.cloudHsmClusterNotActiveException) }
+    public static var cloudHsmClusterNotFoundException: Self { .init(.cloudHsmClusterNotFoundException) }
+    public static var cloudHsmClusterNotRelatedException: Self { .init(.cloudHsmClusterNotRelatedException) }
+    public static var customKeyStoreHasCMKsException: Self { .init(.customKeyStoreHasCMKsException) }
+    public static var customKeyStoreInvalidStateException: Self { .init(.customKeyStoreInvalidStateException) }
+    public static var customKeyStoreNameInUseException: Self { .init(.customKeyStoreNameInUseException) }
+    public static var customKeyStoreNotFoundException: Self { .init(.customKeyStoreNotFoundException) }
+    public static var dependencyTimeoutException: Self { .init(.dependencyTimeoutException) }
+    public static var disabledException: Self { .init(.disabledException) }
+    public static var expiredImportTokenException: Self { .init(.expiredImportTokenException) }
+    public static var incorrectKeyException: Self { .init(.incorrectKeyException) }
+    public static var incorrectKeyMaterialException: Self { .init(.incorrectKeyMaterialException) }
+    public static var incorrectTrustAnchorException: Self { .init(.incorrectTrustAnchorException) }
+    public static var invalidAliasNameException: Self { .init(.invalidAliasNameException) }
+    public static var invalidArnException: Self { .init(.invalidArnException) }
+    public static var invalidCiphertextException: Self { .init(.invalidCiphertextException) }
+    public static var invalidGrantIdException: Self { .init(.invalidGrantIdException) }
+    public static var invalidGrantTokenException: Self { .init(.invalidGrantTokenException) }
+    public static var invalidImportTokenException: Self { .init(.invalidImportTokenException) }
+    public static var invalidKeyUsageException: Self { .init(.invalidKeyUsageException) }
+    public static var invalidMarkerException: Self { .init(.invalidMarkerException) }
+    public static var kMSInternalException: Self { .init(.kMSInternalException) }
+    public static var kMSInvalidSignatureException: Self { .init(.kMSInvalidSignatureException) }
+    public static var kMSInvalidStateException: Self { .init(.kMSInvalidStateException) }
+    public static var keyUnavailableException: Self { .init(.keyUnavailableException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var malformedPolicyDocumentException: Self { .init(.malformedPolicyDocumentException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var tagException: Self { .init(.tagException) }
+    public static var unsupportedOperationException: Self { .init(.unsupportedOperationException) }
+}
+
+extension KMSErrorType: Equatable {
+    public static func == (lhs: KMSErrorType, rhs: KMSErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension KMSErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .alreadyExistsException(let message):
-            return "AlreadyExistsException: \(message ?? "")"
-        case .cloudHsmClusterInUseException(let message):
-            return "CloudHsmClusterInUseException: \(message ?? "")"
-        case .cloudHsmClusterInvalidConfigurationException(let message):
-            return "CloudHsmClusterInvalidConfigurationException: \(message ?? "")"
-        case .cloudHsmClusterNotActiveException(let message):
-            return "CloudHsmClusterNotActiveException: \(message ?? "")"
-        case .cloudHsmClusterNotFoundException(let message):
-            return "CloudHsmClusterNotFoundException: \(message ?? "")"
-        case .cloudHsmClusterNotRelatedException(let message):
-            return "CloudHsmClusterNotRelatedException: \(message ?? "")"
-        case .customKeyStoreHasCMKsException(let message):
-            return "CustomKeyStoreHasCMKsException: \(message ?? "")"
-        case .customKeyStoreInvalidStateException(let message):
-            return "CustomKeyStoreInvalidStateException: \(message ?? "")"
-        case .customKeyStoreNameInUseException(let message):
-            return "CustomKeyStoreNameInUseException: \(message ?? "")"
-        case .customKeyStoreNotFoundException(let message):
-            return "CustomKeyStoreNotFoundException: \(message ?? "")"
-        case .dependencyTimeoutException(let message):
-            return "DependencyTimeoutException: \(message ?? "")"
-        case .disabledException(let message):
-            return "DisabledException: \(message ?? "")"
-        case .expiredImportTokenException(let message):
-            return "ExpiredImportTokenException: \(message ?? "")"
-        case .incorrectKeyException(let message):
-            return "IncorrectKeyException: \(message ?? "")"
-        case .incorrectKeyMaterialException(let message):
-            return "IncorrectKeyMaterialException: \(message ?? "")"
-        case .incorrectTrustAnchorException(let message):
-            return "IncorrectTrustAnchorException: \(message ?? "")"
-        case .invalidAliasNameException(let message):
-            return "InvalidAliasNameException: \(message ?? "")"
-        case .invalidArnException(let message):
-            return "InvalidArnException: \(message ?? "")"
-        case .invalidCiphertextException(let message):
-            return "InvalidCiphertextException: \(message ?? "")"
-        case .invalidGrantIdException(let message):
-            return "InvalidGrantIdException: \(message ?? "")"
-        case .invalidGrantTokenException(let message):
-            return "InvalidGrantTokenException: \(message ?? "")"
-        case .invalidImportTokenException(let message):
-            return "InvalidImportTokenException: \(message ?? "")"
-        case .invalidKeyUsageException(let message):
-            return "InvalidKeyUsageException: \(message ?? "")"
-        case .invalidMarkerException(let message):
-            return "InvalidMarkerException: \(message ?? "")"
-        case .kMSInternalException(let message):
-            return "KMSInternalException: \(message ?? "")"
-        case .kMSInvalidSignatureException(let message):
-            return "KMSInvalidSignatureException: \(message ?? "")"
-        case .kMSInvalidStateException(let message):
-            return "KMSInvalidStateException: \(message ?? "")"
-        case .keyUnavailableException(let message):
-            return "KeyUnavailableException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .malformedPolicyDocumentException(let message):
-            return "MalformedPolicyDocumentException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .tagException(let message):
-            return "TagException: \(message ?? "")"
-        case .unsupportedOperationException(let message):
-            return "UnsupportedOperationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Kafka/Kafka_Error.swift
+++ b/Sources/Soto/Services/Kafka/Kafka_Error.swift
@@ -17,65 +17,54 @@
 import SotoCore
 
 /// Error enum for Kafka
-public enum KafkaErrorType: AWSErrorType {
-    case badRequestException(message: String?)
-    case conflictException(message: String?)
-    case forbiddenException(message: String?)
-    case internalServerErrorException(message: String?)
-    case notFoundException(message: String?)
-    case serviceUnavailableException(message: String?)
-    case tooManyRequestsException(message: String?)
-    case unauthorizedException(message: String?)
-}
+public struct KafkaErrorType: AWSErrorType {
+    enum Code: String {
+        case badRequestException = "BadRequestException"
+        case conflictException = "ConflictException"
+        case forbiddenException = "ForbiddenException"
+        case internalServerErrorException = "InternalServerErrorException"
+        case notFoundException = "NotFoundException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+        case tooManyRequestsException = "TooManyRequestsException"
+        case unauthorizedException = "UnauthorizedException"
+    }
 
-extension KafkaErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "ForbiddenException":
-            self = .forbiddenException(message: message)
-        case "InternalServerErrorException":
-            self = .internalServerErrorException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        case "TooManyRequestsException":
-            self = .tooManyRequestsException(message: message)
-        case "UnauthorizedException":
-            self = .unauthorizedException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var badRequestException: Self { .init(.badRequestException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var forbiddenException: Self { .init(.forbiddenException) }
+    public static var internalServerErrorException: Self { .init(.internalServerErrorException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+    public static var tooManyRequestsException: Self { .init(.tooManyRequestsException) }
+    public static var unauthorizedException: Self { .init(.unauthorizedException) }
+}
+
+extension KafkaErrorType: Equatable {
+    public static func == (lhs: KafkaErrorType, rhs: KafkaErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension KafkaErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .forbiddenException(let message):
-            return "ForbiddenException: \(message ?? "")"
-        case .internalServerErrorException(let message):
-            return "InternalServerErrorException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        case .tooManyRequestsException(let message):
-            return "TooManyRequestsException: \(message ?? "")"
-        case .unauthorizedException(let message):
-            return "UnauthorizedException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Kendra/Kendra_Error.swift
+++ b/Sources/Soto/Services/Kendra/Kendra_Error.swift
@@ -17,75 +17,58 @@
 import SotoCore
 
 /// Error enum for Kendra
-public enum KendraErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case conflictException(message: String?)
-    case internalServerException(message: String?)
-    case resourceAlreadyExistException(message: String?)
-    case resourceInUseException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case resourceUnavailableException(message: String?)
-    case serviceQuotaExceededException(message: String?)
-    case throttlingException(message: String?)
-    case validationException(message: String?)
-}
+public struct KendraErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case conflictException = "ConflictException"
+        case internalServerException = "InternalServerException"
+        case resourceAlreadyExistException = "ResourceAlreadyExistException"
+        case resourceInUseException = "ResourceInUseException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case resourceUnavailableException = "ResourceUnavailableException"
+        case serviceQuotaExceededException = "ServiceQuotaExceededException"
+        case throttlingException = "ThrottlingException"
+        case validationException = "ValidationException"
+    }
 
-extension KendraErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "ResourceAlreadyExistException":
-            self = .resourceAlreadyExistException(message: message)
-        case "ResourceInUseException":
-            self = .resourceInUseException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ResourceUnavailableException":
-            self = .resourceUnavailableException(message: message)
-        case "ServiceQuotaExceededException":
-            self = .serviceQuotaExceededException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var resourceAlreadyExistException: Self { .init(.resourceAlreadyExistException) }
+    public static var resourceInUseException: Self { .init(.resourceInUseException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var resourceUnavailableException: Self { .init(.resourceUnavailableException) }
+    public static var serviceQuotaExceededException: Self { .init(.serviceQuotaExceededException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension KendraErrorType: Equatable {
+    public static func == (lhs: KendraErrorType, rhs: KendraErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension KendraErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .resourceAlreadyExistException(let message):
-            return "ResourceAlreadyExistException: \(message ?? "")"
-        case .resourceInUseException(let message):
-            return "ResourceInUseException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .resourceUnavailableException(let message):
-            return "ResourceUnavailableException: \(message ?? "")"
-        case .serviceQuotaExceededException(let message):
-            return "ServiceQuotaExceededException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Kinesis/Kinesis_Error.swift
+++ b/Sources/Soto/Services/Kinesis/Kinesis_Error.swift
@@ -17,90 +17,64 @@
 import SotoCore
 
 /// Error enum for Kinesis
-public enum KinesisErrorType: AWSErrorType {
-    case expiredIteratorException(message: String?)
-    case expiredNextTokenException(message: String?)
-    case invalidArgumentException(message: String?)
-    case kMSAccessDeniedException(message: String?)
-    case kMSDisabledException(message: String?)
-    case kMSInvalidStateException(message: String?)
-    case kMSNotFoundException(message: String?)
-    case kMSOptInRequired(message: String?)
-    case kMSThrottlingException(message: String?)
-    case limitExceededException(message: String?)
-    case provisionedThroughputExceededException(message: String?)
-    case resourceInUseException(message: String?)
-    case resourceNotFoundException(message: String?)
-}
+public struct KinesisErrorType: AWSErrorType {
+    enum Code: String {
+        case expiredIteratorException = "ExpiredIteratorException"
+        case expiredNextTokenException = "ExpiredNextTokenException"
+        case invalidArgumentException = "InvalidArgumentException"
+        case kMSAccessDeniedException = "KMSAccessDeniedException"
+        case kMSDisabledException = "KMSDisabledException"
+        case kMSInvalidStateException = "KMSInvalidStateException"
+        case kMSNotFoundException = "KMSNotFoundException"
+        case kMSOptInRequired = "KMSOptInRequired"
+        case kMSThrottlingException = "KMSThrottlingException"
+        case limitExceededException = "LimitExceededException"
+        case provisionedThroughputExceededException = "ProvisionedThroughputExceededException"
+        case resourceInUseException = "ResourceInUseException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+    }
 
-extension KinesisErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ExpiredIteratorException":
-            self = .expiredIteratorException(message: message)
-        case "ExpiredNextTokenException":
-            self = .expiredNextTokenException(message: message)
-        case "InvalidArgumentException":
-            self = .invalidArgumentException(message: message)
-        case "KMSAccessDeniedException":
-            self = .kMSAccessDeniedException(message: message)
-        case "KMSDisabledException":
-            self = .kMSDisabledException(message: message)
-        case "KMSInvalidStateException":
-            self = .kMSInvalidStateException(message: message)
-        case "KMSNotFoundException":
-            self = .kMSNotFoundException(message: message)
-        case "KMSOptInRequired":
-            self = .kMSOptInRequired(message: message)
-        case "KMSThrottlingException":
-            self = .kMSThrottlingException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ProvisionedThroughputExceededException":
-            self = .provisionedThroughputExceededException(message: message)
-        case "ResourceInUseException":
-            self = .resourceInUseException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var expiredIteratorException: Self { .init(.expiredIteratorException) }
+    public static var expiredNextTokenException: Self { .init(.expiredNextTokenException) }
+    public static var invalidArgumentException: Self { .init(.invalidArgumentException) }
+    public static var kMSAccessDeniedException: Self { .init(.kMSAccessDeniedException) }
+    public static var kMSDisabledException: Self { .init(.kMSDisabledException) }
+    public static var kMSInvalidStateException: Self { .init(.kMSInvalidStateException) }
+    public static var kMSNotFoundException: Self { .init(.kMSNotFoundException) }
+    public static var kMSOptInRequired: Self { .init(.kMSOptInRequired) }
+    public static var kMSThrottlingException: Self { .init(.kMSThrottlingException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var provisionedThroughputExceededException: Self { .init(.provisionedThroughputExceededException) }
+    public static var resourceInUseException: Self { .init(.resourceInUseException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+}
+
+extension KinesisErrorType: Equatable {
+    public static func == (lhs: KinesisErrorType, rhs: KinesisErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension KinesisErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .expiredIteratorException(let message):
-            return "ExpiredIteratorException: \(message ?? "")"
-        case .expiredNextTokenException(let message):
-            return "ExpiredNextTokenException: \(message ?? "")"
-        case .invalidArgumentException(let message):
-            return "InvalidArgumentException: \(message ?? "")"
-        case .kMSAccessDeniedException(let message):
-            return "KMSAccessDeniedException: \(message ?? "")"
-        case .kMSDisabledException(let message):
-            return "KMSDisabledException: \(message ?? "")"
-        case .kMSInvalidStateException(let message):
-            return "KMSInvalidStateException: \(message ?? "")"
-        case .kMSNotFoundException(let message):
-            return "KMSNotFoundException: \(message ?? "")"
-        case .kMSOptInRequired(let message):
-            return "KMSOptInRequired: \(message ?? "")"
-        case .kMSThrottlingException(let message):
-            return "KMSThrottlingException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .provisionedThroughputExceededException(let message):
-            return "ProvisionedThroughputExceededException: \(message ?? "")"
-        case .resourceInUseException(let message):
-            return "ResourceInUseException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/KinesisAnalytics/KinesisAnalytics_Error.swift
+++ b/Sources/Soto/Services/KinesisAnalytics/KinesisAnalytics_Error.swift
@@ -17,85 +17,62 @@
 import SotoCore
 
 /// Error enum for KinesisAnalytics
-public enum KinesisAnalyticsErrorType: AWSErrorType {
-    case codeValidationException(message: String?)
-    case concurrentModificationException(message: String?)
-    case invalidApplicationConfigurationException(message: String?)
-    case invalidArgumentException(message: String?)
-    case limitExceededException(message: String?)
-    case resourceInUseException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case resourceProvisionedThroughputExceededException(message: String?)
-    case serviceUnavailableException(message: String?)
-    case tooManyTagsException(message: String?)
-    case unableToDetectSchemaException(message: String?)
-    case unsupportedOperationException(message: String?)
-}
+public struct KinesisAnalyticsErrorType: AWSErrorType {
+    enum Code: String {
+        case codeValidationException = "CodeValidationException"
+        case concurrentModificationException = "ConcurrentModificationException"
+        case invalidApplicationConfigurationException = "InvalidApplicationConfigurationException"
+        case invalidArgumentException = "InvalidArgumentException"
+        case limitExceededException = "LimitExceededException"
+        case resourceInUseException = "ResourceInUseException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case resourceProvisionedThroughputExceededException = "ResourceProvisionedThroughputExceededException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+        case tooManyTagsException = "TooManyTagsException"
+        case unableToDetectSchemaException = "UnableToDetectSchemaException"
+        case unsupportedOperationException = "UnsupportedOperationException"
+    }
 
-extension KinesisAnalyticsErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "CodeValidationException":
-            self = .codeValidationException(message: message)
-        case "ConcurrentModificationException":
-            self = .concurrentModificationException(message: message)
-        case "InvalidApplicationConfigurationException":
-            self = .invalidApplicationConfigurationException(message: message)
-        case "InvalidArgumentException":
-            self = .invalidArgumentException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ResourceInUseException":
-            self = .resourceInUseException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ResourceProvisionedThroughputExceededException":
-            self = .resourceProvisionedThroughputExceededException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        case "TooManyTagsException":
-            self = .tooManyTagsException(message: message)
-        case "UnableToDetectSchemaException":
-            self = .unableToDetectSchemaException(message: message)
-        case "UnsupportedOperationException":
-            self = .unsupportedOperationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var codeValidationException: Self { .init(.codeValidationException) }
+    public static var concurrentModificationException: Self { .init(.concurrentModificationException) }
+    public static var invalidApplicationConfigurationException: Self { .init(.invalidApplicationConfigurationException) }
+    public static var invalidArgumentException: Self { .init(.invalidArgumentException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var resourceInUseException: Self { .init(.resourceInUseException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var resourceProvisionedThroughputExceededException: Self { .init(.resourceProvisionedThroughputExceededException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+    public static var tooManyTagsException: Self { .init(.tooManyTagsException) }
+    public static var unableToDetectSchemaException: Self { .init(.unableToDetectSchemaException) }
+    public static var unsupportedOperationException: Self { .init(.unsupportedOperationException) }
+}
+
+extension KinesisAnalyticsErrorType: Equatable {
+    public static func == (lhs: KinesisAnalyticsErrorType, rhs: KinesisAnalyticsErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension KinesisAnalyticsErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .codeValidationException(let message):
-            return "CodeValidationException: \(message ?? "")"
-        case .concurrentModificationException(let message):
-            return "ConcurrentModificationException: \(message ?? "")"
-        case .invalidApplicationConfigurationException(let message):
-            return "InvalidApplicationConfigurationException: \(message ?? "")"
-        case .invalidArgumentException(let message):
-            return "InvalidArgumentException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .resourceInUseException(let message):
-            return "ResourceInUseException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .resourceProvisionedThroughputExceededException(let message):
-            return "ResourceProvisionedThroughputExceededException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        case .tooManyTagsException(let message):
-            return "TooManyTagsException: \(message ?? "")"
-        case .unableToDetectSchemaException(let message):
-            return "UnableToDetectSchemaException: \(message ?? "")"
-        case .unsupportedOperationException(let message):
-            return "UnsupportedOperationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/KinesisAnalyticsV2/KinesisAnalyticsV2_Error.swift
+++ b/Sources/Soto/Services/KinesisAnalyticsV2/KinesisAnalyticsV2_Error.swift
@@ -17,90 +17,64 @@
 import SotoCore
 
 /// Error enum for KinesisAnalyticsV2
-public enum KinesisAnalyticsV2ErrorType: AWSErrorType {
-    case codeValidationException(message: String?)
-    case concurrentModificationException(message: String?)
-    case invalidApplicationConfigurationException(message: String?)
-    case invalidArgumentException(message: String?)
-    case invalidRequestException(message: String?)
-    case limitExceededException(message: String?)
-    case resourceInUseException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case resourceProvisionedThroughputExceededException(message: String?)
-    case serviceUnavailableException(message: String?)
-    case tooManyTagsException(message: String?)
-    case unableToDetectSchemaException(message: String?)
-    case unsupportedOperationException(message: String?)
-}
+public struct KinesisAnalyticsV2ErrorType: AWSErrorType {
+    enum Code: String {
+        case codeValidationException = "CodeValidationException"
+        case concurrentModificationException = "ConcurrentModificationException"
+        case invalidApplicationConfigurationException = "InvalidApplicationConfigurationException"
+        case invalidArgumentException = "InvalidArgumentException"
+        case invalidRequestException = "InvalidRequestException"
+        case limitExceededException = "LimitExceededException"
+        case resourceInUseException = "ResourceInUseException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case resourceProvisionedThroughputExceededException = "ResourceProvisionedThroughputExceededException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+        case tooManyTagsException = "TooManyTagsException"
+        case unableToDetectSchemaException = "UnableToDetectSchemaException"
+        case unsupportedOperationException = "UnsupportedOperationException"
+    }
 
-extension KinesisAnalyticsV2ErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "CodeValidationException":
-            self = .codeValidationException(message: message)
-        case "ConcurrentModificationException":
-            self = .concurrentModificationException(message: message)
-        case "InvalidApplicationConfigurationException":
-            self = .invalidApplicationConfigurationException(message: message)
-        case "InvalidArgumentException":
-            self = .invalidArgumentException(message: message)
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ResourceInUseException":
-            self = .resourceInUseException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ResourceProvisionedThroughputExceededException":
-            self = .resourceProvisionedThroughputExceededException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        case "TooManyTagsException":
-            self = .tooManyTagsException(message: message)
-        case "UnableToDetectSchemaException":
-            self = .unableToDetectSchemaException(message: message)
-        case "UnsupportedOperationException":
-            self = .unsupportedOperationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var codeValidationException: Self { .init(.codeValidationException) }
+    public static var concurrentModificationException: Self { .init(.concurrentModificationException) }
+    public static var invalidApplicationConfigurationException: Self { .init(.invalidApplicationConfigurationException) }
+    public static var invalidArgumentException: Self { .init(.invalidArgumentException) }
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var resourceInUseException: Self { .init(.resourceInUseException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var resourceProvisionedThroughputExceededException: Self { .init(.resourceProvisionedThroughputExceededException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+    public static var tooManyTagsException: Self { .init(.tooManyTagsException) }
+    public static var unableToDetectSchemaException: Self { .init(.unableToDetectSchemaException) }
+    public static var unsupportedOperationException: Self { .init(.unsupportedOperationException) }
+}
+
+extension KinesisAnalyticsV2ErrorType: Equatable {
+    public static func == (lhs: KinesisAnalyticsV2ErrorType, rhs: KinesisAnalyticsV2ErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension KinesisAnalyticsV2ErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .codeValidationException(let message):
-            return "CodeValidationException: \(message ?? "")"
-        case .concurrentModificationException(let message):
-            return "ConcurrentModificationException: \(message ?? "")"
-        case .invalidApplicationConfigurationException(let message):
-            return "InvalidApplicationConfigurationException: \(message ?? "")"
-        case .invalidArgumentException(let message):
-            return "InvalidArgumentException: \(message ?? "")"
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .resourceInUseException(let message):
-            return "ResourceInUseException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .resourceProvisionedThroughputExceededException(let message):
-            return "ResourceProvisionedThroughputExceededException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        case .tooManyTagsException(let message):
-            return "TooManyTagsException: \(message ?? "")"
-        case .unableToDetectSchemaException(let message):
-            return "UnableToDetectSchemaException: \(message ?? "")"
-        case .unsupportedOperationException(let message):
-            return "UnsupportedOperationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/KinesisVideo/KinesisVideo_Error.swift
+++ b/Sources/Soto/Services/KinesisVideo/KinesisVideo_Error.swift
@@ -17,90 +17,64 @@
 import SotoCore
 
 /// Error enum for KinesisVideo
-public enum KinesisVideoErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case accountChannelLimitExceededException(message: String?)
-    case accountStreamLimitExceededException(message: String?)
-    case clientLimitExceededException(message: String?)
-    case deviceStreamLimitExceededException(message: String?)
-    case invalidArgumentException(message: String?)
-    case invalidDeviceException(message: String?)
-    case invalidResourceFormatException(message: String?)
-    case notAuthorizedException(message: String?)
-    case resourceInUseException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case tagsPerResourceExceededLimitException(message: String?)
-    case versionMismatchException(message: String?)
-}
+public struct KinesisVideoErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case accountChannelLimitExceededException = "AccountChannelLimitExceededException"
+        case accountStreamLimitExceededException = "AccountStreamLimitExceededException"
+        case clientLimitExceededException = "ClientLimitExceededException"
+        case deviceStreamLimitExceededException = "DeviceStreamLimitExceededException"
+        case invalidArgumentException = "InvalidArgumentException"
+        case invalidDeviceException = "InvalidDeviceException"
+        case invalidResourceFormatException = "InvalidResourceFormatException"
+        case notAuthorizedException = "NotAuthorizedException"
+        case resourceInUseException = "ResourceInUseException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case tagsPerResourceExceededLimitException = "TagsPerResourceExceededLimitException"
+        case versionMismatchException = "VersionMismatchException"
+    }
 
-extension KinesisVideoErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "AccountChannelLimitExceededException":
-            self = .accountChannelLimitExceededException(message: message)
-        case "AccountStreamLimitExceededException":
-            self = .accountStreamLimitExceededException(message: message)
-        case "ClientLimitExceededException":
-            self = .clientLimitExceededException(message: message)
-        case "DeviceStreamLimitExceededException":
-            self = .deviceStreamLimitExceededException(message: message)
-        case "InvalidArgumentException":
-            self = .invalidArgumentException(message: message)
-        case "InvalidDeviceException":
-            self = .invalidDeviceException(message: message)
-        case "InvalidResourceFormatException":
-            self = .invalidResourceFormatException(message: message)
-        case "NotAuthorizedException":
-            self = .notAuthorizedException(message: message)
-        case "ResourceInUseException":
-            self = .resourceInUseException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "TagsPerResourceExceededLimitException":
-            self = .tagsPerResourceExceededLimitException(message: message)
-        case "VersionMismatchException":
-            self = .versionMismatchException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var accountChannelLimitExceededException: Self { .init(.accountChannelLimitExceededException) }
+    public static var accountStreamLimitExceededException: Self { .init(.accountStreamLimitExceededException) }
+    public static var clientLimitExceededException: Self { .init(.clientLimitExceededException) }
+    public static var deviceStreamLimitExceededException: Self { .init(.deviceStreamLimitExceededException) }
+    public static var invalidArgumentException: Self { .init(.invalidArgumentException) }
+    public static var invalidDeviceException: Self { .init(.invalidDeviceException) }
+    public static var invalidResourceFormatException: Self { .init(.invalidResourceFormatException) }
+    public static var notAuthorizedException: Self { .init(.notAuthorizedException) }
+    public static var resourceInUseException: Self { .init(.resourceInUseException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var tagsPerResourceExceededLimitException: Self { .init(.tagsPerResourceExceededLimitException) }
+    public static var versionMismatchException: Self { .init(.versionMismatchException) }
+}
+
+extension KinesisVideoErrorType: Equatable {
+    public static func == (lhs: KinesisVideoErrorType, rhs: KinesisVideoErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension KinesisVideoErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .accountChannelLimitExceededException(let message):
-            return "AccountChannelLimitExceededException: \(message ?? "")"
-        case .accountStreamLimitExceededException(let message):
-            return "AccountStreamLimitExceededException: \(message ?? "")"
-        case .clientLimitExceededException(let message):
-            return "ClientLimitExceededException: \(message ?? "")"
-        case .deviceStreamLimitExceededException(let message):
-            return "DeviceStreamLimitExceededException: \(message ?? "")"
-        case .invalidArgumentException(let message):
-            return "InvalidArgumentException: \(message ?? "")"
-        case .invalidDeviceException(let message):
-            return "InvalidDeviceException: \(message ?? "")"
-        case .invalidResourceFormatException(let message):
-            return "InvalidResourceFormatException: \(message ?? "")"
-        case .notAuthorizedException(let message):
-            return "NotAuthorizedException: \(message ?? "")"
-        case .resourceInUseException(let message):
-            return "ResourceInUseException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .tagsPerResourceExceededLimitException(let message):
-            return "TagsPerResourceExceededLimitException: \(message ?? "")"
-        case .versionMismatchException(let message):
-            return "VersionMismatchException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/KinesisVideoArchivedMedia/KinesisVideoArchivedMedia_Error.swift
+++ b/Sources/Soto/Services/KinesisVideoArchivedMedia/KinesisVideoArchivedMedia_Error.swift
@@ -17,70 +17,56 @@
 import SotoCore
 
 /// Error enum for KinesisVideoArchivedMedia
-public enum KinesisVideoArchivedMediaErrorType: AWSErrorType {
-    case clientLimitExceededException(message: String?)
-    case invalidArgumentException(message: String?)
-    case invalidCodecPrivateDataException(message: String?)
-    case invalidMediaFrameException(message: String?)
-    case missingCodecPrivateDataException(message: String?)
-    case noDataRetentionException(message: String?)
-    case notAuthorizedException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case unsupportedStreamMediaTypeException(message: String?)
-}
+public struct KinesisVideoArchivedMediaErrorType: AWSErrorType {
+    enum Code: String {
+        case clientLimitExceededException = "ClientLimitExceededException"
+        case invalidArgumentException = "InvalidArgumentException"
+        case invalidCodecPrivateDataException = "InvalidCodecPrivateDataException"
+        case invalidMediaFrameException = "InvalidMediaFrameException"
+        case missingCodecPrivateDataException = "MissingCodecPrivateDataException"
+        case noDataRetentionException = "NoDataRetentionException"
+        case notAuthorizedException = "NotAuthorizedException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case unsupportedStreamMediaTypeException = "UnsupportedStreamMediaTypeException"
+    }
 
-extension KinesisVideoArchivedMediaErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ClientLimitExceededException":
-            self = .clientLimitExceededException(message: message)
-        case "InvalidArgumentException":
-            self = .invalidArgumentException(message: message)
-        case "InvalidCodecPrivateDataException":
-            self = .invalidCodecPrivateDataException(message: message)
-        case "InvalidMediaFrameException":
-            self = .invalidMediaFrameException(message: message)
-        case "MissingCodecPrivateDataException":
-            self = .missingCodecPrivateDataException(message: message)
-        case "NoDataRetentionException":
-            self = .noDataRetentionException(message: message)
-        case "NotAuthorizedException":
-            self = .notAuthorizedException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "UnsupportedStreamMediaTypeException":
-            self = .unsupportedStreamMediaTypeException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var clientLimitExceededException: Self { .init(.clientLimitExceededException) }
+    public static var invalidArgumentException: Self { .init(.invalidArgumentException) }
+    public static var invalidCodecPrivateDataException: Self { .init(.invalidCodecPrivateDataException) }
+    public static var invalidMediaFrameException: Self { .init(.invalidMediaFrameException) }
+    public static var missingCodecPrivateDataException: Self { .init(.missingCodecPrivateDataException) }
+    public static var noDataRetentionException: Self { .init(.noDataRetentionException) }
+    public static var notAuthorizedException: Self { .init(.notAuthorizedException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var unsupportedStreamMediaTypeException: Self { .init(.unsupportedStreamMediaTypeException) }
+}
+
+extension KinesisVideoArchivedMediaErrorType: Equatable {
+    public static func == (lhs: KinesisVideoArchivedMediaErrorType, rhs: KinesisVideoArchivedMediaErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension KinesisVideoArchivedMediaErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .clientLimitExceededException(let message):
-            return "ClientLimitExceededException: \(message ?? "")"
-        case .invalidArgumentException(let message):
-            return "InvalidArgumentException: \(message ?? "")"
-        case .invalidCodecPrivateDataException(let message):
-            return "InvalidCodecPrivateDataException: \(message ?? "")"
-        case .invalidMediaFrameException(let message):
-            return "InvalidMediaFrameException: \(message ?? "")"
-        case .missingCodecPrivateDataException(let message):
-            return "MissingCodecPrivateDataException: \(message ?? "")"
-        case .noDataRetentionException(let message):
-            return "NoDataRetentionException: \(message ?? "")"
-        case .notAuthorizedException(let message):
-            return "NotAuthorizedException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .unsupportedStreamMediaTypeException(let message):
-            return "UnsupportedStreamMediaTypeException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/KinesisVideoMedia/KinesisVideoMedia_Error.swift
+++ b/Sources/Soto/Services/KinesisVideoMedia/KinesisVideoMedia_Error.swift
@@ -17,55 +17,50 @@
 import SotoCore
 
 /// Error enum for KinesisVideoMedia
-public enum KinesisVideoMediaErrorType: AWSErrorType {
-    case clientLimitExceededException(message: String?)
-    case connectionLimitExceededException(message: String?)
-    case invalidArgumentException(message: String?)
-    case invalidEndpointException(message: String?)
-    case notAuthorizedException(message: String?)
-    case resourceNotFoundException(message: String?)
-}
+public struct KinesisVideoMediaErrorType: AWSErrorType {
+    enum Code: String {
+        case clientLimitExceededException = "ClientLimitExceededException"
+        case connectionLimitExceededException = "ConnectionLimitExceededException"
+        case invalidArgumentException = "InvalidArgumentException"
+        case invalidEndpointException = "InvalidEndpointException"
+        case notAuthorizedException = "NotAuthorizedException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+    }
 
-extension KinesisVideoMediaErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ClientLimitExceededException":
-            self = .clientLimitExceededException(message: message)
-        case "ConnectionLimitExceededException":
-            self = .connectionLimitExceededException(message: message)
-        case "InvalidArgumentException":
-            self = .invalidArgumentException(message: message)
-        case "InvalidEndpointException":
-            self = .invalidEndpointException(message: message)
-        case "NotAuthorizedException":
-            self = .notAuthorizedException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var clientLimitExceededException: Self { .init(.clientLimitExceededException) }
+    public static var connectionLimitExceededException: Self { .init(.connectionLimitExceededException) }
+    public static var invalidArgumentException: Self { .init(.invalidArgumentException) }
+    public static var invalidEndpointException: Self { .init(.invalidEndpointException) }
+    public static var notAuthorizedException: Self { .init(.notAuthorizedException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+}
+
+extension KinesisVideoMediaErrorType: Equatable {
+    public static func == (lhs: KinesisVideoMediaErrorType, rhs: KinesisVideoMediaErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension KinesisVideoMediaErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .clientLimitExceededException(let message):
-            return "ClientLimitExceededException: \(message ?? "")"
-        case .connectionLimitExceededException(let message):
-            return "ConnectionLimitExceededException: \(message ?? "")"
-        case .invalidArgumentException(let message):
-            return "InvalidArgumentException: \(message ?? "")"
-        case .invalidEndpointException(let message):
-            return "InvalidEndpointException: \(message ?? "")"
-        case .notAuthorizedException(let message):
-            return "NotAuthorizedException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/KinesisVideoSignalingChannels/KinesisVideoSignalingChannels_Error.swift
+++ b/Sources/Soto/Services/KinesisVideoSignalingChannels/KinesisVideoSignalingChannels_Error.swift
@@ -17,55 +17,50 @@
 import SotoCore
 
 /// Error enum for KinesisVideoSignalingChannels
-public enum KinesisVideoSignalingChannelsErrorType: AWSErrorType {
-    case clientLimitExceededException(message: String?)
-    case invalidArgumentException(message: String?)
-    case invalidClientException(message: String?)
-    case notAuthorizedException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case sessionExpiredException(message: String?)
-}
+public struct KinesisVideoSignalingChannelsErrorType: AWSErrorType {
+    enum Code: String {
+        case clientLimitExceededException = "ClientLimitExceededException"
+        case invalidArgumentException = "InvalidArgumentException"
+        case invalidClientException = "InvalidClientException"
+        case notAuthorizedException = "NotAuthorizedException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case sessionExpiredException = "SessionExpiredException"
+    }
 
-extension KinesisVideoSignalingChannelsErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ClientLimitExceededException":
-            self = .clientLimitExceededException(message: message)
-        case "InvalidArgumentException":
-            self = .invalidArgumentException(message: message)
-        case "InvalidClientException":
-            self = .invalidClientException(message: message)
-        case "NotAuthorizedException":
-            self = .notAuthorizedException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "SessionExpiredException":
-            self = .sessionExpiredException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var clientLimitExceededException: Self { .init(.clientLimitExceededException) }
+    public static var invalidArgumentException: Self { .init(.invalidArgumentException) }
+    public static var invalidClientException: Self { .init(.invalidClientException) }
+    public static var notAuthorizedException: Self { .init(.notAuthorizedException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var sessionExpiredException: Self { .init(.sessionExpiredException) }
+}
+
+extension KinesisVideoSignalingChannelsErrorType: Equatable {
+    public static func == (lhs: KinesisVideoSignalingChannelsErrorType, rhs: KinesisVideoSignalingChannelsErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension KinesisVideoSignalingChannelsErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .clientLimitExceededException(let message):
-            return "ClientLimitExceededException: \(message ?? "")"
-        case .invalidArgumentException(let message):
-            return "InvalidArgumentException: \(message ?? "")"
-        case .invalidClientException(let message):
-            return "InvalidClientException: \(message ?? "")"
-        case .notAuthorizedException(let message):
-            return "NotAuthorizedException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .sessionExpiredException(let message):
-            return "SessionExpiredException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/LakeFormation/LakeFormation_Error.swift
+++ b/Sources/Soto/Services/LakeFormation/LakeFormation_Error.swift
@@ -17,55 +17,50 @@
 import SotoCore
 
 /// Error enum for LakeFormation
-public enum LakeFormationErrorType: AWSErrorType {
-    case alreadyExistsException(message: String?)
-    case concurrentModificationException(message: String?)
-    case entityNotFoundException(message: String?)
-    case internalServiceException(message: String?)
-    case invalidInputException(message: String?)
-    case operationTimeoutException(message: String?)
-}
+public struct LakeFormationErrorType: AWSErrorType {
+    enum Code: String {
+        case alreadyExistsException = "AlreadyExistsException"
+        case concurrentModificationException = "ConcurrentModificationException"
+        case entityNotFoundException = "EntityNotFoundException"
+        case internalServiceException = "InternalServiceException"
+        case invalidInputException = "InvalidInputException"
+        case operationTimeoutException = "OperationTimeoutException"
+    }
 
-extension LakeFormationErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AlreadyExistsException":
-            self = .alreadyExistsException(message: message)
-        case "ConcurrentModificationException":
-            self = .concurrentModificationException(message: message)
-        case "EntityNotFoundException":
-            self = .entityNotFoundException(message: message)
-        case "InternalServiceException":
-            self = .internalServiceException(message: message)
-        case "InvalidInputException":
-            self = .invalidInputException(message: message)
-        case "OperationTimeoutException":
-            self = .operationTimeoutException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var alreadyExistsException: Self { .init(.alreadyExistsException) }
+    public static var concurrentModificationException: Self { .init(.concurrentModificationException) }
+    public static var entityNotFoundException: Self { .init(.entityNotFoundException) }
+    public static var internalServiceException: Self { .init(.internalServiceException) }
+    public static var invalidInputException: Self { .init(.invalidInputException) }
+    public static var operationTimeoutException: Self { .init(.operationTimeoutException) }
+}
+
+extension LakeFormationErrorType: Equatable {
+    public static func == (lhs: LakeFormationErrorType, rhs: LakeFormationErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension LakeFormationErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .alreadyExistsException(let message):
-            return "AlreadyExistsException: \(message ?? "")"
-        case .concurrentModificationException(let message):
-            return "ConcurrentModificationException: \(message ?? "")"
-        case .entityNotFoundException(let message):
-            return "EntityNotFoundException: \(message ?? "")"
-        case .internalServiceException(let message):
-            return "InternalServiceException: \(message ?? "")"
-        case .invalidInputException(let message):
-            return "InvalidInputException: \(message ?? "")"
-        case .operationTimeoutException(let message):
-            return "OperationTimeoutException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Lambda/Lambda_Error.swift
+++ b/Sources/Soto/Services/Lambda/Lambda_Error.swift
@@ -17,180 +17,100 @@
 import SotoCore
 
 /// Error enum for Lambda
-public enum LambdaErrorType: AWSErrorType {
-    case codeStorageExceededException(message: String?)
-    case eC2AccessDeniedException(message: String?)
-    case eC2ThrottledException(message: String?)
-    case eC2UnexpectedException(message: String?)
-    case eFSIOException(message: String?)
-    case eFSMountConnectivityException(message: String?)
-    case eFSMountFailureException(message: String?)
-    case eFSMountTimeoutException(message: String?)
-    case eNILimitReachedException(message: String?)
-    case invalidParameterValueException(message: String?)
-    case invalidRequestContentException(message: String?)
-    case invalidRuntimeException(message: String?)
-    case invalidSecurityGroupIDException(message: String?)
-    case invalidSubnetIDException(message: String?)
-    case invalidZipFileException(message: String?)
-    case kMSAccessDeniedException(message: String?)
-    case kMSDisabledException(message: String?)
-    case kMSInvalidStateException(message: String?)
-    case kMSNotFoundException(message: String?)
-    case policyLengthExceededException(message: String?)
-    case preconditionFailedException(message: String?)
-    case provisionedConcurrencyConfigNotFoundException(message: String?)
-    case requestTooLargeException(message: String?)
-    case resourceConflictException(message: String?)
-    case resourceInUseException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case resourceNotReadyException(message: String?)
-    case serviceException(message: String?)
-    case subnetIPAddressLimitReachedException(message: String?)
-    case tooManyRequestsException(message: String?)
-    case unsupportedMediaTypeException(message: String?)
-}
+public struct LambdaErrorType: AWSErrorType {
+    enum Code: String {
+        case codeStorageExceededException = "CodeStorageExceededException"
+        case eC2AccessDeniedException = "EC2AccessDeniedException"
+        case eC2ThrottledException = "EC2ThrottledException"
+        case eC2UnexpectedException = "EC2UnexpectedException"
+        case eFSIOException = "EFSIOException"
+        case eFSMountConnectivityException = "EFSMountConnectivityException"
+        case eFSMountFailureException = "EFSMountFailureException"
+        case eFSMountTimeoutException = "EFSMountTimeoutException"
+        case eNILimitReachedException = "ENILimitReachedException"
+        case invalidParameterValueException = "InvalidParameterValueException"
+        case invalidRequestContentException = "InvalidRequestContentException"
+        case invalidRuntimeException = "InvalidRuntimeException"
+        case invalidSecurityGroupIDException = "InvalidSecurityGroupIDException"
+        case invalidSubnetIDException = "InvalidSubnetIDException"
+        case invalidZipFileException = "InvalidZipFileException"
+        case kMSAccessDeniedException = "KMSAccessDeniedException"
+        case kMSDisabledException = "KMSDisabledException"
+        case kMSInvalidStateException = "KMSInvalidStateException"
+        case kMSNotFoundException = "KMSNotFoundException"
+        case policyLengthExceededException = "PolicyLengthExceededException"
+        case preconditionFailedException = "PreconditionFailedException"
+        case provisionedConcurrencyConfigNotFoundException = "ProvisionedConcurrencyConfigNotFoundException"
+        case requestTooLargeException = "RequestTooLargeException"
+        case resourceConflictException = "ResourceConflictException"
+        case resourceInUseException = "ResourceInUseException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case resourceNotReadyException = "ResourceNotReadyException"
+        case serviceException = "ServiceException"
+        case subnetIPAddressLimitReachedException = "SubnetIPAddressLimitReachedException"
+        case tooManyRequestsException = "TooManyRequestsException"
+        case unsupportedMediaTypeException = "UnsupportedMediaTypeException"
+    }
 
-extension LambdaErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "CodeStorageExceededException":
-            self = .codeStorageExceededException(message: message)
-        case "EC2AccessDeniedException":
-            self = .eC2AccessDeniedException(message: message)
-        case "EC2ThrottledException":
-            self = .eC2ThrottledException(message: message)
-        case "EC2UnexpectedException":
-            self = .eC2UnexpectedException(message: message)
-        case "EFSIOException":
-            self = .eFSIOException(message: message)
-        case "EFSMountConnectivityException":
-            self = .eFSMountConnectivityException(message: message)
-        case "EFSMountFailureException":
-            self = .eFSMountFailureException(message: message)
-        case "EFSMountTimeoutException":
-            self = .eFSMountTimeoutException(message: message)
-        case "ENILimitReachedException":
-            self = .eNILimitReachedException(message: message)
-        case "InvalidParameterValueException":
-            self = .invalidParameterValueException(message: message)
-        case "InvalidRequestContentException":
-            self = .invalidRequestContentException(message: message)
-        case "InvalidRuntimeException":
-            self = .invalidRuntimeException(message: message)
-        case "InvalidSecurityGroupIDException":
-            self = .invalidSecurityGroupIDException(message: message)
-        case "InvalidSubnetIDException":
-            self = .invalidSubnetIDException(message: message)
-        case "InvalidZipFileException":
-            self = .invalidZipFileException(message: message)
-        case "KMSAccessDeniedException":
-            self = .kMSAccessDeniedException(message: message)
-        case "KMSDisabledException":
-            self = .kMSDisabledException(message: message)
-        case "KMSInvalidStateException":
-            self = .kMSInvalidStateException(message: message)
-        case "KMSNotFoundException":
-            self = .kMSNotFoundException(message: message)
-        case "PolicyLengthExceededException":
-            self = .policyLengthExceededException(message: message)
-        case "PreconditionFailedException":
-            self = .preconditionFailedException(message: message)
-        case "ProvisionedConcurrencyConfigNotFoundException":
-            self = .provisionedConcurrencyConfigNotFoundException(message: message)
-        case "RequestTooLargeException":
-            self = .requestTooLargeException(message: message)
-        case "ResourceConflictException":
-            self = .resourceConflictException(message: message)
-        case "ResourceInUseException":
-            self = .resourceInUseException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ResourceNotReadyException":
-            self = .resourceNotReadyException(message: message)
-        case "ServiceException":
-            self = .serviceException(message: message)
-        case "SubnetIPAddressLimitReachedException":
-            self = .subnetIPAddressLimitReachedException(message: message)
-        case "TooManyRequestsException":
-            self = .tooManyRequestsException(message: message)
-        case "UnsupportedMediaTypeException":
-            self = .unsupportedMediaTypeException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var codeStorageExceededException: Self { .init(.codeStorageExceededException) }
+    public static var eC2AccessDeniedException: Self { .init(.eC2AccessDeniedException) }
+    public static var eC2ThrottledException: Self { .init(.eC2ThrottledException) }
+    public static var eC2UnexpectedException: Self { .init(.eC2UnexpectedException) }
+    public static var eFSIOException: Self { .init(.eFSIOException) }
+    public static var eFSMountConnectivityException: Self { .init(.eFSMountConnectivityException) }
+    public static var eFSMountFailureException: Self { .init(.eFSMountFailureException) }
+    public static var eFSMountTimeoutException: Self { .init(.eFSMountTimeoutException) }
+    public static var eNILimitReachedException: Self { .init(.eNILimitReachedException) }
+    public static var invalidParameterValueException: Self { .init(.invalidParameterValueException) }
+    public static var invalidRequestContentException: Self { .init(.invalidRequestContentException) }
+    public static var invalidRuntimeException: Self { .init(.invalidRuntimeException) }
+    public static var invalidSecurityGroupIDException: Self { .init(.invalidSecurityGroupIDException) }
+    public static var invalidSubnetIDException: Self { .init(.invalidSubnetIDException) }
+    public static var invalidZipFileException: Self { .init(.invalidZipFileException) }
+    public static var kMSAccessDeniedException: Self { .init(.kMSAccessDeniedException) }
+    public static var kMSDisabledException: Self { .init(.kMSDisabledException) }
+    public static var kMSInvalidStateException: Self { .init(.kMSInvalidStateException) }
+    public static var kMSNotFoundException: Self { .init(.kMSNotFoundException) }
+    public static var policyLengthExceededException: Self { .init(.policyLengthExceededException) }
+    public static var preconditionFailedException: Self { .init(.preconditionFailedException) }
+    public static var provisionedConcurrencyConfigNotFoundException: Self { .init(.provisionedConcurrencyConfigNotFoundException) }
+    public static var requestTooLargeException: Self { .init(.requestTooLargeException) }
+    public static var resourceConflictException: Self { .init(.resourceConflictException) }
+    public static var resourceInUseException: Self { .init(.resourceInUseException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var resourceNotReadyException: Self { .init(.resourceNotReadyException) }
+    public static var serviceException: Self { .init(.serviceException) }
+    public static var subnetIPAddressLimitReachedException: Self { .init(.subnetIPAddressLimitReachedException) }
+    public static var tooManyRequestsException: Self { .init(.tooManyRequestsException) }
+    public static var unsupportedMediaTypeException: Self { .init(.unsupportedMediaTypeException) }
+}
+
+extension LambdaErrorType: Equatable {
+    public static func == (lhs: LambdaErrorType, rhs: LambdaErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension LambdaErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .codeStorageExceededException(let message):
-            return "CodeStorageExceededException: \(message ?? "")"
-        case .eC2AccessDeniedException(let message):
-            return "EC2AccessDeniedException: \(message ?? "")"
-        case .eC2ThrottledException(let message):
-            return "EC2ThrottledException: \(message ?? "")"
-        case .eC2UnexpectedException(let message):
-            return "EC2UnexpectedException: \(message ?? "")"
-        case .eFSIOException(let message):
-            return "EFSIOException: \(message ?? "")"
-        case .eFSMountConnectivityException(let message):
-            return "EFSMountConnectivityException: \(message ?? "")"
-        case .eFSMountFailureException(let message):
-            return "EFSMountFailureException: \(message ?? "")"
-        case .eFSMountTimeoutException(let message):
-            return "EFSMountTimeoutException: \(message ?? "")"
-        case .eNILimitReachedException(let message):
-            return "ENILimitReachedException: \(message ?? "")"
-        case .invalidParameterValueException(let message):
-            return "InvalidParameterValueException: \(message ?? "")"
-        case .invalidRequestContentException(let message):
-            return "InvalidRequestContentException: \(message ?? "")"
-        case .invalidRuntimeException(let message):
-            return "InvalidRuntimeException: \(message ?? "")"
-        case .invalidSecurityGroupIDException(let message):
-            return "InvalidSecurityGroupIDException: \(message ?? "")"
-        case .invalidSubnetIDException(let message):
-            return "InvalidSubnetIDException: \(message ?? "")"
-        case .invalidZipFileException(let message):
-            return "InvalidZipFileException: \(message ?? "")"
-        case .kMSAccessDeniedException(let message):
-            return "KMSAccessDeniedException: \(message ?? "")"
-        case .kMSDisabledException(let message):
-            return "KMSDisabledException: \(message ?? "")"
-        case .kMSInvalidStateException(let message):
-            return "KMSInvalidStateException: \(message ?? "")"
-        case .kMSNotFoundException(let message):
-            return "KMSNotFoundException: \(message ?? "")"
-        case .policyLengthExceededException(let message):
-            return "PolicyLengthExceededException: \(message ?? "")"
-        case .preconditionFailedException(let message):
-            return "PreconditionFailedException: \(message ?? "")"
-        case .provisionedConcurrencyConfigNotFoundException(let message):
-            return "ProvisionedConcurrencyConfigNotFoundException: \(message ?? "")"
-        case .requestTooLargeException(let message):
-            return "RequestTooLargeException: \(message ?? "")"
-        case .resourceConflictException(let message):
-            return "ResourceConflictException: \(message ?? "")"
-        case .resourceInUseException(let message):
-            return "ResourceInUseException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .resourceNotReadyException(let message):
-            return "ResourceNotReadyException: \(message ?? "")"
-        case .serviceException(let message):
-            return "ServiceException: \(message ?? "")"
-        case .subnetIPAddressLimitReachedException(let message):
-            return "SubnetIPAddressLimitReachedException: \(message ?? "")"
-        case .tooManyRequestsException(let message):
-            return "TooManyRequestsException: \(message ?? "")"
-        case .unsupportedMediaTypeException(let message):
-            return "UnsupportedMediaTypeException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/LexModelBuildingService/LexModelBuildingService_Error.swift
+++ b/Sources/Soto/Services/LexModelBuildingService/LexModelBuildingService_Error.swift
@@ -17,60 +17,52 @@
 import SotoCore
 
 /// Error enum for LexModelBuildingService
-public enum LexModelBuildingServiceErrorType: AWSErrorType {
-    case badRequestException(message: String?)
-    case conflictException(message: String?)
-    case internalFailureException(message: String?)
-    case limitExceededException(message: String?)
-    case notFoundException(message: String?)
-    case preconditionFailedException(message: String?)
-    case resourceInUseException(message: String?)
-}
+public struct LexModelBuildingServiceErrorType: AWSErrorType {
+    enum Code: String {
+        case badRequestException = "BadRequestException"
+        case conflictException = "ConflictException"
+        case internalFailureException = "InternalFailureException"
+        case limitExceededException = "LimitExceededException"
+        case notFoundException = "NotFoundException"
+        case preconditionFailedException = "PreconditionFailedException"
+        case resourceInUseException = "ResourceInUseException"
+    }
 
-extension LexModelBuildingServiceErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "InternalFailureException":
-            self = .internalFailureException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "PreconditionFailedException":
-            self = .preconditionFailedException(message: message)
-        case "ResourceInUseException":
-            self = .resourceInUseException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var badRequestException: Self { .init(.badRequestException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var internalFailureException: Self { .init(.internalFailureException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var preconditionFailedException: Self { .init(.preconditionFailedException) }
+    public static var resourceInUseException: Self { .init(.resourceInUseException) }
+}
+
+extension LexModelBuildingServiceErrorType: Equatable {
+    public static func == (lhs: LexModelBuildingServiceErrorType, rhs: LexModelBuildingServiceErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension LexModelBuildingServiceErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .internalFailureException(let message):
-            return "InternalFailureException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .preconditionFailedException(let message):
-            return "PreconditionFailedException: \(message ?? "")"
-        case .resourceInUseException(let message):
-            return "ResourceInUseException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/LexRuntimeService/LexRuntimeService_Error.swift
+++ b/Sources/Soto/Services/LexRuntimeService/LexRuntimeService_Error.swift
@@ -17,80 +17,60 @@
 import SotoCore
 
 /// Error enum for LexRuntimeService
-public enum LexRuntimeServiceErrorType: AWSErrorType {
-    case badGatewayException(message: String?)
-    case badRequestException(message: String?)
-    case conflictException(message: String?)
-    case dependencyFailedException(message: String?)
-    case internalFailureException(message: String?)
-    case limitExceededException(message: String?)
-    case loopDetectedException(message: String?)
-    case notAcceptableException(message: String?)
-    case notFoundException(message: String?)
-    case requestTimeoutException(message: String?)
-    case unsupportedMediaTypeException(message: String?)
-}
+public struct LexRuntimeServiceErrorType: AWSErrorType {
+    enum Code: String {
+        case badGatewayException = "BadGatewayException"
+        case badRequestException = "BadRequestException"
+        case conflictException = "ConflictException"
+        case dependencyFailedException = "DependencyFailedException"
+        case internalFailureException = "InternalFailureException"
+        case limitExceededException = "LimitExceededException"
+        case loopDetectedException = "LoopDetectedException"
+        case notAcceptableException = "NotAcceptableException"
+        case notFoundException = "NotFoundException"
+        case requestTimeoutException = "RequestTimeoutException"
+        case unsupportedMediaTypeException = "UnsupportedMediaTypeException"
+    }
 
-extension LexRuntimeServiceErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "BadGatewayException":
-            self = .badGatewayException(message: message)
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "DependencyFailedException":
-            self = .dependencyFailedException(message: message)
-        case "InternalFailureException":
-            self = .internalFailureException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "LoopDetectedException":
-            self = .loopDetectedException(message: message)
-        case "NotAcceptableException":
-            self = .notAcceptableException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "RequestTimeoutException":
-            self = .requestTimeoutException(message: message)
-        case "UnsupportedMediaTypeException":
-            self = .unsupportedMediaTypeException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var badGatewayException: Self { .init(.badGatewayException) }
+    public static var badRequestException: Self { .init(.badRequestException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var dependencyFailedException: Self { .init(.dependencyFailedException) }
+    public static var internalFailureException: Self { .init(.internalFailureException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var loopDetectedException: Self { .init(.loopDetectedException) }
+    public static var notAcceptableException: Self { .init(.notAcceptableException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var requestTimeoutException: Self { .init(.requestTimeoutException) }
+    public static var unsupportedMediaTypeException: Self { .init(.unsupportedMediaTypeException) }
+}
+
+extension LexRuntimeServiceErrorType: Equatable {
+    public static func == (lhs: LexRuntimeServiceErrorType, rhs: LexRuntimeServiceErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension LexRuntimeServiceErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .badGatewayException(let message):
-            return "BadGatewayException: \(message ?? "")"
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .dependencyFailedException(let message):
-            return "DependencyFailedException: \(message ?? "")"
-        case .internalFailureException(let message):
-            return "InternalFailureException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .loopDetectedException(let message):
-            return "LoopDetectedException: \(message ?? "")"
-        case .notAcceptableException(let message):
-            return "NotAcceptableException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .requestTimeoutException(let message):
-            return "RequestTimeoutException: \(message ?? "")"
-        case .unsupportedMediaTypeException(let message):
-            return "UnsupportedMediaTypeException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/LicenseManager/LicenseManager_Error.swift
+++ b/Sources/Soto/Services/LicenseManager/LicenseManager_Error.swift
@@ -17,75 +17,58 @@
 import SotoCore
 
 /// Error enum for LicenseManager
-public enum LicenseManagerErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case authorizationException(message: String?)
-    case failedDependencyException(message: String?)
-    case filterLimitExceededException(message: String?)
-    case invalidParameterValueException(message: String?)
-    case invalidResourceStateException(message: String?)
-    case licenseUsageException(message: String?)
-    case rateLimitExceededException(message: String?)
-    case resourceLimitExceededException(message: String?)
-    case serverInternalException(message: String?)
-}
+public struct LicenseManagerErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case authorizationException = "AuthorizationException"
+        case failedDependencyException = "FailedDependencyException"
+        case filterLimitExceededException = "FilterLimitExceededException"
+        case invalidParameterValueException = "InvalidParameterValueException"
+        case invalidResourceStateException = "InvalidResourceStateException"
+        case licenseUsageException = "LicenseUsageException"
+        case rateLimitExceededException = "RateLimitExceededException"
+        case resourceLimitExceededException = "ResourceLimitExceededException"
+        case serverInternalException = "ServerInternalException"
+    }
 
-extension LicenseManagerErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "AuthorizationException":
-            self = .authorizationException(message: message)
-        case "FailedDependencyException":
-            self = .failedDependencyException(message: message)
-        case "FilterLimitExceededException":
-            self = .filterLimitExceededException(message: message)
-        case "InvalidParameterValueException":
-            self = .invalidParameterValueException(message: message)
-        case "InvalidResourceStateException":
-            self = .invalidResourceStateException(message: message)
-        case "LicenseUsageException":
-            self = .licenseUsageException(message: message)
-        case "RateLimitExceededException":
-            self = .rateLimitExceededException(message: message)
-        case "ResourceLimitExceededException":
-            self = .resourceLimitExceededException(message: message)
-        case "ServerInternalException":
-            self = .serverInternalException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var authorizationException: Self { .init(.authorizationException) }
+    public static var failedDependencyException: Self { .init(.failedDependencyException) }
+    public static var filterLimitExceededException: Self { .init(.filterLimitExceededException) }
+    public static var invalidParameterValueException: Self { .init(.invalidParameterValueException) }
+    public static var invalidResourceStateException: Self { .init(.invalidResourceStateException) }
+    public static var licenseUsageException: Self { .init(.licenseUsageException) }
+    public static var rateLimitExceededException: Self { .init(.rateLimitExceededException) }
+    public static var resourceLimitExceededException: Self { .init(.resourceLimitExceededException) }
+    public static var serverInternalException: Self { .init(.serverInternalException) }
+}
+
+extension LicenseManagerErrorType: Equatable {
+    public static func == (lhs: LicenseManagerErrorType, rhs: LicenseManagerErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension LicenseManagerErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .authorizationException(let message):
-            return "AuthorizationException: \(message ?? "")"
-        case .failedDependencyException(let message):
-            return "FailedDependencyException: \(message ?? "")"
-        case .filterLimitExceededException(let message):
-            return "FilterLimitExceededException: \(message ?? "")"
-        case .invalidParameterValueException(let message):
-            return "InvalidParameterValueException: \(message ?? "")"
-        case .invalidResourceStateException(let message):
-            return "InvalidResourceStateException: \(message ?? "")"
-        case .licenseUsageException(let message):
-            return "LicenseUsageException: \(message ?? "")"
-        case .rateLimitExceededException(let message):
-            return "RateLimitExceededException: \(message ?? "")"
-        case .resourceLimitExceededException(let message):
-            return "ResourceLimitExceededException: \(message ?? "")"
-        case .serverInternalException(let message):
-            return "ServerInternalException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Lightsail/Lightsail_Error.swift
+++ b/Sources/Soto/Services/Lightsail/Lightsail_Error.swift
@@ -17,60 +17,52 @@
 import SotoCore
 
 /// Error enum for Lightsail
-public enum LightsailErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case accountSetupInProgressException(message: String?)
-    case invalidInputException(message: String?)
-    case notFoundException(message: String?)
-    case operationFailureException(message: String?)
-    case serviceException(message: String?)
-    case unauthenticatedException(message: String?)
-}
+public struct LightsailErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case accountSetupInProgressException = "AccountSetupInProgressException"
+        case invalidInputException = "InvalidInputException"
+        case notFoundException = "NotFoundException"
+        case operationFailureException = "OperationFailureException"
+        case serviceException = "ServiceException"
+        case unauthenticatedException = "UnauthenticatedException"
+    }
 
-extension LightsailErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "AccountSetupInProgressException":
-            self = .accountSetupInProgressException(message: message)
-        case "InvalidInputException":
-            self = .invalidInputException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "OperationFailureException":
-            self = .operationFailureException(message: message)
-        case "ServiceException":
-            self = .serviceException(message: message)
-        case "UnauthenticatedException":
-            self = .unauthenticatedException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var accountSetupInProgressException: Self { .init(.accountSetupInProgressException) }
+    public static var invalidInputException: Self { .init(.invalidInputException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var operationFailureException: Self { .init(.operationFailureException) }
+    public static var serviceException: Self { .init(.serviceException) }
+    public static var unauthenticatedException: Self { .init(.unauthenticatedException) }
+}
+
+extension LightsailErrorType: Equatable {
+    public static func == (lhs: LightsailErrorType, rhs: LightsailErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension LightsailErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .accountSetupInProgressException(let message):
-            return "AccountSetupInProgressException: \(message ?? "")"
-        case .invalidInputException(let message):
-            return "InvalidInputException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .operationFailureException(let message):
-            return "OperationFailureException: \(message ?? "")"
-        case .serviceException(let message):
-            return "ServiceException: \(message ?? "")"
-        case .unauthenticatedException(let message):
-            return "UnauthenticatedException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/MQ/MQ_Error.swift
+++ b/Sources/Soto/Services/MQ/MQ_Error.swift
@@ -17,55 +17,50 @@
 import SotoCore
 
 /// Error enum for MQ
-public enum MQErrorType: AWSErrorType {
-    case badRequestException(message: String?)
-    case conflictException(message: String?)
-    case forbiddenException(message: String?)
-    case internalServerErrorException(message: String?)
-    case notFoundException(message: String?)
-    case unauthorizedException(message: String?)
-}
+public struct MQErrorType: AWSErrorType {
+    enum Code: String {
+        case badRequestException = "BadRequestException"
+        case conflictException = "ConflictException"
+        case forbiddenException = "ForbiddenException"
+        case internalServerErrorException = "InternalServerErrorException"
+        case notFoundException = "NotFoundException"
+        case unauthorizedException = "UnauthorizedException"
+    }
 
-extension MQErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "ForbiddenException":
-            self = .forbiddenException(message: message)
-        case "InternalServerErrorException":
-            self = .internalServerErrorException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "UnauthorizedException":
-            self = .unauthorizedException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var badRequestException: Self { .init(.badRequestException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var forbiddenException: Self { .init(.forbiddenException) }
+    public static var internalServerErrorException: Self { .init(.internalServerErrorException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var unauthorizedException: Self { .init(.unauthorizedException) }
+}
+
+extension MQErrorType: Equatable {
+    public static func == (lhs: MQErrorType, rhs: MQErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension MQErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .forbiddenException(let message):
-            return "ForbiddenException: \(message ?? "")"
-        case .internalServerErrorException(let message):
-            return "InternalServerErrorException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .unauthorizedException(let message):
-            return "UnauthorizedException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/MachineLearning/MachineLearning_Error.swift
+++ b/Sources/Soto/Services/MachineLearning/MachineLearning_Error.swift
@@ -17,65 +17,54 @@
 import SotoCore
 
 /// Error enum for MachineLearning
-public enum MachineLearningErrorType: AWSErrorType {
-    case idempotentParameterMismatchException(message: String?)
-    case internalServerException(message: String?)
-    case invalidInputException(message: String?)
-    case invalidTagException(message: String?)
-    case limitExceededException(message: String?)
-    case predictorNotMountedException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case tagLimitExceededException(message: String?)
-}
+public struct MachineLearningErrorType: AWSErrorType {
+    enum Code: String {
+        case idempotentParameterMismatchException = "IdempotentParameterMismatchException"
+        case internalServerException = "InternalServerException"
+        case invalidInputException = "InvalidInputException"
+        case invalidTagException = "InvalidTagException"
+        case limitExceededException = "LimitExceededException"
+        case predictorNotMountedException = "PredictorNotMountedException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case tagLimitExceededException = "TagLimitExceededException"
+    }
 
-extension MachineLearningErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "IdempotentParameterMismatchException":
-            self = .idempotentParameterMismatchException(message: message)
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "InvalidInputException":
-            self = .invalidInputException(message: message)
-        case "InvalidTagException":
-            self = .invalidTagException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "PredictorNotMountedException":
-            self = .predictorNotMountedException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "TagLimitExceededException":
-            self = .tagLimitExceededException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var idempotentParameterMismatchException: Self { .init(.idempotentParameterMismatchException) }
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var invalidInputException: Self { .init(.invalidInputException) }
+    public static var invalidTagException: Self { .init(.invalidTagException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var predictorNotMountedException: Self { .init(.predictorNotMountedException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var tagLimitExceededException: Self { .init(.tagLimitExceededException) }
+}
+
+extension MachineLearningErrorType: Equatable {
+    public static func == (lhs: MachineLearningErrorType, rhs: MachineLearningErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension MachineLearningErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .idempotentParameterMismatchException(let message):
-            return "IdempotentParameterMismatchException: \(message ?? "")"
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .invalidInputException(let message):
-            return "InvalidInputException: \(message ?? "")"
-        case .invalidTagException(let message):
-            return "InvalidTagException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .predictorNotMountedException(let message):
-            return "PredictorNotMountedException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .tagLimitExceededException(let message):
-            return "TagLimitExceededException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Macie/Macie_Error.swift
+++ b/Sources/Soto/Services/Macie/Macie_Error.swift
@@ -17,45 +17,46 @@
 import SotoCore
 
 /// Error enum for Macie
-public enum MacieErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case internalException(message: String?)
-    case invalidInputException(message: String?)
-    case limitExceededException(message: String?)
-}
+public struct MacieErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case internalException = "InternalException"
+        case invalidInputException = "InvalidInputException"
+        case limitExceededException = "LimitExceededException"
+    }
 
-extension MacieErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "InternalException":
-            self = .internalException(message: message)
-        case "InvalidInputException":
-            self = .invalidInputException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var internalException: Self { .init(.internalException) }
+    public static var invalidInputException: Self { .init(.invalidInputException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+}
+
+extension MacieErrorType: Equatable {
+    public static func == (lhs: MacieErrorType, rhs: MacieErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension MacieErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .internalException(let message):
-            return "InternalException: \(message ?? "")"
-        case .invalidInputException(let message):
-            return "InvalidInputException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Macie2/Macie2_Error.swift
+++ b/Sources/Soto/Services/Macie2/Macie2_Error.swift
@@ -17,60 +17,52 @@
 import SotoCore
 
 /// Error enum for Macie2
-public enum Macie2ErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case conflictException(message: String?)
-    case internalServerException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceQuotaExceededException(message: String?)
-    case throttlingException(message: String?)
-    case validationException(message: String?)
-}
+public struct Macie2ErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case conflictException = "ConflictException"
+        case internalServerException = "InternalServerException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceQuotaExceededException = "ServiceQuotaExceededException"
+        case throttlingException = "ThrottlingException"
+        case validationException = "ValidationException"
+    }
 
-extension Macie2ErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceQuotaExceededException":
-            self = .serviceQuotaExceededException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceQuotaExceededException: Self { .init(.serviceQuotaExceededException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension Macie2ErrorType: Equatable {
+    public static func == (lhs: Macie2ErrorType, rhs: Macie2ErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension Macie2ErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceQuotaExceededException(let message):
-            return "ServiceQuotaExceededException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/ManagedBlockchain/ManagedBlockchain_Error.swift
+++ b/Sources/Soto/Services/ManagedBlockchain/ManagedBlockchain_Error.swift
@@ -17,70 +17,56 @@
 import SotoCore
 
 /// Error enum for ManagedBlockchain
-public enum ManagedBlockchainErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case illegalActionException(message: String?)
-    case internalServiceErrorException(message: String?)
-    case invalidRequestException(message: String?)
-    case resourceAlreadyExistsException(message: String?)
-    case resourceLimitExceededException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case resourceNotReadyException(message: String?)
-    case throttlingException(message: String?)
-}
+public struct ManagedBlockchainErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case illegalActionException = "IllegalActionException"
+        case internalServiceErrorException = "InternalServiceErrorException"
+        case invalidRequestException = "InvalidRequestException"
+        case resourceAlreadyExistsException = "ResourceAlreadyExistsException"
+        case resourceLimitExceededException = "ResourceLimitExceededException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case resourceNotReadyException = "ResourceNotReadyException"
+        case throttlingException = "ThrottlingException"
+    }
 
-extension ManagedBlockchainErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "IllegalActionException":
-            self = .illegalActionException(message: message)
-        case "InternalServiceErrorException":
-            self = .internalServiceErrorException(message: message)
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        case "ResourceAlreadyExistsException":
-            self = .resourceAlreadyExistsException(message: message)
-        case "ResourceLimitExceededException":
-            self = .resourceLimitExceededException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ResourceNotReadyException":
-            self = .resourceNotReadyException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var illegalActionException: Self { .init(.illegalActionException) }
+    public static var internalServiceErrorException: Self { .init(.internalServiceErrorException) }
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+    public static var resourceAlreadyExistsException: Self { .init(.resourceAlreadyExistsException) }
+    public static var resourceLimitExceededException: Self { .init(.resourceLimitExceededException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var resourceNotReadyException: Self { .init(.resourceNotReadyException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+}
+
+extension ManagedBlockchainErrorType: Equatable {
+    public static func == (lhs: ManagedBlockchainErrorType, rhs: ManagedBlockchainErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ManagedBlockchainErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .illegalActionException(let message):
-            return "IllegalActionException: \(message ?? "")"
-        case .internalServiceErrorException(let message):
-            return "InternalServiceErrorException: \(message ?? "")"
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        case .resourceAlreadyExistsException(let message):
-            return "ResourceAlreadyExistsException: \(message ?? "")"
-        case .resourceLimitExceededException(let message):
-            return "ResourceLimitExceededException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .resourceNotReadyException(let message):
-            return "ResourceNotReadyException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/MarketplaceCatalog/MarketplaceCatalog_Error.swift
+++ b/Sources/Soto/Services/MarketplaceCatalog/MarketplaceCatalog_Error.swift
@@ -17,65 +17,54 @@
 import SotoCore
 
 /// Error enum for MarketplaceCatalog
-public enum MarketplaceCatalogErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case internalServiceException(message: String?)
-    case resourceInUseException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case resourceNotSupportedException(message: String?)
-    case serviceQuotaExceededException(message: String?)
-    case throttlingException(message: String?)
-    case validationException(message: String?)
-}
+public struct MarketplaceCatalogErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case internalServiceException = "InternalServiceException"
+        case resourceInUseException = "ResourceInUseException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case resourceNotSupportedException = "ResourceNotSupportedException"
+        case serviceQuotaExceededException = "ServiceQuotaExceededException"
+        case throttlingException = "ThrottlingException"
+        case validationException = "ValidationException"
+    }
 
-extension MarketplaceCatalogErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "InternalServiceException":
-            self = .internalServiceException(message: message)
-        case "ResourceInUseException":
-            self = .resourceInUseException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ResourceNotSupportedException":
-            self = .resourceNotSupportedException(message: message)
-        case "ServiceQuotaExceededException":
-            self = .serviceQuotaExceededException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var internalServiceException: Self { .init(.internalServiceException) }
+    public static var resourceInUseException: Self { .init(.resourceInUseException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var resourceNotSupportedException: Self { .init(.resourceNotSupportedException) }
+    public static var serviceQuotaExceededException: Self { .init(.serviceQuotaExceededException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension MarketplaceCatalogErrorType: Equatable {
+    public static func == (lhs: MarketplaceCatalogErrorType, rhs: MarketplaceCatalogErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension MarketplaceCatalogErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .internalServiceException(let message):
-            return "InternalServiceException: \(message ?? "")"
-        case .resourceInUseException(let message):
-            return "ResourceInUseException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .resourceNotSupportedException(let message):
-            return "ResourceNotSupportedException: \(message ?? "")"
-        case .serviceQuotaExceededException(let message):
-            return "ServiceQuotaExceededException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/MarketplaceCommerceAnalytics/MarketplaceCommerceAnalytics_Error.swift
+++ b/Sources/Soto/Services/MarketplaceCommerceAnalytics/MarketplaceCommerceAnalytics_Error.swift
@@ -17,30 +17,40 @@
 import SotoCore
 
 /// Error enum for MarketplaceCommerceAnalytics
-public enum MarketplaceCommerceAnalyticsErrorType: AWSErrorType {
-    case marketplaceCommerceAnalyticsException(message: String?)
-}
+public struct MarketplaceCommerceAnalyticsErrorType: AWSErrorType {
+    enum Code: String {
+        case marketplaceCommerceAnalyticsException = "MarketplaceCommerceAnalyticsException"
+    }
 
-extension MarketplaceCommerceAnalyticsErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "MarketplaceCommerceAnalyticsException":
-            self = .marketplaceCommerceAnalyticsException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var marketplaceCommerceAnalyticsException: Self { .init(.marketplaceCommerceAnalyticsException) }
+}
+
+extension MarketplaceCommerceAnalyticsErrorType: Equatable {
+    public static func == (lhs: MarketplaceCommerceAnalyticsErrorType, rhs: MarketplaceCommerceAnalyticsErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension MarketplaceCommerceAnalyticsErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .marketplaceCommerceAnalyticsException(let message):
-            return "MarketplaceCommerceAnalyticsException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/MarketplaceEntitlementService/MarketplaceEntitlementService_Error.swift
+++ b/Sources/Soto/Services/MarketplaceEntitlementService/MarketplaceEntitlementService_Error.swift
@@ -17,40 +17,44 @@
 import SotoCore
 
 /// Error enum for MarketplaceEntitlementService
-public enum MarketplaceEntitlementServiceErrorType: AWSErrorType {
-    case internalServiceErrorException(message: String?)
-    case invalidParameterException(message: String?)
-    case throttlingException(message: String?)
-}
+public struct MarketplaceEntitlementServiceErrorType: AWSErrorType {
+    enum Code: String {
+        case internalServiceErrorException = "InternalServiceErrorException"
+        case invalidParameterException = "InvalidParameterException"
+        case throttlingException = "ThrottlingException"
+    }
 
-extension MarketplaceEntitlementServiceErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "InternalServiceErrorException":
-            self = .internalServiceErrorException(message: message)
-        case "InvalidParameterException":
-            self = .invalidParameterException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var internalServiceErrorException: Self { .init(.internalServiceErrorException) }
+    public static var invalidParameterException: Self { .init(.invalidParameterException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+}
+
+extension MarketplaceEntitlementServiceErrorType: Equatable {
+    public static func == (lhs: MarketplaceEntitlementServiceErrorType, rhs: MarketplaceEntitlementServiceErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension MarketplaceEntitlementServiceErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .internalServiceErrorException(let message):
-            return "InternalServiceErrorException: \(message ?? "")"
-        case .invalidParameterException(let message):
-            return "InvalidParameterException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/MarketplaceMetering/MarketplaceMetering_Error.swift
+++ b/Sources/Soto/Services/MarketplaceMetering/MarketplaceMetering_Error.swift
@@ -17,100 +17,68 @@
 import SotoCore
 
 /// Error enum for MarketplaceMetering
-public enum MarketplaceMeteringErrorType: AWSErrorType {
-    case customerNotEntitledException(message: String?)
-    case disabledApiException(message: String?)
-    case duplicateRequestException(message: String?)
-    case expiredTokenException(message: String?)
-    case internalServiceErrorException(message: String?)
-    case invalidCustomerIdentifierException(message: String?)
-    case invalidEndpointRegionException(message: String?)
-    case invalidProductCodeException(message: String?)
-    case invalidPublicKeyVersionException(message: String?)
-    case invalidRegionException(message: String?)
-    case invalidTokenException(message: String?)
-    case invalidUsageDimensionException(message: String?)
-    case platformNotSupportedException(message: String?)
-    case throttlingException(message: String?)
-    case timestampOutOfBoundsException(message: String?)
-}
+public struct MarketplaceMeteringErrorType: AWSErrorType {
+    enum Code: String {
+        case customerNotEntitledException = "CustomerNotEntitledException"
+        case disabledApiException = "DisabledApiException"
+        case duplicateRequestException = "DuplicateRequestException"
+        case expiredTokenException = "ExpiredTokenException"
+        case internalServiceErrorException = "InternalServiceErrorException"
+        case invalidCustomerIdentifierException = "InvalidCustomerIdentifierException"
+        case invalidEndpointRegionException = "InvalidEndpointRegionException"
+        case invalidProductCodeException = "InvalidProductCodeException"
+        case invalidPublicKeyVersionException = "InvalidPublicKeyVersionException"
+        case invalidRegionException = "InvalidRegionException"
+        case invalidTokenException = "InvalidTokenException"
+        case invalidUsageDimensionException = "InvalidUsageDimensionException"
+        case platformNotSupportedException = "PlatformNotSupportedException"
+        case throttlingException = "ThrottlingException"
+        case timestampOutOfBoundsException = "TimestampOutOfBoundsException"
+    }
 
-extension MarketplaceMeteringErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "CustomerNotEntitledException":
-            self = .customerNotEntitledException(message: message)
-        case "DisabledApiException":
-            self = .disabledApiException(message: message)
-        case "DuplicateRequestException":
-            self = .duplicateRequestException(message: message)
-        case "ExpiredTokenException":
-            self = .expiredTokenException(message: message)
-        case "InternalServiceErrorException":
-            self = .internalServiceErrorException(message: message)
-        case "InvalidCustomerIdentifierException":
-            self = .invalidCustomerIdentifierException(message: message)
-        case "InvalidEndpointRegionException":
-            self = .invalidEndpointRegionException(message: message)
-        case "InvalidProductCodeException":
-            self = .invalidProductCodeException(message: message)
-        case "InvalidPublicKeyVersionException":
-            self = .invalidPublicKeyVersionException(message: message)
-        case "InvalidRegionException":
-            self = .invalidRegionException(message: message)
-        case "InvalidTokenException":
-            self = .invalidTokenException(message: message)
-        case "InvalidUsageDimensionException":
-            self = .invalidUsageDimensionException(message: message)
-        case "PlatformNotSupportedException":
-            self = .platformNotSupportedException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        case "TimestampOutOfBoundsException":
-            self = .timestampOutOfBoundsException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var customerNotEntitledException: Self { .init(.customerNotEntitledException) }
+    public static var disabledApiException: Self { .init(.disabledApiException) }
+    public static var duplicateRequestException: Self { .init(.duplicateRequestException) }
+    public static var expiredTokenException: Self { .init(.expiredTokenException) }
+    public static var internalServiceErrorException: Self { .init(.internalServiceErrorException) }
+    public static var invalidCustomerIdentifierException: Self { .init(.invalidCustomerIdentifierException) }
+    public static var invalidEndpointRegionException: Self { .init(.invalidEndpointRegionException) }
+    public static var invalidProductCodeException: Self { .init(.invalidProductCodeException) }
+    public static var invalidPublicKeyVersionException: Self { .init(.invalidPublicKeyVersionException) }
+    public static var invalidRegionException: Self { .init(.invalidRegionException) }
+    public static var invalidTokenException: Self { .init(.invalidTokenException) }
+    public static var invalidUsageDimensionException: Self { .init(.invalidUsageDimensionException) }
+    public static var platformNotSupportedException: Self { .init(.platformNotSupportedException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+    public static var timestampOutOfBoundsException: Self { .init(.timestampOutOfBoundsException) }
+}
+
+extension MarketplaceMeteringErrorType: Equatable {
+    public static func == (lhs: MarketplaceMeteringErrorType, rhs: MarketplaceMeteringErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension MarketplaceMeteringErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .customerNotEntitledException(let message):
-            return "CustomerNotEntitledException: \(message ?? "")"
-        case .disabledApiException(let message):
-            return "DisabledApiException: \(message ?? "")"
-        case .duplicateRequestException(let message):
-            return "DuplicateRequestException: \(message ?? "")"
-        case .expiredTokenException(let message):
-            return "ExpiredTokenException: \(message ?? "")"
-        case .internalServiceErrorException(let message):
-            return "InternalServiceErrorException: \(message ?? "")"
-        case .invalidCustomerIdentifierException(let message):
-            return "InvalidCustomerIdentifierException: \(message ?? "")"
-        case .invalidEndpointRegionException(let message):
-            return "InvalidEndpointRegionException: \(message ?? "")"
-        case .invalidProductCodeException(let message):
-            return "InvalidProductCodeException: \(message ?? "")"
-        case .invalidPublicKeyVersionException(let message):
-            return "InvalidPublicKeyVersionException: \(message ?? "")"
-        case .invalidRegionException(let message):
-            return "InvalidRegionException: \(message ?? "")"
-        case .invalidTokenException(let message):
-            return "InvalidTokenException: \(message ?? "")"
-        case .invalidUsageDimensionException(let message):
-            return "InvalidUsageDimensionException: \(message ?? "")"
-        case .platformNotSupportedException(let message):
-            return "PlatformNotSupportedException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        case .timestampOutOfBoundsException(let message):
-            return "TimestampOutOfBoundsException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/MediaConnect/MediaConnect_Error.swift
+++ b/Sources/Soto/Services/MediaConnect/MediaConnect_Error.swift
@@ -17,70 +17,56 @@
 import SotoCore
 
 /// Error enum for MediaConnect
-public enum MediaConnectErrorType: AWSErrorType {
-    case addFlowOutputs420Exception(message: String?)
-    case badRequestException(message: String?)
-    case createFlow420Exception(message: String?)
-    case forbiddenException(message: String?)
-    case grantFlowEntitlements420Exception(message: String?)
-    case internalServerErrorException(message: String?)
-    case notFoundException(message: String?)
-    case serviceUnavailableException(message: String?)
-    case tooManyRequestsException(message: String?)
-}
+public struct MediaConnectErrorType: AWSErrorType {
+    enum Code: String {
+        case addFlowOutputs420Exception = "AddFlowOutputs420Exception"
+        case badRequestException = "BadRequestException"
+        case createFlow420Exception = "CreateFlow420Exception"
+        case forbiddenException = "ForbiddenException"
+        case grantFlowEntitlements420Exception = "GrantFlowEntitlements420Exception"
+        case internalServerErrorException = "InternalServerErrorException"
+        case notFoundException = "NotFoundException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+        case tooManyRequestsException = "TooManyRequestsException"
+    }
 
-extension MediaConnectErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AddFlowOutputs420Exception":
-            self = .addFlowOutputs420Exception(message: message)
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        case "CreateFlow420Exception":
-            self = .createFlow420Exception(message: message)
-        case "ForbiddenException":
-            self = .forbiddenException(message: message)
-        case "GrantFlowEntitlements420Exception":
-            self = .grantFlowEntitlements420Exception(message: message)
-        case "InternalServerErrorException":
-            self = .internalServerErrorException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        case "TooManyRequestsException":
-            self = .tooManyRequestsException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var addFlowOutputs420Exception: Self { .init(.addFlowOutputs420Exception) }
+    public static var badRequestException: Self { .init(.badRequestException) }
+    public static var createFlow420Exception: Self { .init(.createFlow420Exception) }
+    public static var forbiddenException: Self { .init(.forbiddenException) }
+    public static var grantFlowEntitlements420Exception: Self { .init(.grantFlowEntitlements420Exception) }
+    public static var internalServerErrorException: Self { .init(.internalServerErrorException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+    public static var tooManyRequestsException: Self { .init(.tooManyRequestsException) }
+}
+
+extension MediaConnectErrorType: Equatable {
+    public static func == (lhs: MediaConnectErrorType, rhs: MediaConnectErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension MediaConnectErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .addFlowOutputs420Exception(let message):
-            return "AddFlowOutputs420Exception: \(message ?? "")"
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        case .createFlow420Exception(let message):
-            return "CreateFlow420Exception: \(message ?? "")"
-        case .forbiddenException(let message):
-            return "ForbiddenException: \(message ?? "")"
-        case .grantFlowEntitlements420Exception(let message):
-            return "GrantFlowEntitlements420Exception: \(message ?? "")"
-        case .internalServerErrorException(let message):
-            return "InternalServerErrorException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        case .tooManyRequestsException(let message):
-            return "TooManyRequestsException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/MediaConvert/MediaConvert_Error.swift
+++ b/Sources/Soto/Services/MediaConvert/MediaConvert_Error.swift
@@ -17,55 +17,50 @@
 import SotoCore
 
 /// Error enum for MediaConvert
-public enum MediaConvertErrorType: AWSErrorType {
-    case badRequestException(message: String?)
-    case conflictException(message: String?)
-    case forbiddenException(message: String?)
-    case internalServerErrorException(message: String?)
-    case notFoundException(message: String?)
-    case tooManyRequestsException(message: String?)
-}
+public struct MediaConvertErrorType: AWSErrorType {
+    enum Code: String {
+        case badRequestException = "BadRequestException"
+        case conflictException = "ConflictException"
+        case forbiddenException = "ForbiddenException"
+        case internalServerErrorException = "InternalServerErrorException"
+        case notFoundException = "NotFoundException"
+        case tooManyRequestsException = "TooManyRequestsException"
+    }
 
-extension MediaConvertErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "ForbiddenException":
-            self = .forbiddenException(message: message)
-        case "InternalServerErrorException":
-            self = .internalServerErrorException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "TooManyRequestsException":
-            self = .tooManyRequestsException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var badRequestException: Self { .init(.badRequestException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var forbiddenException: Self { .init(.forbiddenException) }
+    public static var internalServerErrorException: Self { .init(.internalServerErrorException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var tooManyRequestsException: Self { .init(.tooManyRequestsException) }
+}
+
+extension MediaConvertErrorType: Equatable {
+    public static func == (lhs: MediaConvertErrorType, rhs: MediaConvertErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension MediaConvertErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .forbiddenException(let message):
-            return "ForbiddenException: \(message ?? "")"
-        case .internalServerErrorException(let message):
-            return "InternalServerErrorException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .tooManyRequestsException(let message):
-            return "TooManyRequestsException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/MediaLive/MediaLive_Error.swift
+++ b/Sources/Soto/Services/MediaLive/MediaLive_Error.swift
@@ -17,70 +17,56 @@
 import SotoCore
 
 /// Error enum for MediaLive
-public enum MediaLiveErrorType: AWSErrorType {
-    case badGatewayException(message: String?)
-    case badRequestException(message: String?)
-    case conflictException(message: String?)
-    case forbiddenException(message: String?)
-    case gatewayTimeoutException(message: String?)
-    case internalServerErrorException(message: String?)
-    case notFoundException(message: String?)
-    case tooManyRequestsException(message: String?)
-    case unprocessableEntityException(message: String?)
-}
+public struct MediaLiveErrorType: AWSErrorType {
+    enum Code: String {
+        case badGatewayException = "BadGatewayException"
+        case badRequestException = "BadRequestException"
+        case conflictException = "ConflictException"
+        case forbiddenException = "ForbiddenException"
+        case gatewayTimeoutException = "GatewayTimeoutException"
+        case internalServerErrorException = "InternalServerErrorException"
+        case notFoundException = "NotFoundException"
+        case tooManyRequestsException = "TooManyRequestsException"
+        case unprocessableEntityException = "UnprocessableEntityException"
+    }
 
-extension MediaLiveErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "BadGatewayException":
-            self = .badGatewayException(message: message)
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "ForbiddenException":
-            self = .forbiddenException(message: message)
-        case "GatewayTimeoutException":
-            self = .gatewayTimeoutException(message: message)
-        case "InternalServerErrorException":
-            self = .internalServerErrorException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "TooManyRequestsException":
-            self = .tooManyRequestsException(message: message)
-        case "UnprocessableEntityException":
-            self = .unprocessableEntityException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var badGatewayException: Self { .init(.badGatewayException) }
+    public static var badRequestException: Self { .init(.badRequestException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var forbiddenException: Self { .init(.forbiddenException) }
+    public static var gatewayTimeoutException: Self { .init(.gatewayTimeoutException) }
+    public static var internalServerErrorException: Self { .init(.internalServerErrorException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var tooManyRequestsException: Self { .init(.tooManyRequestsException) }
+    public static var unprocessableEntityException: Self { .init(.unprocessableEntityException) }
+}
+
+extension MediaLiveErrorType: Equatable {
+    public static func == (lhs: MediaLiveErrorType, rhs: MediaLiveErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension MediaLiveErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .badGatewayException(let message):
-            return "BadGatewayException: \(message ?? "")"
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .forbiddenException(let message):
-            return "ForbiddenException: \(message ?? "")"
-        case .gatewayTimeoutException(let message):
-            return "GatewayTimeoutException: \(message ?? "")"
-        case .internalServerErrorException(let message):
-            return "InternalServerErrorException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .tooManyRequestsException(let message):
-            return "TooManyRequestsException: \(message ?? "")"
-        case .unprocessableEntityException(let message):
-            return "UnprocessableEntityException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/MediaPackage/MediaPackage_Error.swift
+++ b/Sources/Soto/Services/MediaPackage/MediaPackage_Error.swift
@@ -17,55 +17,50 @@
 import SotoCore
 
 /// Error enum for MediaPackage
-public enum MediaPackageErrorType: AWSErrorType {
-    case forbiddenException(message: String?)
-    case internalServerErrorException(message: String?)
-    case notFoundException(message: String?)
-    case serviceUnavailableException(message: String?)
-    case tooManyRequestsException(message: String?)
-    case unprocessableEntityException(message: String?)
-}
+public struct MediaPackageErrorType: AWSErrorType {
+    enum Code: String {
+        case forbiddenException = "ForbiddenException"
+        case internalServerErrorException = "InternalServerErrorException"
+        case notFoundException = "NotFoundException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+        case tooManyRequestsException = "TooManyRequestsException"
+        case unprocessableEntityException = "UnprocessableEntityException"
+    }
 
-extension MediaPackageErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ForbiddenException":
-            self = .forbiddenException(message: message)
-        case "InternalServerErrorException":
-            self = .internalServerErrorException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        case "TooManyRequestsException":
-            self = .tooManyRequestsException(message: message)
-        case "UnprocessableEntityException":
-            self = .unprocessableEntityException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var forbiddenException: Self { .init(.forbiddenException) }
+    public static var internalServerErrorException: Self { .init(.internalServerErrorException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+    public static var tooManyRequestsException: Self { .init(.tooManyRequestsException) }
+    public static var unprocessableEntityException: Self { .init(.unprocessableEntityException) }
+}
+
+extension MediaPackageErrorType: Equatable {
+    public static func == (lhs: MediaPackageErrorType, rhs: MediaPackageErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension MediaPackageErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .forbiddenException(let message):
-            return "ForbiddenException: \(message ?? "")"
-        case .internalServerErrorException(let message):
-            return "InternalServerErrorException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        case .tooManyRequestsException(let message):
-            return "TooManyRequestsException: \(message ?? "")"
-        case .unprocessableEntityException(let message):
-            return "UnprocessableEntityException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/MediaPackageVod/MediaPackageVod_Error.swift
+++ b/Sources/Soto/Services/MediaPackageVod/MediaPackageVod_Error.swift
@@ -17,55 +17,50 @@
 import SotoCore
 
 /// Error enum for MediaPackageVod
-public enum MediaPackageVodErrorType: AWSErrorType {
-    case forbiddenException(message: String?)
-    case internalServerErrorException(message: String?)
-    case notFoundException(message: String?)
-    case serviceUnavailableException(message: String?)
-    case tooManyRequestsException(message: String?)
-    case unprocessableEntityException(message: String?)
-}
+public struct MediaPackageVodErrorType: AWSErrorType {
+    enum Code: String {
+        case forbiddenException = "ForbiddenException"
+        case internalServerErrorException = "InternalServerErrorException"
+        case notFoundException = "NotFoundException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+        case tooManyRequestsException = "TooManyRequestsException"
+        case unprocessableEntityException = "UnprocessableEntityException"
+    }
 
-extension MediaPackageVodErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ForbiddenException":
-            self = .forbiddenException(message: message)
-        case "InternalServerErrorException":
-            self = .internalServerErrorException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        case "TooManyRequestsException":
-            self = .tooManyRequestsException(message: message)
-        case "UnprocessableEntityException":
-            self = .unprocessableEntityException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var forbiddenException: Self { .init(.forbiddenException) }
+    public static var internalServerErrorException: Self { .init(.internalServerErrorException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+    public static var tooManyRequestsException: Self { .init(.tooManyRequestsException) }
+    public static var unprocessableEntityException: Self { .init(.unprocessableEntityException) }
+}
+
+extension MediaPackageVodErrorType: Equatable {
+    public static func == (lhs: MediaPackageVodErrorType, rhs: MediaPackageVodErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension MediaPackageVodErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .forbiddenException(let message):
-            return "ForbiddenException: \(message ?? "")"
-        case .internalServerErrorException(let message):
-            return "InternalServerErrorException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        case .tooManyRequestsException(let message):
-            return "TooManyRequestsException: \(message ?? "")"
-        case .unprocessableEntityException(let message):
-            return "UnprocessableEntityException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/MediaStore/MediaStore_Error.swift
+++ b/Sources/Soto/Services/MediaStore/MediaStore_Error.swift
@@ -17,55 +17,50 @@
 import SotoCore
 
 /// Error enum for MediaStore
-public enum MediaStoreErrorType: AWSErrorType {
-    case containerInUseException(message: String?)
-    case containerNotFoundException(message: String?)
-    case corsPolicyNotFoundException(message: String?)
-    case internalServerError(message: String?)
-    case limitExceededException(message: String?)
-    case policyNotFoundException(message: String?)
-}
+public struct MediaStoreErrorType: AWSErrorType {
+    enum Code: String {
+        case containerInUseException = "ContainerInUseException"
+        case containerNotFoundException = "ContainerNotFoundException"
+        case corsPolicyNotFoundException = "CorsPolicyNotFoundException"
+        case internalServerError = "InternalServerError"
+        case limitExceededException = "LimitExceededException"
+        case policyNotFoundException = "PolicyNotFoundException"
+    }
 
-extension MediaStoreErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ContainerInUseException":
-            self = .containerInUseException(message: message)
-        case "ContainerNotFoundException":
-            self = .containerNotFoundException(message: message)
-        case "CorsPolicyNotFoundException":
-            self = .corsPolicyNotFoundException(message: message)
-        case "InternalServerError":
-            self = .internalServerError(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "PolicyNotFoundException":
-            self = .policyNotFoundException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var containerInUseException: Self { .init(.containerInUseException) }
+    public static var containerNotFoundException: Self { .init(.containerNotFoundException) }
+    public static var corsPolicyNotFoundException: Self { .init(.corsPolicyNotFoundException) }
+    public static var internalServerError: Self { .init(.internalServerError) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var policyNotFoundException: Self { .init(.policyNotFoundException) }
+}
+
+extension MediaStoreErrorType: Equatable {
+    public static func == (lhs: MediaStoreErrorType, rhs: MediaStoreErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension MediaStoreErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .containerInUseException(let message):
-            return "ContainerInUseException: \(message ?? "")"
-        case .containerNotFoundException(let message):
-            return "ContainerNotFoundException: \(message ?? "")"
-        case .corsPolicyNotFoundException(let message):
-            return "CorsPolicyNotFoundException: \(message ?? "")"
-        case .internalServerError(let message):
-            return "InternalServerError: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .policyNotFoundException(let message):
-            return "PolicyNotFoundException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/MediaStoreData/MediaStoreData_Error.swift
+++ b/Sources/Soto/Services/MediaStoreData/MediaStoreData_Error.swift
@@ -17,45 +17,46 @@
 import SotoCore
 
 /// Error enum for MediaStoreData
-public enum MediaStoreDataErrorType: AWSErrorType {
-    case containerNotFoundException(message: String?)
-    case internalServerError(message: String?)
-    case objectNotFoundException(message: String?)
-    case requestedRangeNotSatisfiableException(message: String?)
-}
+public struct MediaStoreDataErrorType: AWSErrorType {
+    enum Code: String {
+        case containerNotFoundException = "ContainerNotFoundException"
+        case internalServerError = "InternalServerError"
+        case objectNotFoundException = "ObjectNotFoundException"
+        case requestedRangeNotSatisfiableException = "RequestedRangeNotSatisfiableException"
+    }
 
-extension MediaStoreDataErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ContainerNotFoundException":
-            self = .containerNotFoundException(message: message)
-        case "InternalServerError":
-            self = .internalServerError(message: message)
-        case "ObjectNotFoundException":
-            self = .objectNotFoundException(message: message)
-        case "RequestedRangeNotSatisfiableException":
-            self = .requestedRangeNotSatisfiableException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var containerNotFoundException: Self { .init(.containerNotFoundException) }
+    public static var internalServerError: Self { .init(.internalServerError) }
+    public static var objectNotFoundException: Self { .init(.objectNotFoundException) }
+    public static var requestedRangeNotSatisfiableException: Self { .init(.requestedRangeNotSatisfiableException) }
+}
+
+extension MediaStoreDataErrorType: Equatable {
+    public static func == (lhs: MediaStoreDataErrorType, rhs: MediaStoreDataErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension MediaStoreDataErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .containerNotFoundException(let message):
-            return "ContainerNotFoundException: \(message ?? "")"
-        case .internalServerError(let message):
-            return "InternalServerError: \(message ?? "")"
-        case .objectNotFoundException(let message):
-            return "ObjectNotFoundException: \(message ?? "")"
-        case .requestedRangeNotSatisfiableException(let message):
-            return "RequestedRangeNotSatisfiableException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/MediaTailor/MediaTailor_Error.swift
+++ b/Sources/Soto/Services/MediaTailor/MediaTailor_Error.swift
@@ -17,30 +17,40 @@
 import SotoCore
 
 /// Error enum for MediaTailor
-public enum MediaTailorErrorType: AWSErrorType {
-    case badRequestException(message: String?)
-}
+public struct MediaTailorErrorType: AWSErrorType {
+    enum Code: String {
+        case badRequestException = "BadRequestException"
+    }
 
-extension MediaTailorErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var badRequestException: Self { .init(.badRequestException) }
+}
+
+extension MediaTailorErrorType: Equatable {
+    public static func == (lhs: MediaTailorErrorType, rhs: MediaTailorErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension MediaTailorErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/MigrationHub/MigrationHub_Error.swift
+++ b/Sources/Soto/Services/MigrationHub/MigrationHub_Error.swift
@@ -17,75 +17,58 @@
 import SotoCore
 
 /// Error enum for MigrationHub
-public enum MigrationHubErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case dryRunOperation(message: String?)
-    case homeRegionNotSetException(message: String?)
-    case internalServerError(message: String?)
-    case invalidInputException(message: String?)
-    case policyErrorException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceUnavailableException(message: String?)
-    case throttlingException(message: String?)
-    case unauthorizedOperation(message: String?)
-}
+public struct MigrationHubErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case dryRunOperation = "DryRunOperation"
+        case homeRegionNotSetException = "HomeRegionNotSetException"
+        case internalServerError = "InternalServerError"
+        case invalidInputException = "InvalidInputException"
+        case policyErrorException = "PolicyErrorException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+        case throttlingException = "ThrottlingException"
+        case unauthorizedOperation = "UnauthorizedOperation"
+    }
 
-extension MigrationHubErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "DryRunOperation":
-            self = .dryRunOperation(message: message)
-        case "HomeRegionNotSetException":
-            self = .homeRegionNotSetException(message: message)
-        case "InternalServerError":
-            self = .internalServerError(message: message)
-        case "InvalidInputException":
-            self = .invalidInputException(message: message)
-        case "PolicyErrorException":
-            self = .policyErrorException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        case "UnauthorizedOperation":
-            self = .unauthorizedOperation(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var dryRunOperation: Self { .init(.dryRunOperation) }
+    public static var homeRegionNotSetException: Self { .init(.homeRegionNotSetException) }
+    public static var internalServerError: Self { .init(.internalServerError) }
+    public static var invalidInputException: Self { .init(.invalidInputException) }
+    public static var policyErrorException: Self { .init(.policyErrorException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+    public static var unauthorizedOperation: Self { .init(.unauthorizedOperation) }
+}
+
+extension MigrationHubErrorType: Equatable {
+    public static func == (lhs: MigrationHubErrorType, rhs: MigrationHubErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension MigrationHubErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .dryRunOperation(let message):
-            return "DryRunOperation: \(message ?? "")"
-        case .homeRegionNotSetException(let message):
-            return "HomeRegionNotSetException: \(message ?? "")"
-        case .internalServerError(let message):
-            return "InternalServerError: \(message ?? "")"
-        case .invalidInputException(let message):
-            return "InvalidInputException: \(message ?? "")"
-        case .policyErrorException(let message):
-            return "PolicyErrorException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        case .unauthorizedOperation(let message):
-            return "UnauthorizedOperation: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/MigrationHubConfig/MigrationHubConfig_Error.swift
+++ b/Sources/Soto/Services/MigrationHubConfig/MigrationHubConfig_Error.swift
@@ -17,55 +17,50 @@
 import SotoCore
 
 /// Error enum for MigrationHubConfig
-public enum MigrationHubConfigErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case dryRunOperation(message: String?)
-    case internalServerError(message: String?)
-    case invalidInputException(message: String?)
-    case serviceUnavailableException(message: String?)
-    case throttlingException(message: String?)
-}
+public struct MigrationHubConfigErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case dryRunOperation = "DryRunOperation"
+        case internalServerError = "InternalServerError"
+        case invalidInputException = "InvalidInputException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+        case throttlingException = "ThrottlingException"
+    }
 
-extension MigrationHubConfigErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "DryRunOperation":
-            self = .dryRunOperation(message: message)
-        case "InternalServerError":
-            self = .internalServerError(message: message)
-        case "InvalidInputException":
-            self = .invalidInputException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var dryRunOperation: Self { .init(.dryRunOperation) }
+    public static var internalServerError: Self { .init(.internalServerError) }
+    public static var invalidInputException: Self { .init(.invalidInputException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+}
+
+extension MigrationHubConfigErrorType: Equatable {
+    public static func == (lhs: MigrationHubConfigErrorType, rhs: MigrationHubConfigErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension MigrationHubConfigErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .dryRunOperation(let message):
-            return "DryRunOperation: \(message ?? "")"
-        case .internalServerError(let message):
-            return "InternalServerError: \(message ?? "")"
-        case .invalidInputException(let message):
-            return "InvalidInputException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Mobile/Mobile_Error.swift
+++ b/Sources/Soto/Services/Mobile/Mobile_Error.swift
@@ -17,65 +17,54 @@
 import SotoCore
 
 /// Error enum for Mobile
-public enum MobileErrorType: AWSErrorType {
-    case accountActionRequiredException(message: String?)
-    case badRequestException(message: String?)
-    case internalFailureException(message: String?)
-    case limitExceededException(message: String?)
-    case notFoundException(message: String?)
-    case serviceUnavailableException(message: String?)
-    case tooManyRequestsException(message: String?)
-    case unauthorizedException(message: String?)
-}
+public struct MobileErrorType: AWSErrorType {
+    enum Code: String {
+        case accountActionRequiredException = "AccountActionRequiredException"
+        case badRequestException = "BadRequestException"
+        case internalFailureException = "InternalFailureException"
+        case limitExceededException = "LimitExceededException"
+        case notFoundException = "NotFoundException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+        case tooManyRequestsException = "TooManyRequestsException"
+        case unauthorizedException = "UnauthorizedException"
+    }
 
-extension MobileErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccountActionRequiredException":
-            self = .accountActionRequiredException(message: message)
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        case "InternalFailureException":
-            self = .internalFailureException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        case "TooManyRequestsException":
-            self = .tooManyRequestsException(message: message)
-        case "UnauthorizedException":
-            self = .unauthorizedException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accountActionRequiredException: Self { .init(.accountActionRequiredException) }
+    public static var badRequestException: Self { .init(.badRequestException) }
+    public static var internalFailureException: Self { .init(.internalFailureException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+    public static var tooManyRequestsException: Self { .init(.tooManyRequestsException) }
+    public static var unauthorizedException: Self { .init(.unauthorizedException) }
+}
+
+extension MobileErrorType: Equatable {
+    public static func == (lhs: MobileErrorType, rhs: MobileErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension MobileErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accountActionRequiredException(let message):
-            return "AccountActionRequiredException: \(message ?? "")"
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        case .internalFailureException(let message):
-            return "InternalFailureException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        case .tooManyRequestsException(let message):
-            return "TooManyRequestsException: \(message ?? "")"
-        case .unauthorizedException(let message):
-            return "UnauthorizedException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/MobileAnalytics/MobileAnalytics_Error.swift
+++ b/Sources/Soto/Services/MobileAnalytics/MobileAnalytics_Error.swift
@@ -17,30 +17,40 @@
 import SotoCore
 
 /// Error enum for MobileAnalytics
-public enum MobileAnalyticsErrorType: AWSErrorType {
-    case badRequestException(message: String?)
-}
+public struct MobileAnalyticsErrorType: AWSErrorType {
+    enum Code: String {
+        case badRequestException = "BadRequestException"
+    }
 
-extension MobileAnalyticsErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var badRequestException: Self { .init(.badRequestException) }
+}
+
+extension MobileAnalyticsErrorType: Equatable {
+    public static func == (lhs: MobileAnalyticsErrorType, rhs: MobileAnalyticsErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension MobileAnalyticsErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Neptune/Neptune_Error.swift
+++ b/Sources/Soto/Services/Neptune/Neptune_Error.swift
@@ -17,320 +17,156 @@
 import SotoCore
 
 /// Error enum for Neptune
-public enum NeptuneErrorType: AWSErrorType {
-    case authorizationNotFoundFault(message: String?)
-    case certificateNotFoundFault(message: String?)
-    case dBClusterAlreadyExistsFault(message: String?)
-    case dBClusterNotFoundFault(message: String?)
-    case dBClusterParameterGroupNotFoundFault(message: String?)
-    case dBClusterQuotaExceededFault(message: String?)
-    case dBClusterRoleAlreadyExistsFault(message: String?)
-    case dBClusterRoleNotFoundFault(message: String?)
-    case dBClusterRoleQuotaExceededFault(message: String?)
-    case dBClusterSnapshotAlreadyExistsFault(message: String?)
-    case dBClusterSnapshotNotFoundFault(message: String?)
-    case dBInstanceAlreadyExistsFault(message: String?)
-    case dBInstanceNotFoundFault(message: String?)
-    case dBParameterGroupAlreadyExistsFault(message: String?)
-    case dBParameterGroupNotFoundFault(message: String?)
-    case dBParameterGroupQuotaExceededFault(message: String?)
-    case dBSecurityGroupNotFoundFault(message: String?)
-    case dBSnapshotAlreadyExistsFault(message: String?)
-    case dBSnapshotNotFoundFault(message: String?)
-    case dBSubnetGroupAlreadyExistsFault(message: String?)
-    case dBSubnetGroupDoesNotCoverEnoughAZs(message: String?)
-    case dBSubnetGroupNotFoundFault(message: String?)
-    case dBSubnetGroupQuotaExceededFault(message: String?)
-    case dBSubnetQuotaExceededFault(message: String?)
-    case dBUpgradeDependencyFailureFault(message: String?)
-    case domainNotFoundFault(message: String?)
-    case eventSubscriptionQuotaExceededFault(message: String?)
-    case instanceQuotaExceededFault(message: String?)
-    case insufficientDBClusterCapacityFault(message: String?)
-    case insufficientDBInstanceCapacityFault(message: String?)
-    case insufficientStorageClusterCapacityFault(message: String?)
-    case invalidDBClusterSnapshotStateFault(message: String?)
-    case invalidDBClusterStateFault(message: String?)
-    case invalidDBInstanceStateFault(message: String?)
-    case invalidDBParameterGroupStateFault(message: String?)
-    case invalidDBSecurityGroupStateFault(message: String?)
-    case invalidDBSnapshotStateFault(message: String?)
-    case invalidDBSubnetGroupStateFault(message: String?)
-    case invalidDBSubnetStateFault(message: String?)
-    case invalidEventSubscriptionStateFault(message: String?)
-    case invalidRestoreFault(message: String?)
-    case invalidSubnet(message: String?)
-    case invalidVPCNetworkStateFault(message: String?)
-    case kMSKeyNotAccessibleFault(message: String?)
-    case optionGroupNotFoundFault(message: String?)
-    case provisionedIopsNotAvailableInAZFault(message: String?)
-    case resourceNotFoundFault(message: String?)
-    case sNSInvalidTopicFault(message: String?)
-    case sNSNoAuthorizationFault(message: String?)
-    case sNSTopicArnNotFoundFault(message: String?)
-    case sharedSnapshotQuotaExceededFault(message: String?)
-    case snapshotQuotaExceededFault(message: String?)
-    case sourceNotFoundFault(message: String?)
-    case storageQuotaExceededFault(message: String?)
-    case storageTypeNotSupportedFault(message: String?)
-    case subnetAlreadyInUse(message: String?)
-    case subscriptionAlreadyExistFault(message: String?)
-    case subscriptionCategoryNotFoundFault(message: String?)
-    case subscriptionNotFoundFault(message: String?)
-}
+public struct NeptuneErrorType: AWSErrorType {
+    enum Code: String {
+        case authorizationNotFoundFault = "AuthorizationNotFound"
+        case certificateNotFoundFault = "CertificateNotFound"
+        case dBClusterAlreadyExistsFault = "DBClusterAlreadyExistsFault"
+        case dBClusterNotFoundFault = "DBClusterNotFoundFault"
+        case dBClusterParameterGroupNotFoundFault = "DBClusterParameterGroupNotFound"
+        case dBClusterQuotaExceededFault = "DBClusterQuotaExceededFault"
+        case dBClusterRoleAlreadyExistsFault = "DBClusterRoleAlreadyExists"
+        case dBClusterRoleNotFoundFault = "DBClusterRoleNotFound"
+        case dBClusterRoleQuotaExceededFault = "DBClusterRoleQuotaExceeded"
+        case dBClusterSnapshotAlreadyExistsFault = "DBClusterSnapshotAlreadyExistsFault"
+        case dBClusterSnapshotNotFoundFault = "DBClusterSnapshotNotFoundFault"
+        case dBInstanceAlreadyExistsFault = "DBInstanceAlreadyExists"
+        case dBInstanceNotFoundFault = "DBInstanceNotFound"
+        case dBParameterGroupAlreadyExistsFault = "DBParameterGroupAlreadyExists"
+        case dBParameterGroupNotFoundFault = "DBParameterGroupNotFound"
+        case dBParameterGroupQuotaExceededFault = "DBParameterGroupQuotaExceeded"
+        case dBSecurityGroupNotFoundFault = "DBSecurityGroupNotFound"
+        case dBSnapshotAlreadyExistsFault = "DBSnapshotAlreadyExists"
+        case dBSnapshotNotFoundFault = "DBSnapshotNotFound"
+        case dBSubnetGroupAlreadyExistsFault = "DBSubnetGroupAlreadyExists"
+        case dBSubnetGroupDoesNotCoverEnoughAZs = "DBSubnetGroupDoesNotCoverEnoughAZs"
+        case dBSubnetGroupNotFoundFault = "DBSubnetGroupNotFoundFault"
+        case dBSubnetGroupQuotaExceededFault = "DBSubnetGroupQuotaExceeded"
+        case dBSubnetQuotaExceededFault = "DBSubnetQuotaExceededFault"
+        case dBUpgradeDependencyFailureFault = "DBUpgradeDependencyFailure"
+        case domainNotFoundFault = "DomainNotFoundFault"
+        case eventSubscriptionQuotaExceededFault = "EventSubscriptionQuotaExceeded"
+        case instanceQuotaExceededFault = "InstanceQuotaExceeded"
+        case insufficientDBClusterCapacityFault = "InsufficientDBClusterCapacityFault"
+        case insufficientDBInstanceCapacityFault = "InsufficientDBInstanceCapacity"
+        case insufficientStorageClusterCapacityFault = "InsufficientStorageClusterCapacity"
+        case invalidDBClusterSnapshotStateFault = "InvalidDBClusterSnapshotStateFault"
+        case invalidDBClusterStateFault = "InvalidDBClusterStateFault"
+        case invalidDBInstanceStateFault = "InvalidDBInstanceState"
+        case invalidDBParameterGroupStateFault = "InvalidDBParameterGroupState"
+        case invalidDBSecurityGroupStateFault = "InvalidDBSecurityGroupState"
+        case invalidDBSnapshotStateFault = "InvalidDBSnapshotState"
+        case invalidDBSubnetGroupStateFault = "InvalidDBSubnetGroupStateFault"
+        case invalidDBSubnetStateFault = "InvalidDBSubnetStateFault"
+        case invalidEventSubscriptionStateFault = "InvalidEventSubscriptionState"
+        case invalidRestoreFault = "InvalidRestoreFault"
+        case invalidSubnet = "InvalidSubnet"
+        case invalidVPCNetworkStateFault = "InvalidVPCNetworkStateFault"
+        case kMSKeyNotAccessibleFault = "KMSKeyNotAccessibleFault"
+        case optionGroupNotFoundFault = "OptionGroupNotFoundFault"
+        case provisionedIopsNotAvailableInAZFault = "ProvisionedIopsNotAvailableInAZFault"
+        case resourceNotFoundFault = "ResourceNotFoundFault"
+        case sNSInvalidTopicFault = "SNSInvalidTopic"
+        case sNSNoAuthorizationFault = "SNSNoAuthorization"
+        case sNSTopicArnNotFoundFault = "SNSTopicArnNotFound"
+        case sharedSnapshotQuotaExceededFault = "SharedSnapshotQuotaExceeded"
+        case snapshotQuotaExceededFault = "SnapshotQuotaExceeded"
+        case sourceNotFoundFault = "SourceNotFound"
+        case storageQuotaExceededFault = "StorageQuotaExceeded"
+        case storageTypeNotSupportedFault = "StorageTypeNotSupported"
+        case subnetAlreadyInUse = "SubnetAlreadyInUse"
+        case subscriptionAlreadyExistFault = "SubscriptionAlreadyExist"
+        case subscriptionCategoryNotFoundFault = "SubscriptionCategoryNotFound"
+        case subscriptionNotFoundFault = "SubscriptionNotFound"
+    }
 
-extension NeptuneErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AuthorizationNotFound":
-            self = .authorizationNotFoundFault(message: message)
-        case "CertificateNotFound":
-            self = .certificateNotFoundFault(message: message)
-        case "DBClusterAlreadyExistsFault":
-            self = .dBClusterAlreadyExistsFault(message: message)
-        case "DBClusterNotFoundFault":
-            self = .dBClusterNotFoundFault(message: message)
-        case "DBClusterParameterGroupNotFound":
-            self = .dBClusterParameterGroupNotFoundFault(message: message)
-        case "DBClusterQuotaExceededFault":
-            self = .dBClusterQuotaExceededFault(message: message)
-        case "DBClusterRoleAlreadyExists":
-            self = .dBClusterRoleAlreadyExistsFault(message: message)
-        case "DBClusterRoleNotFound":
-            self = .dBClusterRoleNotFoundFault(message: message)
-        case "DBClusterRoleQuotaExceeded":
-            self = .dBClusterRoleQuotaExceededFault(message: message)
-        case "DBClusterSnapshotAlreadyExistsFault":
-            self = .dBClusterSnapshotAlreadyExistsFault(message: message)
-        case "DBClusterSnapshotNotFoundFault":
-            self = .dBClusterSnapshotNotFoundFault(message: message)
-        case "DBInstanceAlreadyExists":
-            self = .dBInstanceAlreadyExistsFault(message: message)
-        case "DBInstanceNotFound":
-            self = .dBInstanceNotFoundFault(message: message)
-        case "DBParameterGroupAlreadyExists":
-            self = .dBParameterGroupAlreadyExistsFault(message: message)
-        case "DBParameterGroupNotFound":
-            self = .dBParameterGroupNotFoundFault(message: message)
-        case "DBParameterGroupQuotaExceeded":
-            self = .dBParameterGroupQuotaExceededFault(message: message)
-        case "DBSecurityGroupNotFound":
-            self = .dBSecurityGroupNotFoundFault(message: message)
-        case "DBSnapshotAlreadyExists":
-            self = .dBSnapshotAlreadyExistsFault(message: message)
-        case "DBSnapshotNotFound":
-            self = .dBSnapshotNotFoundFault(message: message)
-        case "DBSubnetGroupAlreadyExists":
-            self = .dBSubnetGroupAlreadyExistsFault(message: message)
-        case "DBSubnetGroupDoesNotCoverEnoughAZs":
-            self = .dBSubnetGroupDoesNotCoverEnoughAZs(message: message)
-        case "DBSubnetGroupNotFoundFault":
-            self = .dBSubnetGroupNotFoundFault(message: message)
-        case "DBSubnetGroupQuotaExceeded":
-            self = .dBSubnetGroupQuotaExceededFault(message: message)
-        case "DBSubnetQuotaExceededFault":
-            self = .dBSubnetQuotaExceededFault(message: message)
-        case "DBUpgradeDependencyFailure":
-            self = .dBUpgradeDependencyFailureFault(message: message)
-        case "DomainNotFoundFault":
-            self = .domainNotFoundFault(message: message)
-        case "EventSubscriptionQuotaExceeded":
-            self = .eventSubscriptionQuotaExceededFault(message: message)
-        case "InstanceQuotaExceeded":
-            self = .instanceQuotaExceededFault(message: message)
-        case "InsufficientDBClusterCapacityFault":
-            self = .insufficientDBClusterCapacityFault(message: message)
-        case "InsufficientDBInstanceCapacity":
-            self = .insufficientDBInstanceCapacityFault(message: message)
-        case "InsufficientStorageClusterCapacity":
-            self = .insufficientStorageClusterCapacityFault(message: message)
-        case "InvalidDBClusterSnapshotStateFault":
-            self = .invalidDBClusterSnapshotStateFault(message: message)
-        case "InvalidDBClusterStateFault":
-            self = .invalidDBClusterStateFault(message: message)
-        case "InvalidDBInstanceState":
-            self = .invalidDBInstanceStateFault(message: message)
-        case "InvalidDBParameterGroupState":
-            self = .invalidDBParameterGroupStateFault(message: message)
-        case "InvalidDBSecurityGroupState":
-            self = .invalidDBSecurityGroupStateFault(message: message)
-        case "InvalidDBSnapshotState":
-            self = .invalidDBSnapshotStateFault(message: message)
-        case "InvalidDBSubnetGroupStateFault":
-            self = .invalidDBSubnetGroupStateFault(message: message)
-        case "InvalidDBSubnetStateFault":
-            self = .invalidDBSubnetStateFault(message: message)
-        case "InvalidEventSubscriptionState":
-            self = .invalidEventSubscriptionStateFault(message: message)
-        case "InvalidRestoreFault":
-            self = .invalidRestoreFault(message: message)
-        case "InvalidSubnet":
-            self = .invalidSubnet(message: message)
-        case "InvalidVPCNetworkStateFault":
-            self = .invalidVPCNetworkStateFault(message: message)
-        case "KMSKeyNotAccessibleFault":
-            self = .kMSKeyNotAccessibleFault(message: message)
-        case "OptionGroupNotFoundFault":
-            self = .optionGroupNotFoundFault(message: message)
-        case "ProvisionedIopsNotAvailableInAZFault":
-            self = .provisionedIopsNotAvailableInAZFault(message: message)
-        case "ResourceNotFoundFault":
-            self = .resourceNotFoundFault(message: message)
-        case "SNSInvalidTopic":
-            self = .sNSInvalidTopicFault(message: message)
-        case "SNSNoAuthorization":
-            self = .sNSNoAuthorizationFault(message: message)
-        case "SNSTopicArnNotFound":
-            self = .sNSTopicArnNotFoundFault(message: message)
-        case "SharedSnapshotQuotaExceeded":
-            self = .sharedSnapshotQuotaExceededFault(message: message)
-        case "SnapshotQuotaExceeded":
-            self = .snapshotQuotaExceededFault(message: message)
-        case "SourceNotFound":
-            self = .sourceNotFoundFault(message: message)
-        case "StorageQuotaExceeded":
-            self = .storageQuotaExceededFault(message: message)
-        case "StorageTypeNotSupported":
-            self = .storageTypeNotSupportedFault(message: message)
-        case "SubnetAlreadyInUse":
-            self = .subnetAlreadyInUse(message: message)
-        case "SubscriptionAlreadyExist":
-            self = .subscriptionAlreadyExistFault(message: message)
-        case "SubscriptionCategoryNotFound":
-            self = .subscriptionCategoryNotFoundFault(message: message)
-        case "SubscriptionNotFound":
-            self = .subscriptionNotFoundFault(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var authorizationNotFoundFault: Self { .init(.authorizationNotFoundFault) }
+    public static var certificateNotFoundFault: Self { .init(.certificateNotFoundFault) }
+    public static var dBClusterAlreadyExistsFault: Self { .init(.dBClusterAlreadyExistsFault) }
+    public static var dBClusterNotFoundFault: Self { .init(.dBClusterNotFoundFault) }
+    public static var dBClusterParameterGroupNotFoundFault: Self { .init(.dBClusterParameterGroupNotFoundFault) }
+    public static var dBClusterQuotaExceededFault: Self { .init(.dBClusterQuotaExceededFault) }
+    public static var dBClusterRoleAlreadyExistsFault: Self { .init(.dBClusterRoleAlreadyExistsFault) }
+    public static var dBClusterRoleNotFoundFault: Self { .init(.dBClusterRoleNotFoundFault) }
+    public static var dBClusterRoleQuotaExceededFault: Self { .init(.dBClusterRoleQuotaExceededFault) }
+    public static var dBClusterSnapshotAlreadyExistsFault: Self { .init(.dBClusterSnapshotAlreadyExistsFault) }
+    public static var dBClusterSnapshotNotFoundFault: Self { .init(.dBClusterSnapshotNotFoundFault) }
+    public static var dBInstanceAlreadyExistsFault: Self { .init(.dBInstanceAlreadyExistsFault) }
+    public static var dBInstanceNotFoundFault: Self { .init(.dBInstanceNotFoundFault) }
+    public static var dBParameterGroupAlreadyExistsFault: Self { .init(.dBParameterGroupAlreadyExistsFault) }
+    public static var dBParameterGroupNotFoundFault: Self { .init(.dBParameterGroupNotFoundFault) }
+    public static var dBParameterGroupQuotaExceededFault: Self { .init(.dBParameterGroupQuotaExceededFault) }
+    public static var dBSecurityGroupNotFoundFault: Self { .init(.dBSecurityGroupNotFoundFault) }
+    public static var dBSnapshotAlreadyExistsFault: Self { .init(.dBSnapshotAlreadyExistsFault) }
+    public static var dBSnapshotNotFoundFault: Self { .init(.dBSnapshotNotFoundFault) }
+    public static var dBSubnetGroupAlreadyExistsFault: Self { .init(.dBSubnetGroupAlreadyExistsFault) }
+    public static var dBSubnetGroupDoesNotCoverEnoughAZs: Self { .init(.dBSubnetGroupDoesNotCoverEnoughAZs) }
+    public static var dBSubnetGroupNotFoundFault: Self { .init(.dBSubnetGroupNotFoundFault) }
+    public static var dBSubnetGroupQuotaExceededFault: Self { .init(.dBSubnetGroupQuotaExceededFault) }
+    public static var dBSubnetQuotaExceededFault: Self { .init(.dBSubnetQuotaExceededFault) }
+    public static var dBUpgradeDependencyFailureFault: Self { .init(.dBUpgradeDependencyFailureFault) }
+    public static var domainNotFoundFault: Self { .init(.domainNotFoundFault) }
+    public static var eventSubscriptionQuotaExceededFault: Self { .init(.eventSubscriptionQuotaExceededFault) }
+    public static var instanceQuotaExceededFault: Self { .init(.instanceQuotaExceededFault) }
+    public static var insufficientDBClusterCapacityFault: Self { .init(.insufficientDBClusterCapacityFault) }
+    public static var insufficientDBInstanceCapacityFault: Self { .init(.insufficientDBInstanceCapacityFault) }
+    public static var insufficientStorageClusterCapacityFault: Self { .init(.insufficientStorageClusterCapacityFault) }
+    public static var invalidDBClusterSnapshotStateFault: Self { .init(.invalidDBClusterSnapshotStateFault) }
+    public static var invalidDBClusterStateFault: Self { .init(.invalidDBClusterStateFault) }
+    public static var invalidDBInstanceStateFault: Self { .init(.invalidDBInstanceStateFault) }
+    public static var invalidDBParameterGroupStateFault: Self { .init(.invalidDBParameterGroupStateFault) }
+    public static var invalidDBSecurityGroupStateFault: Self { .init(.invalidDBSecurityGroupStateFault) }
+    public static var invalidDBSnapshotStateFault: Self { .init(.invalidDBSnapshotStateFault) }
+    public static var invalidDBSubnetGroupStateFault: Self { .init(.invalidDBSubnetGroupStateFault) }
+    public static var invalidDBSubnetStateFault: Self { .init(.invalidDBSubnetStateFault) }
+    public static var invalidEventSubscriptionStateFault: Self { .init(.invalidEventSubscriptionStateFault) }
+    public static var invalidRestoreFault: Self { .init(.invalidRestoreFault) }
+    public static var invalidSubnet: Self { .init(.invalidSubnet) }
+    public static var invalidVPCNetworkStateFault: Self { .init(.invalidVPCNetworkStateFault) }
+    public static var kMSKeyNotAccessibleFault: Self { .init(.kMSKeyNotAccessibleFault) }
+    public static var optionGroupNotFoundFault: Self { .init(.optionGroupNotFoundFault) }
+    public static var provisionedIopsNotAvailableInAZFault: Self { .init(.provisionedIopsNotAvailableInAZFault) }
+    public static var resourceNotFoundFault: Self { .init(.resourceNotFoundFault) }
+    public static var sNSInvalidTopicFault: Self { .init(.sNSInvalidTopicFault) }
+    public static var sNSNoAuthorizationFault: Self { .init(.sNSNoAuthorizationFault) }
+    public static var sNSTopicArnNotFoundFault: Self { .init(.sNSTopicArnNotFoundFault) }
+    public static var sharedSnapshotQuotaExceededFault: Self { .init(.sharedSnapshotQuotaExceededFault) }
+    public static var snapshotQuotaExceededFault: Self { .init(.snapshotQuotaExceededFault) }
+    public static var sourceNotFoundFault: Self { .init(.sourceNotFoundFault) }
+    public static var storageQuotaExceededFault: Self { .init(.storageQuotaExceededFault) }
+    public static var storageTypeNotSupportedFault: Self { .init(.storageTypeNotSupportedFault) }
+    public static var subnetAlreadyInUse: Self { .init(.subnetAlreadyInUse) }
+    public static var subscriptionAlreadyExistFault: Self { .init(.subscriptionAlreadyExistFault) }
+    public static var subscriptionCategoryNotFoundFault: Self { .init(.subscriptionCategoryNotFoundFault) }
+    public static var subscriptionNotFoundFault: Self { .init(.subscriptionNotFoundFault) }
+}
+
+extension NeptuneErrorType: Equatable {
+    public static func == (lhs: NeptuneErrorType, rhs: NeptuneErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension NeptuneErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .authorizationNotFoundFault(let message):
-            return "AuthorizationNotFound: \(message ?? "")"
-        case .certificateNotFoundFault(let message):
-            return "CertificateNotFound: \(message ?? "")"
-        case .dBClusterAlreadyExistsFault(let message):
-            return "DBClusterAlreadyExistsFault: \(message ?? "")"
-        case .dBClusterNotFoundFault(let message):
-            return "DBClusterNotFoundFault: \(message ?? "")"
-        case .dBClusterParameterGroupNotFoundFault(let message):
-            return "DBClusterParameterGroupNotFound: \(message ?? "")"
-        case .dBClusterQuotaExceededFault(let message):
-            return "DBClusterQuotaExceededFault: \(message ?? "")"
-        case .dBClusterRoleAlreadyExistsFault(let message):
-            return "DBClusterRoleAlreadyExists: \(message ?? "")"
-        case .dBClusterRoleNotFoundFault(let message):
-            return "DBClusterRoleNotFound: \(message ?? "")"
-        case .dBClusterRoleQuotaExceededFault(let message):
-            return "DBClusterRoleQuotaExceeded: \(message ?? "")"
-        case .dBClusterSnapshotAlreadyExistsFault(let message):
-            return "DBClusterSnapshotAlreadyExistsFault: \(message ?? "")"
-        case .dBClusterSnapshotNotFoundFault(let message):
-            return "DBClusterSnapshotNotFoundFault: \(message ?? "")"
-        case .dBInstanceAlreadyExistsFault(let message):
-            return "DBInstanceAlreadyExists: \(message ?? "")"
-        case .dBInstanceNotFoundFault(let message):
-            return "DBInstanceNotFound: \(message ?? "")"
-        case .dBParameterGroupAlreadyExistsFault(let message):
-            return "DBParameterGroupAlreadyExists: \(message ?? "")"
-        case .dBParameterGroupNotFoundFault(let message):
-            return "DBParameterGroupNotFound: \(message ?? "")"
-        case .dBParameterGroupQuotaExceededFault(let message):
-            return "DBParameterGroupQuotaExceeded: \(message ?? "")"
-        case .dBSecurityGroupNotFoundFault(let message):
-            return "DBSecurityGroupNotFound: \(message ?? "")"
-        case .dBSnapshotAlreadyExistsFault(let message):
-            return "DBSnapshotAlreadyExists: \(message ?? "")"
-        case .dBSnapshotNotFoundFault(let message):
-            return "DBSnapshotNotFound: \(message ?? "")"
-        case .dBSubnetGroupAlreadyExistsFault(let message):
-            return "DBSubnetGroupAlreadyExists: \(message ?? "")"
-        case .dBSubnetGroupDoesNotCoverEnoughAZs(let message):
-            return "DBSubnetGroupDoesNotCoverEnoughAZs: \(message ?? "")"
-        case .dBSubnetGroupNotFoundFault(let message):
-            return "DBSubnetGroupNotFoundFault: \(message ?? "")"
-        case .dBSubnetGroupQuotaExceededFault(let message):
-            return "DBSubnetGroupQuotaExceeded: \(message ?? "")"
-        case .dBSubnetQuotaExceededFault(let message):
-            return "DBSubnetQuotaExceededFault: \(message ?? "")"
-        case .dBUpgradeDependencyFailureFault(let message):
-            return "DBUpgradeDependencyFailure: \(message ?? "")"
-        case .domainNotFoundFault(let message):
-            return "DomainNotFoundFault: \(message ?? "")"
-        case .eventSubscriptionQuotaExceededFault(let message):
-            return "EventSubscriptionQuotaExceeded: \(message ?? "")"
-        case .instanceQuotaExceededFault(let message):
-            return "InstanceQuotaExceeded: \(message ?? "")"
-        case .insufficientDBClusterCapacityFault(let message):
-            return "InsufficientDBClusterCapacityFault: \(message ?? "")"
-        case .insufficientDBInstanceCapacityFault(let message):
-            return "InsufficientDBInstanceCapacity: \(message ?? "")"
-        case .insufficientStorageClusterCapacityFault(let message):
-            return "InsufficientStorageClusterCapacity: \(message ?? "")"
-        case .invalidDBClusterSnapshotStateFault(let message):
-            return "InvalidDBClusterSnapshotStateFault: \(message ?? "")"
-        case .invalidDBClusterStateFault(let message):
-            return "InvalidDBClusterStateFault: \(message ?? "")"
-        case .invalidDBInstanceStateFault(let message):
-            return "InvalidDBInstanceState: \(message ?? "")"
-        case .invalidDBParameterGroupStateFault(let message):
-            return "InvalidDBParameterGroupState: \(message ?? "")"
-        case .invalidDBSecurityGroupStateFault(let message):
-            return "InvalidDBSecurityGroupState: \(message ?? "")"
-        case .invalidDBSnapshotStateFault(let message):
-            return "InvalidDBSnapshotState: \(message ?? "")"
-        case .invalidDBSubnetGroupStateFault(let message):
-            return "InvalidDBSubnetGroupStateFault: \(message ?? "")"
-        case .invalidDBSubnetStateFault(let message):
-            return "InvalidDBSubnetStateFault: \(message ?? "")"
-        case .invalidEventSubscriptionStateFault(let message):
-            return "InvalidEventSubscriptionState: \(message ?? "")"
-        case .invalidRestoreFault(let message):
-            return "InvalidRestoreFault: \(message ?? "")"
-        case .invalidSubnet(let message):
-            return "InvalidSubnet: \(message ?? "")"
-        case .invalidVPCNetworkStateFault(let message):
-            return "InvalidVPCNetworkStateFault: \(message ?? "")"
-        case .kMSKeyNotAccessibleFault(let message):
-            return "KMSKeyNotAccessibleFault: \(message ?? "")"
-        case .optionGroupNotFoundFault(let message):
-            return "OptionGroupNotFoundFault: \(message ?? "")"
-        case .provisionedIopsNotAvailableInAZFault(let message):
-            return "ProvisionedIopsNotAvailableInAZFault: \(message ?? "")"
-        case .resourceNotFoundFault(let message):
-            return "ResourceNotFoundFault: \(message ?? "")"
-        case .sNSInvalidTopicFault(let message):
-            return "SNSInvalidTopic: \(message ?? "")"
-        case .sNSNoAuthorizationFault(let message):
-            return "SNSNoAuthorization: \(message ?? "")"
-        case .sNSTopicArnNotFoundFault(let message):
-            return "SNSTopicArnNotFound: \(message ?? "")"
-        case .sharedSnapshotQuotaExceededFault(let message):
-            return "SharedSnapshotQuotaExceeded: \(message ?? "")"
-        case .snapshotQuotaExceededFault(let message):
-            return "SnapshotQuotaExceeded: \(message ?? "")"
-        case .sourceNotFoundFault(let message):
-            return "SourceNotFound: \(message ?? "")"
-        case .storageQuotaExceededFault(let message):
-            return "StorageQuotaExceeded: \(message ?? "")"
-        case .storageTypeNotSupportedFault(let message):
-            return "StorageTypeNotSupported: \(message ?? "")"
-        case .subnetAlreadyInUse(let message):
-            return "SubnetAlreadyInUse: \(message ?? "")"
-        case .subscriptionAlreadyExistFault(let message):
-            return "SubscriptionAlreadyExist: \(message ?? "")"
-        case .subscriptionCategoryNotFoundFault(let message):
-            return "SubscriptionCategoryNotFound: \(message ?? "")"
-        case .subscriptionNotFoundFault(let message):
-            return "SubscriptionNotFound: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/NetworkManager/NetworkManager_Error.swift
+++ b/Sources/Soto/Services/NetworkManager/NetworkManager_Error.swift
@@ -17,60 +17,52 @@
 import SotoCore
 
 /// Error enum for NetworkManager
-public enum NetworkManagerErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case conflictException(message: String?)
-    case internalServerException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceQuotaExceededException(message: String?)
-    case throttlingException(message: String?)
-    case validationException(message: String?)
-}
+public struct NetworkManagerErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case conflictException = "ConflictException"
+        case internalServerException = "InternalServerException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceQuotaExceededException = "ServiceQuotaExceededException"
+        case throttlingException = "ThrottlingException"
+        case validationException = "ValidationException"
+    }
 
-extension NetworkManagerErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceQuotaExceededException":
-            self = .serviceQuotaExceededException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceQuotaExceededException: Self { .init(.serviceQuotaExceededException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension NetworkManagerErrorType: Equatable {
+    public static func == (lhs: NetworkManagerErrorType, rhs: NetworkManagerErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension NetworkManagerErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceQuotaExceededException(let message):
-            return "ServiceQuotaExceededException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/OpsWorks/OpsWorks_Error.swift
+++ b/Sources/Soto/Services/OpsWorks/OpsWorks_Error.swift
@@ -17,35 +17,42 @@
 import SotoCore
 
 /// Error enum for OpsWorks
-public enum OpsWorksErrorType: AWSErrorType {
-    case resourceNotFoundException(message: String?)
-    case validationException(message: String?)
-}
+public struct OpsWorksErrorType: AWSErrorType {
+    enum Code: String {
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case validationException = "ValidationException"
+    }
 
-extension OpsWorksErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension OpsWorksErrorType: Equatable {
+    public static func == (lhs: OpsWorksErrorType, rhs: OpsWorksErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension OpsWorksErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/OpsWorksCM/OpsWorksCM_Error.swift
+++ b/Sources/Soto/Services/OpsWorksCM/OpsWorksCM_Error.swift
@@ -17,55 +17,50 @@
 import SotoCore
 
 /// Error enum for OpsWorksCM
-public enum OpsWorksCMErrorType: AWSErrorType {
-    case invalidNextTokenException(message: String?)
-    case invalidStateException(message: String?)
-    case limitExceededException(message: String?)
-    case resourceAlreadyExistsException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case validationException(message: String?)
-}
+public struct OpsWorksCMErrorType: AWSErrorType {
+    enum Code: String {
+        case invalidNextTokenException = "InvalidNextTokenException"
+        case invalidStateException = "InvalidStateException"
+        case limitExceededException = "LimitExceededException"
+        case resourceAlreadyExistsException = "ResourceAlreadyExistsException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case validationException = "ValidationException"
+    }
 
-extension OpsWorksCMErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "InvalidNextTokenException":
-            self = .invalidNextTokenException(message: message)
-        case "InvalidStateException":
-            self = .invalidStateException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ResourceAlreadyExistsException":
-            self = .resourceAlreadyExistsException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var invalidNextTokenException: Self { .init(.invalidNextTokenException) }
+    public static var invalidStateException: Self { .init(.invalidStateException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var resourceAlreadyExistsException: Self { .init(.resourceAlreadyExistsException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension OpsWorksCMErrorType: Equatable {
+    public static func == (lhs: OpsWorksCMErrorType, rhs: OpsWorksCMErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension OpsWorksCMErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .invalidNextTokenException(let message):
-            return "InvalidNextTokenException: \(message ?? "")"
-        case .invalidStateException(let message):
-            return "InvalidStateException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .resourceAlreadyExistsException(let message):
-            return "ResourceAlreadyExistsException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Organizations/Organizations_Error.swift
+++ b/Sources/Soto/Services/Organizations/Organizations_Error.swift
@@ -17,245 +17,126 @@
 import SotoCore
 
 /// Error enum for Organizations
-public enum OrganizationsErrorType: AWSErrorType {
-    case aWSOrganizationsNotInUseException(message: String?)
-    case accessDeniedException(message: String?)
-    case accessDeniedForDependencyException(message: String?)
-    case accountAlreadyRegisteredException(message: String?)
-    case accountNotFoundException(message: String?)
-    case accountNotRegisteredException(message: String?)
-    case accountOwnerNotVerifiedException(message: String?)
-    case alreadyInOrganizationException(message: String?)
-    case childNotFoundException(message: String?)
-    case concurrentModificationException(message: String?)
-    case constraintViolationException(message: String?)
-    case createAccountStatusNotFoundException(message: String?)
-    case destinationParentNotFoundException(message: String?)
-    case duplicateAccountException(message: String?)
-    case duplicateHandshakeException(message: String?)
-    case duplicateOrganizationalUnitException(message: String?)
-    case duplicatePolicyAttachmentException(message: String?)
-    case duplicatePolicyException(message: String?)
-    case effectivePolicyNotFoundException(message: String?)
-    case finalizingOrganizationException(message: String?)
-    case handshakeAlreadyInStateException(message: String?)
-    case handshakeConstraintViolationException(message: String?)
-    case handshakeNotFoundException(message: String?)
-    case invalidHandshakeTransitionException(message: String?)
-    case invalidInputException(message: String?)
-    case malformedPolicyDocumentException(message: String?)
-    case masterCannotLeaveOrganizationException(message: String?)
-    case organizationNotEmptyException(message: String?)
-    case organizationalUnitNotEmptyException(message: String?)
-    case organizationalUnitNotFoundException(message: String?)
-    case parentNotFoundException(message: String?)
-    case policyChangesInProgressException(message: String?)
-    case policyInUseException(message: String?)
-    case policyNotAttachedException(message: String?)
-    case policyNotFoundException(message: String?)
-    case policyTypeAlreadyEnabledException(message: String?)
-    case policyTypeNotAvailableForOrganizationException(message: String?)
-    case policyTypeNotEnabledException(message: String?)
-    case rootNotFoundException(message: String?)
-    case serviceException(message: String?)
-    case sourceParentNotFoundException(message: String?)
-    case targetNotFoundException(message: String?)
-    case tooManyRequestsException(message: String?)
-    case unsupportedAPIEndpointException(message: String?)
-}
+public struct OrganizationsErrorType: AWSErrorType {
+    enum Code: String {
+        case aWSOrganizationsNotInUseException = "AWSOrganizationsNotInUseException"
+        case accessDeniedException = "AccessDeniedException"
+        case accessDeniedForDependencyException = "AccessDeniedForDependencyException"
+        case accountAlreadyRegisteredException = "AccountAlreadyRegisteredException"
+        case accountNotFoundException = "AccountNotFoundException"
+        case accountNotRegisteredException = "AccountNotRegisteredException"
+        case accountOwnerNotVerifiedException = "AccountOwnerNotVerifiedException"
+        case alreadyInOrganizationException = "AlreadyInOrganizationException"
+        case childNotFoundException = "ChildNotFoundException"
+        case concurrentModificationException = "ConcurrentModificationException"
+        case constraintViolationException = "ConstraintViolationException"
+        case createAccountStatusNotFoundException = "CreateAccountStatusNotFoundException"
+        case destinationParentNotFoundException = "DestinationParentNotFoundException"
+        case duplicateAccountException = "DuplicateAccountException"
+        case duplicateHandshakeException = "DuplicateHandshakeException"
+        case duplicateOrganizationalUnitException = "DuplicateOrganizationalUnitException"
+        case duplicatePolicyAttachmentException = "DuplicatePolicyAttachmentException"
+        case duplicatePolicyException = "DuplicatePolicyException"
+        case effectivePolicyNotFoundException = "EffectivePolicyNotFoundException"
+        case finalizingOrganizationException = "FinalizingOrganizationException"
+        case handshakeAlreadyInStateException = "HandshakeAlreadyInStateException"
+        case handshakeConstraintViolationException = "HandshakeConstraintViolationException"
+        case handshakeNotFoundException = "HandshakeNotFoundException"
+        case invalidHandshakeTransitionException = "InvalidHandshakeTransitionException"
+        case invalidInputException = "InvalidInputException"
+        case malformedPolicyDocumentException = "MalformedPolicyDocumentException"
+        case masterCannotLeaveOrganizationException = "MasterCannotLeaveOrganizationException"
+        case organizationNotEmptyException = "OrganizationNotEmptyException"
+        case organizationalUnitNotEmptyException = "OrganizationalUnitNotEmptyException"
+        case organizationalUnitNotFoundException = "OrganizationalUnitNotFoundException"
+        case parentNotFoundException = "ParentNotFoundException"
+        case policyChangesInProgressException = "PolicyChangesInProgressException"
+        case policyInUseException = "PolicyInUseException"
+        case policyNotAttachedException = "PolicyNotAttachedException"
+        case policyNotFoundException = "PolicyNotFoundException"
+        case policyTypeAlreadyEnabledException = "PolicyTypeAlreadyEnabledException"
+        case policyTypeNotAvailableForOrganizationException = "PolicyTypeNotAvailableForOrganizationException"
+        case policyTypeNotEnabledException = "PolicyTypeNotEnabledException"
+        case rootNotFoundException = "RootNotFoundException"
+        case serviceException = "ServiceException"
+        case sourceParentNotFoundException = "SourceParentNotFoundException"
+        case targetNotFoundException = "TargetNotFoundException"
+        case tooManyRequestsException = "TooManyRequestsException"
+        case unsupportedAPIEndpointException = "UnsupportedAPIEndpointException"
+    }
 
-extension OrganizationsErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AWSOrganizationsNotInUseException":
-            self = .aWSOrganizationsNotInUseException(message: message)
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "AccessDeniedForDependencyException":
-            self = .accessDeniedForDependencyException(message: message)
-        case "AccountAlreadyRegisteredException":
-            self = .accountAlreadyRegisteredException(message: message)
-        case "AccountNotFoundException":
-            self = .accountNotFoundException(message: message)
-        case "AccountNotRegisteredException":
-            self = .accountNotRegisteredException(message: message)
-        case "AccountOwnerNotVerifiedException":
-            self = .accountOwnerNotVerifiedException(message: message)
-        case "AlreadyInOrganizationException":
-            self = .alreadyInOrganizationException(message: message)
-        case "ChildNotFoundException":
-            self = .childNotFoundException(message: message)
-        case "ConcurrentModificationException":
-            self = .concurrentModificationException(message: message)
-        case "ConstraintViolationException":
-            self = .constraintViolationException(message: message)
-        case "CreateAccountStatusNotFoundException":
-            self = .createAccountStatusNotFoundException(message: message)
-        case "DestinationParentNotFoundException":
-            self = .destinationParentNotFoundException(message: message)
-        case "DuplicateAccountException":
-            self = .duplicateAccountException(message: message)
-        case "DuplicateHandshakeException":
-            self = .duplicateHandshakeException(message: message)
-        case "DuplicateOrganizationalUnitException":
-            self = .duplicateOrganizationalUnitException(message: message)
-        case "DuplicatePolicyAttachmentException":
-            self = .duplicatePolicyAttachmentException(message: message)
-        case "DuplicatePolicyException":
-            self = .duplicatePolicyException(message: message)
-        case "EffectivePolicyNotFoundException":
-            self = .effectivePolicyNotFoundException(message: message)
-        case "FinalizingOrganizationException":
-            self = .finalizingOrganizationException(message: message)
-        case "HandshakeAlreadyInStateException":
-            self = .handshakeAlreadyInStateException(message: message)
-        case "HandshakeConstraintViolationException":
-            self = .handshakeConstraintViolationException(message: message)
-        case "HandshakeNotFoundException":
-            self = .handshakeNotFoundException(message: message)
-        case "InvalidHandshakeTransitionException":
-            self = .invalidHandshakeTransitionException(message: message)
-        case "InvalidInputException":
-            self = .invalidInputException(message: message)
-        case "MalformedPolicyDocumentException":
-            self = .malformedPolicyDocumentException(message: message)
-        case "MasterCannotLeaveOrganizationException":
-            self = .masterCannotLeaveOrganizationException(message: message)
-        case "OrganizationNotEmptyException":
-            self = .organizationNotEmptyException(message: message)
-        case "OrganizationalUnitNotEmptyException":
-            self = .organizationalUnitNotEmptyException(message: message)
-        case "OrganizationalUnitNotFoundException":
-            self = .organizationalUnitNotFoundException(message: message)
-        case "ParentNotFoundException":
-            self = .parentNotFoundException(message: message)
-        case "PolicyChangesInProgressException":
-            self = .policyChangesInProgressException(message: message)
-        case "PolicyInUseException":
-            self = .policyInUseException(message: message)
-        case "PolicyNotAttachedException":
-            self = .policyNotAttachedException(message: message)
-        case "PolicyNotFoundException":
-            self = .policyNotFoundException(message: message)
-        case "PolicyTypeAlreadyEnabledException":
-            self = .policyTypeAlreadyEnabledException(message: message)
-        case "PolicyTypeNotAvailableForOrganizationException":
-            self = .policyTypeNotAvailableForOrganizationException(message: message)
-        case "PolicyTypeNotEnabledException":
-            self = .policyTypeNotEnabledException(message: message)
-        case "RootNotFoundException":
-            self = .rootNotFoundException(message: message)
-        case "ServiceException":
-            self = .serviceException(message: message)
-        case "SourceParentNotFoundException":
-            self = .sourceParentNotFoundException(message: message)
-        case "TargetNotFoundException":
-            self = .targetNotFoundException(message: message)
-        case "TooManyRequestsException":
-            self = .tooManyRequestsException(message: message)
-        case "UnsupportedAPIEndpointException":
-            self = .unsupportedAPIEndpointException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var aWSOrganizationsNotInUseException: Self { .init(.aWSOrganizationsNotInUseException) }
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var accessDeniedForDependencyException: Self { .init(.accessDeniedForDependencyException) }
+    public static var accountAlreadyRegisteredException: Self { .init(.accountAlreadyRegisteredException) }
+    public static var accountNotFoundException: Self { .init(.accountNotFoundException) }
+    public static var accountNotRegisteredException: Self { .init(.accountNotRegisteredException) }
+    public static var accountOwnerNotVerifiedException: Self { .init(.accountOwnerNotVerifiedException) }
+    public static var alreadyInOrganizationException: Self { .init(.alreadyInOrganizationException) }
+    public static var childNotFoundException: Self { .init(.childNotFoundException) }
+    public static var concurrentModificationException: Self { .init(.concurrentModificationException) }
+    public static var constraintViolationException: Self { .init(.constraintViolationException) }
+    public static var createAccountStatusNotFoundException: Self { .init(.createAccountStatusNotFoundException) }
+    public static var destinationParentNotFoundException: Self { .init(.destinationParentNotFoundException) }
+    public static var duplicateAccountException: Self { .init(.duplicateAccountException) }
+    public static var duplicateHandshakeException: Self { .init(.duplicateHandshakeException) }
+    public static var duplicateOrganizationalUnitException: Self { .init(.duplicateOrganizationalUnitException) }
+    public static var duplicatePolicyAttachmentException: Self { .init(.duplicatePolicyAttachmentException) }
+    public static var duplicatePolicyException: Self { .init(.duplicatePolicyException) }
+    public static var effectivePolicyNotFoundException: Self { .init(.effectivePolicyNotFoundException) }
+    public static var finalizingOrganizationException: Self { .init(.finalizingOrganizationException) }
+    public static var handshakeAlreadyInStateException: Self { .init(.handshakeAlreadyInStateException) }
+    public static var handshakeConstraintViolationException: Self { .init(.handshakeConstraintViolationException) }
+    public static var handshakeNotFoundException: Self { .init(.handshakeNotFoundException) }
+    public static var invalidHandshakeTransitionException: Self { .init(.invalidHandshakeTransitionException) }
+    public static var invalidInputException: Self { .init(.invalidInputException) }
+    public static var malformedPolicyDocumentException: Self { .init(.malformedPolicyDocumentException) }
+    public static var masterCannotLeaveOrganizationException: Self { .init(.masterCannotLeaveOrganizationException) }
+    public static var organizationNotEmptyException: Self { .init(.organizationNotEmptyException) }
+    public static var organizationalUnitNotEmptyException: Self { .init(.organizationalUnitNotEmptyException) }
+    public static var organizationalUnitNotFoundException: Self { .init(.organizationalUnitNotFoundException) }
+    public static var parentNotFoundException: Self { .init(.parentNotFoundException) }
+    public static var policyChangesInProgressException: Self { .init(.policyChangesInProgressException) }
+    public static var policyInUseException: Self { .init(.policyInUseException) }
+    public static var policyNotAttachedException: Self { .init(.policyNotAttachedException) }
+    public static var policyNotFoundException: Self { .init(.policyNotFoundException) }
+    public static var policyTypeAlreadyEnabledException: Self { .init(.policyTypeAlreadyEnabledException) }
+    public static var policyTypeNotAvailableForOrganizationException: Self { .init(.policyTypeNotAvailableForOrganizationException) }
+    public static var policyTypeNotEnabledException: Self { .init(.policyTypeNotEnabledException) }
+    public static var rootNotFoundException: Self { .init(.rootNotFoundException) }
+    public static var serviceException: Self { .init(.serviceException) }
+    public static var sourceParentNotFoundException: Self { .init(.sourceParentNotFoundException) }
+    public static var targetNotFoundException: Self { .init(.targetNotFoundException) }
+    public static var tooManyRequestsException: Self { .init(.tooManyRequestsException) }
+    public static var unsupportedAPIEndpointException: Self { .init(.unsupportedAPIEndpointException) }
+}
+
+extension OrganizationsErrorType: Equatable {
+    public static func == (lhs: OrganizationsErrorType, rhs: OrganizationsErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension OrganizationsErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .aWSOrganizationsNotInUseException(let message):
-            return "AWSOrganizationsNotInUseException: \(message ?? "")"
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .accessDeniedForDependencyException(let message):
-            return "AccessDeniedForDependencyException: \(message ?? "")"
-        case .accountAlreadyRegisteredException(let message):
-            return "AccountAlreadyRegisteredException: \(message ?? "")"
-        case .accountNotFoundException(let message):
-            return "AccountNotFoundException: \(message ?? "")"
-        case .accountNotRegisteredException(let message):
-            return "AccountNotRegisteredException: \(message ?? "")"
-        case .accountOwnerNotVerifiedException(let message):
-            return "AccountOwnerNotVerifiedException: \(message ?? "")"
-        case .alreadyInOrganizationException(let message):
-            return "AlreadyInOrganizationException: \(message ?? "")"
-        case .childNotFoundException(let message):
-            return "ChildNotFoundException: \(message ?? "")"
-        case .concurrentModificationException(let message):
-            return "ConcurrentModificationException: \(message ?? "")"
-        case .constraintViolationException(let message):
-            return "ConstraintViolationException: \(message ?? "")"
-        case .createAccountStatusNotFoundException(let message):
-            return "CreateAccountStatusNotFoundException: \(message ?? "")"
-        case .destinationParentNotFoundException(let message):
-            return "DestinationParentNotFoundException: \(message ?? "")"
-        case .duplicateAccountException(let message):
-            return "DuplicateAccountException: \(message ?? "")"
-        case .duplicateHandshakeException(let message):
-            return "DuplicateHandshakeException: \(message ?? "")"
-        case .duplicateOrganizationalUnitException(let message):
-            return "DuplicateOrganizationalUnitException: \(message ?? "")"
-        case .duplicatePolicyAttachmentException(let message):
-            return "DuplicatePolicyAttachmentException: \(message ?? "")"
-        case .duplicatePolicyException(let message):
-            return "DuplicatePolicyException: \(message ?? "")"
-        case .effectivePolicyNotFoundException(let message):
-            return "EffectivePolicyNotFoundException: \(message ?? "")"
-        case .finalizingOrganizationException(let message):
-            return "FinalizingOrganizationException: \(message ?? "")"
-        case .handshakeAlreadyInStateException(let message):
-            return "HandshakeAlreadyInStateException: \(message ?? "")"
-        case .handshakeConstraintViolationException(let message):
-            return "HandshakeConstraintViolationException: \(message ?? "")"
-        case .handshakeNotFoundException(let message):
-            return "HandshakeNotFoundException: \(message ?? "")"
-        case .invalidHandshakeTransitionException(let message):
-            return "InvalidHandshakeTransitionException: \(message ?? "")"
-        case .invalidInputException(let message):
-            return "InvalidInputException: \(message ?? "")"
-        case .malformedPolicyDocumentException(let message):
-            return "MalformedPolicyDocumentException: \(message ?? "")"
-        case .masterCannotLeaveOrganizationException(let message):
-            return "MasterCannotLeaveOrganizationException: \(message ?? "")"
-        case .organizationNotEmptyException(let message):
-            return "OrganizationNotEmptyException: \(message ?? "")"
-        case .organizationalUnitNotEmptyException(let message):
-            return "OrganizationalUnitNotEmptyException: \(message ?? "")"
-        case .organizationalUnitNotFoundException(let message):
-            return "OrganizationalUnitNotFoundException: \(message ?? "")"
-        case .parentNotFoundException(let message):
-            return "ParentNotFoundException: \(message ?? "")"
-        case .policyChangesInProgressException(let message):
-            return "PolicyChangesInProgressException: \(message ?? "")"
-        case .policyInUseException(let message):
-            return "PolicyInUseException: \(message ?? "")"
-        case .policyNotAttachedException(let message):
-            return "PolicyNotAttachedException: \(message ?? "")"
-        case .policyNotFoundException(let message):
-            return "PolicyNotFoundException: \(message ?? "")"
-        case .policyTypeAlreadyEnabledException(let message):
-            return "PolicyTypeAlreadyEnabledException: \(message ?? "")"
-        case .policyTypeNotAvailableForOrganizationException(let message):
-            return "PolicyTypeNotAvailableForOrganizationException: \(message ?? "")"
-        case .policyTypeNotEnabledException(let message):
-            return "PolicyTypeNotEnabledException: \(message ?? "")"
-        case .rootNotFoundException(let message):
-            return "RootNotFoundException: \(message ?? "")"
-        case .serviceException(let message):
-            return "ServiceException: \(message ?? "")"
-        case .sourceParentNotFoundException(let message):
-            return "SourceParentNotFoundException: \(message ?? "")"
-        case .targetNotFoundException(let message):
-            return "TargetNotFoundException: \(message ?? "")"
-        case .tooManyRequestsException(let message):
-            return "TooManyRequestsException: \(message ?? "")"
-        case .unsupportedAPIEndpointException(let message):
-            return "UnsupportedAPIEndpointException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Outposts/Outposts_Error.swift
+++ b/Sources/Soto/Services/Outposts/Outposts_Error.swift
@@ -17,50 +17,48 @@
 import SotoCore
 
 /// Error enum for Outposts
-public enum OutpostsErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case internalServerException(message: String?)
-    case notFoundException(message: String?)
-    case serviceQuotaExceededException(message: String?)
-    case validationException(message: String?)
-}
+public struct OutpostsErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case internalServerException = "InternalServerException"
+        case notFoundException = "NotFoundException"
+        case serviceQuotaExceededException = "ServiceQuotaExceededException"
+        case validationException = "ValidationException"
+    }
 
-extension OutpostsErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "ServiceQuotaExceededException":
-            self = .serviceQuotaExceededException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var serviceQuotaExceededException: Self { .init(.serviceQuotaExceededException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension OutpostsErrorType: Equatable {
+    public static func == (lhs: OutpostsErrorType, rhs: OutpostsErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension OutpostsErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .serviceQuotaExceededException(let message):
-            return "ServiceQuotaExceededException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Personalize/Personalize_Error.swift
+++ b/Sources/Soto/Services/Personalize/Personalize_Error.swift
@@ -17,55 +17,50 @@
 import SotoCore
 
 /// Error enum for Personalize
-public enum PersonalizeErrorType: AWSErrorType {
-    case invalidInputException(message: String?)
-    case invalidNextTokenException(message: String?)
-    case limitExceededException(message: String?)
-    case resourceAlreadyExistsException(message: String?)
-    case resourceInUseException(message: String?)
-    case resourceNotFoundException(message: String?)
-}
+public struct PersonalizeErrorType: AWSErrorType {
+    enum Code: String {
+        case invalidInputException = "InvalidInputException"
+        case invalidNextTokenException = "InvalidNextTokenException"
+        case limitExceededException = "LimitExceededException"
+        case resourceAlreadyExistsException = "ResourceAlreadyExistsException"
+        case resourceInUseException = "ResourceInUseException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+    }
 
-extension PersonalizeErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "InvalidInputException":
-            self = .invalidInputException(message: message)
-        case "InvalidNextTokenException":
-            self = .invalidNextTokenException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ResourceAlreadyExistsException":
-            self = .resourceAlreadyExistsException(message: message)
-        case "ResourceInUseException":
-            self = .resourceInUseException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var invalidInputException: Self { .init(.invalidInputException) }
+    public static var invalidNextTokenException: Self { .init(.invalidNextTokenException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var resourceAlreadyExistsException: Self { .init(.resourceAlreadyExistsException) }
+    public static var resourceInUseException: Self { .init(.resourceInUseException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+}
+
+extension PersonalizeErrorType: Equatable {
+    public static func == (lhs: PersonalizeErrorType, rhs: PersonalizeErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension PersonalizeErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .invalidInputException(let message):
-            return "InvalidInputException: \(message ?? "")"
-        case .invalidNextTokenException(let message):
-            return "InvalidNextTokenException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .resourceAlreadyExistsException(let message):
-            return "ResourceAlreadyExistsException: \(message ?? "")"
-        case .resourceInUseException(let message):
-            return "ResourceInUseException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/PersonalizeEvents/PersonalizeEvents_Error.swift
+++ b/Sources/Soto/Services/PersonalizeEvents/PersonalizeEvents_Error.swift
@@ -17,35 +17,42 @@
 import SotoCore
 
 /// Error enum for PersonalizeEvents
-public enum PersonalizeEventsErrorType: AWSErrorType {
-    case invalidInputException(message: String?)
-    case resourceNotFoundException(message: String?)
-}
+public struct PersonalizeEventsErrorType: AWSErrorType {
+    enum Code: String {
+        case invalidInputException = "InvalidInputException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+    }
 
-extension PersonalizeEventsErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "InvalidInputException":
-            self = .invalidInputException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var invalidInputException: Self { .init(.invalidInputException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+}
+
+extension PersonalizeEventsErrorType: Equatable {
+    public static func == (lhs: PersonalizeEventsErrorType, rhs: PersonalizeEventsErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension PersonalizeEventsErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .invalidInputException(let message):
-            return "InvalidInputException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/PersonalizeRuntime/PersonalizeRuntime_Error.swift
+++ b/Sources/Soto/Services/PersonalizeRuntime/PersonalizeRuntime_Error.swift
@@ -17,35 +17,42 @@
 import SotoCore
 
 /// Error enum for PersonalizeRuntime
-public enum PersonalizeRuntimeErrorType: AWSErrorType {
-    case invalidInputException(message: String?)
-    case resourceNotFoundException(message: String?)
-}
+public struct PersonalizeRuntimeErrorType: AWSErrorType {
+    enum Code: String {
+        case invalidInputException = "InvalidInputException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+    }
 
-extension PersonalizeRuntimeErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "InvalidInputException":
-            self = .invalidInputException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var invalidInputException: Self { .init(.invalidInputException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+}
+
+extension PersonalizeRuntimeErrorType: Equatable {
+    public static func == (lhs: PersonalizeRuntimeErrorType, rhs: PersonalizeRuntimeErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension PersonalizeRuntimeErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .invalidInputException(let message):
-            return "InvalidInputException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Pinpoint/Pinpoint_Error.swift
+++ b/Sources/Soto/Services/Pinpoint/Pinpoint_Error.swift
@@ -17,65 +17,54 @@
 import SotoCore
 
 /// Error enum for Pinpoint
-public enum PinpointErrorType: AWSErrorType {
-    case badRequestException(message: String?)
-    case conflictException(message: String?)
-    case forbiddenException(message: String?)
-    case internalServerErrorException(message: String?)
-    case methodNotAllowedException(message: String?)
-    case notFoundException(message: String?)
-    case payloadTooLargeException(message: String?)
-    case tooManyRequestsException(message: String?)
-}
+public struct PinpointErrorType: AWSErrorType {
+    enum Code: String {
+        case badRequestException = "BadRequestException"
+        case conflictException = "ConflictException"
+        case forbiddenException = "ForbiddenException"
+        case internalServerErrorException = "InternalServerErrorException"
+        case methodNotAllowedException = "MethodNotAllowedException"
+        case notFoundException = "NotFoundException"
+        case payloadTooLargeException = "PayloadTooLargeException"
+        case tooManyRequestsException = "TooManyRequestsException"
+    }
 
-extension PinpointErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "ForbiddenException":
-            self = .forbiddenException(message: message)
-        case "InternalServerErrorException":
-            self = .internalServerErrorException(message: message)
-        case "MethodNotAllowedException":
-            self = .methodNotAllowedException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "PayloadTooLargeException":
-            self = .payloadTooLargeException(message: message)
-        case "TooManyRequestsException":
-            self = .tooManyRequestsException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var badRequestException: Self { .init(.badRequestException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var forbiddenException: Self { .init(.forbiddenException) }
+    public static var internalServerErrorException: Self { .init(.internalServerErrorException) }
+    public static var methodNotAllowedException: Self { .init(.methodNotAllowedException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var payloadTooLargeException: Self { .init(.payloadTooLargeException) }
+    public static var tooManyRequestsException: Self { .init(.tooManyRequestsException) }
+}
+
+extension PinpointErrorType: Equatable {
+    public static func == (lhs: PinpointErrorType, rhs: PinpointErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension PinpointErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .forbiddenException(let message):
-            return "ForbiddenException: \(message ?? "")"
-        case .internalServerErrorException(let message):
-            return "InternalServerErrorException: \(message ?? "")"
-        case .methodNotAllowedException(let message):
-            return "MethodNotAllowedException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .payloadTooLargeException(let message):
-            return "PayloadTooLargeException: \(message ?? "")"
-        case .tooManyRequestsException(let message):
-            return "TooManyRequestsException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/PinpointEmail/PinpointEmail_Error.swift
+++ b/Sources/Soto/Services/PinpointEmail/PinpointEmail_Error.swift
@@ -17,75 +17,58 @@
 import SotoCore
 
 /// Error enum for PinpointEmail
-public enum PinpointEmailErrorType: AWSErrorType {
-    case accountSuspendedException(message: String?)
-    case alreadyExistsException(message: String?)
-    case badRequestException(message: String?)
-    case concurrentModificationException(message: String?)
-    case limitExceededException(message: String?)
-    case mailFromDomainNotVerifiedException(message: String?)
-    case messageRejected(message: String?)
-    case notFoundException(message: String?)
-    case sendingPausedException(message: String?)
-    case tooManyRequestsException(message: String?)
-}
+public struct PinpointEmailErrorType: AWSErrorType {
+    enum Code: String {
+        case accountSuspendedException = "AccountSuspendedException"
+        case alreadyExistsException = "AlreadyExistsException"
+        case badRequestException = "BadRequestException"
+        case concurrentModificationException = "ConcurrentModificationException"
+        case limitExceededException = "LimitExceededException"
+        case mailFromDomainNotVerifiedException = "MailFromDomainNotVerifiedException"
+        case messageRejected = "MessageRejected"
+        case notFoundException = "NotFoundException"
+        case sendingPausedException = "SendingPausedException"
+        case tooManyRequestsException = "TooManyRequestsException"
+    }
 
-extension PinpointEmailErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccountSuspendedException":
-            self = .accountSuspendedException(message: message)
-        case "AlreadyExistsException":
-            self = .alreadyExistsException(message: message)
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        case "ConcurrentModificationException":
-            self = .concurrentModificationException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "MailFromDomainNotVerifiedException":
-            self = .mailFromDomainNotVerifiedException(message: message)
-        case "MessageRejected":
-            self = .messageRejected(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "SendingPausedException":
-            self = .sendingPausedException(message: message)
-        case "TooManyRequestsException":
-            self = .tooManyRequestsException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accountSuspendedException: Self { .init(.accountSuspendedException) }
+    public static var alreadyExistsException: Self { .init(.alreadyExistsException) }
+    public static var badRequestException: Self { .init(.badRequestException) }
+    public static var concurrentModificationException: Self { .init(.concurrentModificationException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var mailFromDomainNotVerifiedException: Self { .init(.mailFromDomainNotVerifiedException) }
+    public static var messageRejected: Self { .init(.messageRejected) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var sendingPausedException: Self { .init(.sendingPausedException) }
+    public static var tooManyRequestsException: Self { .init(.tooManyRequestsException) }
+}
+
+extension PinpointEmailErrorType: Equatable {
+    public static func == (lhs: PinpointEmailErrorType, rhs: PinpointEmailErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension PinpointEmailErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accountSuspendedException(let message):
-            return "AccountSuspendedException: \(message ?? "")"
-        case .alreadyExistsException(let message):
-            return "AlreadyExistsException: \(message ?? "")"
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        case .concurrentModificationException(let message):
-            return "ConcurrentModificationException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .mailFromDomainNotVerifiedException(let message):
-            return "MailFromDomainNotVerifiedException: \(message ?? "")"
-        case .messageRejected(let message):
-            return "MessageRejected: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .sendingPausedException(let message):
-            return "SendingPausedException: \(message ?? "")"
-        case .tooManyRequestsException(let message):
-            return "TooManyRequestsException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/PinpointSMSVoice/PinpointSMSVoice_Error.swift
+++ b/Sources/Soto/Services/PinpointSMSVoice/PinpointSMSVoice_Error.swift
@@ -17,55 +17,50 @@
 import SotoCore
 
 /// Error enum for PinpointSMSVoice
-public enum PinpointSMSVoiceErrorType: AWSErrorType {
-    case alreadyExistsException(message: String?)
-    case badRequestException(message: String?)
-    case internalServiceErrorException(message: String?)
-    case limitExceededException(message: String?)
-    case notFoundException(message: String?)
-    case tooManyRequestsException(message: String?)
-}
+public struct PinpointSMSVoiceErrorType: AWSErrorType {
+    enum Code: String {
+        case alreadyExistsException = "AlreadyExistsException"
+        case badRequestException = "BadRequestException"
+        case internalServiceErrorException = "InternalServiceErrorException"
+        case limitExceededException = "LimitExceededException"
+        case notFoundException = "NotFoundException"
+        case tooManyRequestsException = "TooManyRequestsException"
+    }
 
-extension PinpointSMSVoiceErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AlreadyExistsException":
-            self = .alreadyExistsException(message: message)
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        case "InternalServiceErrorException":
-            self = .internalServiceErrorException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "TooManyRequestsException":
-            self = .tooManyRequestsException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var alreadyExistsException: Self { .init(.alreadyExistsException) }
+    public static var badRequestException: Self { .init(.badRequestException) }
+    public static var internalServiceErrorException: Self { .init(.internalServiceErrorException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var tooManyRequestsException: Self { .init(.tooManyRequestsException) }
+}
+
+extension PinpointSMSVoiceErrorType: Equatable {
+    public static func == (lhs: PinpointSMSVoiceErrorType, rhs: PinpointSMSVoiceErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension PinpointSMSVoiceErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .alreadyExistsException(let message):
-            return "AlreadyExistsException: \(message ?? "")"
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        case .internalServiceErrorException(let message):
-            return "InternalServiceErrorException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .tooManyRequestsException(let message):
-            return "TooManyRequestsException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Polly/Polly_Error.swift
+++ b/Sources/Soto/Services/Polly/Polly_Error.swift
@@ -17,130 +17,80 @@
 import SotoCore
 
 /// Error enum for Polly
-public enum PollyErrorType: AWSErrorType {
-    case engineNotSupportedException(message: String?)
-    case invalidLexiconException(message: String?)
-    case invalidNextTokenException(message: String?)
-    case invalidS3BucketException(message: String?)
-    case invalidS3KeyException(message: String?)
-    case invalidSampleRateException(message: String?)
-    case invalidSnsTopicArnException(message: String?)
-    case invalidSsmlException(message: String?)
-    case invalidTaskIdException(message: String?)
-    case languageNotSupportedException(message: String?)
-    case lexiconNotFoundException(message: String?)
-    case lexiconSizeExceededException(message: String?)
-    case marksNotSupportedForFormatException(message: String?)
-    case maxLexemeLengthExceededException(message: String?)
-    case maxLexiconsNumberExceededException(message: String?)
-    case serviceFailureException(message: String?)
-    case ssmlMarksNotSupportedForTextTypeException(message: String?)
-    case synthesisTaskNotFoundException(message: String?)
-    case textLengthExceededException(message: String?)
-    case unsupportedPlsAlphabetException(message: String?)
-    case unsupportedPlsLanguageException(message: String?)
-}
+public struct PollyErrorType: AWSErrorType {
+    enum Code: String {
+        case engineNotSupportedException = "EngineNotSupportedException"
+        case invalidLexiconException = "InvalidLexiconException"
+        case invalidNextTokenException = "InvalidNextTokenException"
+        case invalidS3BucketException = "InvalidS3BucketException"
+        case invalidS3KeyException = "InvalidS3KeyException"
+        case invalidSampleRateException = "InvalidSampleRateException"
+        case invalidSnsTopicArnException = "InvalidSnsTopicArnException"
+        case invalidSsmlException = "InvalidSsmlException"
+        case invalidTaskIdException = "InvalidTaskIdException"
+        case languageNotSupportedException = "LanguageNotSupportedException"
+        case lexiconNotFoundException = "LexiconNotFoundException"
+        case lexiconSizeExceededException = "LexiconSizeExceededException"
+        case marksNotSupportedForFormatException = "MarksNotSupportedForFormatException"
+        case maxLexemeLengthExceededException = "MaxLexemeLengthExceededException"
+        case maxLexiconsNumberExceededException = "MaxLexiconsNumberExceededException"
+        case serviceFailureException = "ServiceFailureException"
+        case ssmlMarksNotSupportedForTextTypeException = "SsmlMarksNotSupportedForTextTypeException"
+        case synthesisTaskNotFoundException = "SynthesisTaskNotFoundException"
+        case textLengthExceededException = "TextLengthExceededException"
+        case unsupportedPlsAlphabetException = "UnsupportedPlsAlphabetException"
+        case unsupportedPlsLanguageException = "UnsupportedPlsLanguageException"
+    }
 
-extension PollyErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "EngineNotSupportedException":
-            self = .engineNotSupportedException(message: message)
-        case "InvalidLexiconException":
-            self = .invalidLexiconException(message: message)
-        case "InvalidNextTokenException":
-            self = .invalidNextTokenException(message: message)
-        case "InvalidS3BucketException":
-            self = .invalidS3BucketException(message: message)
-        case "InvalidS3KeyException":
-            self = .invalidS3KeyException(message: message)
-        case "InvalidSampleRateException":
-            self = .invalidSampleRateException(message: message)
-        case "InvalidSnsTopicArnException":
-            self = .invalidSnsTopicArnException(message: message)
-        case "InvalidSsmlException":
-            self = .invalidSsmlException(message: message)
-        case "InvalidTaskIdException":
-            self = .invalidTaskIdException(message: message)
-        case "LanguageNotSupportedException":
-            self = .languageNotSupportedException(message: message)
-        case "LexiconNotFoundException":
-            self = .lexiconNotFoundException(message: message)
-        case "LexiconSizeExceededException":
-            self = .lexiconSizeExceededException(message: message)
-        case "MarksNotSupportedForFormatException":
-            self = .marksNotSupportedForFormatException(message: message)
-        case "MaxLexemeLengthExceededException":
-            self = .maxLexemeLengthExceededException(message: message)
-        case "MaxLexiconsNumberExceededException":
-            self = .maxLexiconsNumberExceededException(message: message)
-        case "ServiceFailureException":
-            self = .serviceFailureException(message: message)
-        case "SsmlMarksNotSupportedForTextTypeException":
-            self = .ssmlMarksNotSupportedForTextTypeException(message: message)
-        case "SynthesisTaskNotFoundException":
-            self = .synthesisTaskNotFoundException(message: message)
-        case "TextLengthExceededException":
-            self = .textLengthExceededException(message: message)
-        case "UnsupportedPlsAlphabetException":
-            self = .unsupportedPlsAlphabetException(message: message)
-        case "UnsupportedPlsLanguageException":
-            self = .unsupportedPlsLanguageException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var engineNotSupportedException: Self { .init(.engineNotSupportedException) }
+    public static var invalidLexiconException: Self { .init(.invalidLexiconException) }
+    public static var invalidNextTokenException: Self { .init(.invalidNextTokenException) }
+    public static var invalidS3BucketException: Self { .init(.invalidS3BucketException) }
+    public static var invalidS3KeyException: Self { .init(.invalidS3KeyException) }
+    public static var invalidSampleRateException: Self { .init(.invalidSampleRateException) }
+    public static var invalidSnsTopicArnException: Self { .init(.invalidSnsTopicArnException) }
+    public static var invalidSsmlException: Self { .init(.invalidSsmlException) }
+    public static var invalidTaskIdException: Self { .init(.invalidTaskIdException) }
+    public static var languageNotSupportedException: Self { .init(.languageNotSupportedException) }
+    public static var lexiconNotFoundException: Self { .init(.lexiconNotFoundException) }
+    public static var lexiconSizeExceededException: Self { .init(.lexiconSizeExceededException) }
+    public static var marksNotSupportedForFormatException: Self { .init(.marksNotSupportedForFormatException) }
+    public static var maxLexemeLengthExceededException: Self { .init(.maxLexemeLengthExceededException) }
+    public static var maxLexiconsNumberExceededException: Self { .init(.maxLexiconsNumberExceededException) }
+    public static var serviceFailureException: Self { .init(.serviceFailureException) }
+    public static var ssmlMarksNotSupportedForTextTypeException: Self { .init(.ssmlMarksNotSupportedForTextTypeException) }
+    public static var synthesisTaskNotFoundException: Self { .init(.synthesisTaskNotFoundException) }
+    public static var textLengthExceededException: Self { .init(.textLengthExceededException) }
+    public static var unsupportedPlsAlphabetException: Self { .init(.unsupportedPlsAlphabetException) }
+    public static var unsupportedPlsLanguageException: Self { .init(.unsupportedPlsLanguageException) }
+}
+
+extension PollyErrorType: Equatable {
+    public static func == (lhs: PollyErrorType, rhs: PollyErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension PollyErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .engineNotSupportedException(let message):
-            return "EngineNotSupportedException: \(message ?? "")"
-        case .invalidLexiconException(let message):
-            return "InvalidLexiconException: \(message ?? "")"
-        case .invalidNextTokenException(let message):
-            return "InvalidNextTokenException: \(message ?? "")"
-        case .invalidS3BucketException(let message):
-            return "InvalidS3BucketException: \(message ?? "")"
-        case .invalidS3KeyException(let message):
-            return "InvalidS3KeyException: \(message ?? "")"
-        case .invalidSampleRateException(let message):
-            return "InvalidSampleRateException: \(message ?? "")"
-        case .invalidSnsTopicArnException(let message):
-            return "InvalidSnsTopicArnException: \(message ?? "")"
-        case .invalidSsmlException(let message):
-            return "InvalidSsmlException: \(message ?? "")"
-        case .invalidTaskIdException(let message):
-            return "InvalidTaskIdException: \(message ?? "")"
-        case .languageNotSupportedException(let message):
-            return "LanguageNotSupportedException: \(message ?? "")"
-        case .lexiconNotFoundException(let message):
-            return "LexiconNotFoundException: \(message ?? "")"
-        case .lexiconSizeExceededException(let message):
-            return "LexiconSizeExceededException: \(message ?? "")"
-        case .marksNotSupportedForFormatException(let message):
-            return "MarksNotSupportedForFormatException: \(message ?? "")"
-        case .maxLexemeLengthExceededException(let message):
-            return "MaxLexemeLengthExceededException: \(message ?? "")"
-        case .maxLexiconsNumberExceededException(let message):
-            return "MaxLexiconsNumberExceededException: \(message ?? "")"
-        case .serviceFailureException(let message):
-            return "ServiceFailureException: \(message ?? "")"
-        case .ssmlMarksNotSupportedForTextTypeException(let message):
-            return "SsmlMarksNotSupportedForTextTypeException: \(message ?? "")"
-        case .synthesisTaskNotFoundException(let message):
-            return "SynthesisTaskNotFoundException: \(message ?? "")"
-        case .textLengthExceededException(let message):
-            return "TextLengthExceededException: \(message ?? "")"
-        case .unsupportedPlsAlphabetException(let message):
-            return "UnsupportedPlsAlphabetException: \(message ?? "")"
-        case .unsupportedPlsLanguageException(let message):
-            return "UnsupportedPlsLanguageException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Pricing/Pricing_Error.swift
+++ b/Sources/Soto/Services/Pricing/Pricing_Error.swift
@@ -17,50 +17,48 @@
 import SotoCore
 
 /// Error enum for Pricing
-public enum PricingErrorType: AWSErrorType {
-    case expiredNextTokenException(message: String?)
-    case internalErrorException(message: String?)
-    case invalidNextTokenException(message: String?)
-    case invalidParameterException(message: String?)
-    case notFoundException(message: String?)
-}
+public struct PricingErrorType: AWSErrorType {
+    enum Code: String {
+        case expiredNextTokenException = "ExpiredNextTokenException"
+        case internalErrorException = "InternalErrorException"
+        case invalidNextTokenException = "InvalidNextTokenException"
+        case invalidParameterException = "InvalidParameterException"
+        case notFoundException = "NotFoundException"
+    }
 
-extension PricingErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ExpiredNextTokenException":
-            self = .expiredNextTokenException(message: message)
-        case "InternalErrorException":
-            self = .internalErrorException(message: message)
-        case "InvalidNextTokenException":
-            self = .invalidNextTokenException(message: message)
-        case "InvalidParameterException":
-            self = .invalidParameterException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var expiredNextTokenException: Self { .init(.expiredNextTokenException) }
+    public static var internalErrorException: Self { .init(.internalErrorException) }
+    public static var invalidNextTokenException: Self { .init(.invalidNextTokenException) }
+    public static var invalidParameterException: Self { .init(.invalidParameterException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+}
+
+extension PricingErrorType: Equatable {
+    public static func == (lhs: PricingErrorType, rhs: PricingErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension PricingErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .expiredNextTokenException(let message):
-            return "ExpiredNextTokenException: \(message ?? "")"
-        case .internalErrorException(let message):
-            return "InternalErrorException: \(message ?? "")"
-        case .invalidNextTokenException(let message):
-            return "InvalidNextTokenException: \(message ?? "")"
-        case .invalidParameterException(let message):
-            return "InvalidParameterException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/QLDB/QLDB_Error.swift
+++ b/Sources/Soto/Services/QLDB/QLDB_Error.swift
@@ -17,55 +17,50 @@
 import SotoCore
 
 /// Error enum for QLDB
-public enum QLDBErrorType: AWSErrorType {
-    case invalidParameterException(message: String?)
-    case limitExceededException(message: String?)
-    case resourceAlreadyExistsException(message: String?)
-    case resourceInUseException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case resourcePreconditionNotMetException(message: String?)
-}
+public struct QLDBErrorType: AWSErrorType {
+    enum Code: String {
+        case invalidParameterException = "InvalidParameterException"
+        case limitExceededException = "LimitExceededException"
+        case resourceAlreadyExistsException = "ResourceAlreadyExistsException"
+        case resourceInUseException = "ResourceInUseException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case resourcePreconditionNotMetException = "ResourcePreconditionNotMetException"
+    }
 
-extension QLDBErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "InvalidParameterException":
-            self = .invalidParameterException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ResourceAlreadyExistsException":
-            self = .resourceAlreadyExistsException(message: message)
-        case "ResourceInUseException":
-            self = .resourceInUseException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ResourcePreconditionNotMetException":
-            self = .resourcePreconditionNotMetException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var invalidParameterException: Self { .init(.invalidParameterException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var resourceAlreadyExistsException: Self { .init(.resourceAlreadyExistsException) }
+    public static var resourceInUseException: Self { .init(.resourceInUseException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var resourcePreconditionNotMetException: Self { .init(.resourcePreconditionNotMetException) }
+}
+
+extension QLDBErrorType: Equatable {
+    public static func == (lhs: QLDBErrorType, rhs: QLDBErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension QLDBErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .invalidParameterException(let message):
-            return "InvalidParameterException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .resourceAlreadyExistsException(let message):
-            return "ResourceAlreadyExistsException: \(message ?? "")"
-        case .resourceInUseException(let message):
-            return "ResourceInUseException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .resourcePreconditionNotMetException(let message):
-            return "ResourcePreconditionNotMetException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/QLDBSession/QLDBSession_Error.swift
+++ b/Sources/Soto/Services/QLDBSession/QLDBSession_Error.swift
@@ -17,50 +17,48 @@
 import SotoCore
 
 /// Error enum for QLDBSession
-public enum QLDBSessionErrorType: AWSErrorType {
-    case badRequestException(message: String?)
-    case invalidSessionException(message: String?)
-    case limitExceededException(message: String?)
-    case occConflictException(message: String?)
-    case rateExceededException(message: String?)
-}
+public struct QLDBSessionErrorType: AWSErrorType {
+    enum Code: String {
+        case badRequestException = "BadRequestException"
+        case invalidSessionException = "InvalidSessionException"
+        case limitExceededException = "LimitExceededException"
+        case occConflictException = "OccConflictException"
+        case rateExceededException = "RateExceededException"
+    }
 
-extension QLDBSessionErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        case "InvalidSessionException":
-            self = .invalidSessionException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "OccConflictException":
-            self = .occConflictException(message: message)
-        case "RateExceededException":
-            self = .rateExceededException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var badRequestException: Self { .init(.badRequestException) }
+    public static var invalidSessionException: Self { .init(.invalidSessionException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var occConflictException: Self { .init(.occConflictException) }
+    public static var rateExceededException: Self { .init(.rateExceededException) }
+}
+
+extension QLDBSessionErrorType: Equatable {
+    public static func == (lhs: QLDBSessionErrorType, rhs: QLDBSessionErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension QLDBSessionErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        case .invalidSessionException(let message):
-            return "InvalidSessionException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .occConflictException(let message):
-            return "OccConflictException: \(message ?? "")"
-        case .rateExceededException(let message):
-            return "RateExceededException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/QuickSight/QuickSight_Error.swift
+++ b/Sources/Soto/Services/QuickSight/QuickSight_Error.swift
@@ -17,110 +17,72 @@
 import SotoCore
 
 /// Error enum for QuickSight
-public enum QuickSightErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case concurrentUpdatingException(message: String?)
-    case conflictException(message: String?)
-    case domainNotWhitelistedException(message: String?)
-    case identityTypeNotSupportedException(message: String?)
-    case internalFailureException(message: String?)
-    case invalidNextTokenException(message: String?)
-    case invalidParameterValueException(message: String?)
-    case limitExceededException(message: String?)
-    case preconditionNotMetException(message: String?)
-    case quickSightUserNotFoundException(message: String?)
-    case resourceExistsException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case resourceUnavailableException(message: String?)
-    case sessionLifetimeInMinutesInvalidException(message: String?)
-    case throttlingException(message: String?)
-    case unsupportedUserEditionException(message: String?)
-}
+public struct QuickSightErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case concurrentUpdatingException = "ConcurrentUpdatingException"
+        case conflictException = "ConflictException"
+        case domainNotWhitelistedException = "DomainNotWhitelistedException"
+        case identityTypeNotSupportedException = "IdentityTypeNotSupportedException"
+        case internalFailureException = "InternalFailureException"
+        case invalidNextTokenException = "InvalidNextTokenException"
+        case invalidParameterValueException = "InvalidParameterValueException"
+        case limitExceededException = "LimitExceededException"
+        case preconditionNotMetException = "PreconditionNotMetException"
+        case quickSightUserNotFoundException = "QuickSightUserNotFoundException"
+        case resourceExistsException = "ResourceExistsException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case resourceUnavailableException = "ResourceUnavailableException"
+        case sessionLifetimeInMinutesInvalidException = "SessionLifetimeInMinutesInvalidException"
+        case throttlingException = "ThrottlingException"
+        case unsupportedUserEditionException = "UnsupportedUserEditionException"
+    }
 
-extension QuickSightErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "ConcurrentUpdatingException":
-            self = .concurrentUpdatingException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "DomainNotWhitelistedException":
-            self = .domainNotWhitelistedException(message: message)
-        case "IdentityTypeNotSupportedException":
-            self = .identityTypeNotSupportedException(message: message)
-        case "InternalFailureException":
-            self = .internalFailureException(message: message)
-        case "InvalidNextTokenException":
-            self = .invalidNextTokenException(message: message)
-        case "InvalidParameterValueException":
-            self = .invalidParameterValueException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "PreconditionNotMetException":
-            self = .preconditionNotMetException(message: message)
-        case "QuickSightUserNotFoundException":
-            self = .quickSightUserNotFoundException(message: message)
-        case "ResourceExistsException":
-            self = .resourceExistsException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ResourceUnavailableException":
-            self = .resourceUnavailableException(message: message)
-        case "SessionLifetimeInMinutesInvalidException":
-            self = .sessionLifetimeInMinutesInvalidException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        case "UnsupportedUserEditionException":
-            self = .unsupportedUserEditionException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var concurrentUpdatingException: Self { .init(.concurrentUpdatingException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var domainNotWhitelistedException: Self { .init(.domainNotWhitelistedException) }
+    public static var identityTypeNotSupportedException: Self { .init(.identityTypeNotSupportedException) }
+    public static var internalFailureException: Self { .init(.internalFailureException) }
+    public static var invalidNextTokenException: Self { .init(.invalidNextTokenException) }
+    public static var invalidParameterValueException: Self { .init(.invalidParameterValueException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var preconditionNotMetException: Self { .init(.preconditionNotMetException) }
+    public static var quickSightUserNotFoundException: Self { .init(.quickSightUserNotFoundException) }
+    public static var resourceExistsException: Self { .init(.resourceExistsException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var resourceUnavailableException: Self { .init(.resourceUnavailableException) }
+    public static var sessionLifetimeInMinutesInvalidException: Self { .init(.sessionLifetimeInMinutesInvalidException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+    public static var unsupportedUserEditionException: Self { .init(.unsupportedUserEditionException) }
+}
+
+extension QuickSightErrorType: Equatable {
+    public static func == (lhs: QuickSightErrorType, rhs: QuickSightErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension QuickSightErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .concurrentUpdatingException(let message):
-            return "ConcurrentUpdatingException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .domainNotWhitelistedException(let message):
-            return "DomainNotWhitelistedException: \(message ?? "")"
-        case .identityTypeNotSupportedException(let message):
-            return "IdentityTypeNotSupportedException: \(message ?? "")"
-        case .internalFailureException(let message):
-            return "InternalFailureException: \(message ?? "")"
-        case .invalidNextTokenException(let message):
-            return "InvalidNextTokenException: \(message ?? "")"
-        case .invalidParameterValueException(let message):
-            return "InvalidParameterValueException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .preconditionNotMetException(let message):
-            return "PreconditionNotMetException: \(message ?? "")"
-        case .quickSightUserNotFoundException(let message):
-            return "QuickSightUserNotFoundException: \(message ?? "")"
-        case .resourceExistsException(let message):
-            return "ResourceExistsException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .resourceUnavailableException(let message):
-            return "ResourceUnavailableException: \(message ?? "")"
-        case .sessionLifetimeInMinutesInvalidException(let message):
-            return "SessionLifetimeInMinutesInvalidException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        case .unsupportedUserEditionException(let message):
-            return "UnsupportedUserEditionException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/RAM/RAM_Error.swift
+++ b/Sources/Soto/Services/RAM/RAM_Error.swift
@@ -17,130 +17,80 @@
 import SotoCore
 
 /// Error enum for RAM
-public enum RAMErrorType: AWSErrorType {
-    case idempotentParameterMismatchException(message: String?)
-    case invalidClientTokenException(message: String?)
-    case invalidMaxResultsException(message: String?)
-    case invalidNextTokenException(message: String?)
-    case invalidParameterException(message: String?)
-    case invalidResourceTypeException(message: String?)
-    case invalidStateTransitionException(message: String?)
-    case malformedArnException(message: String?)
-    case missingRequiredParameterException(message: String?)
-    case operationNotPermittedException(message: String?)
-    case resourceArnNotFoundException(message: String?)
-    case resourceShareInvitationAlreadyAcceptedException(message: String?)
-    case resourceShareInvitationAlreadyRejectedException(message: String?)
-    case resourceShareInvitationArnNotFoundException(message: String?)
-    case resourceShareInvitationExpiredException(message: String?)
-    case resourceShareLimitExceededException(message: String?)
-    case serverInternalException(message: String?)
-    case serviceUnavailableException(message: String?)
-    case tagLimitExceededException(message: String?)
-    case tagPolicyViolationException(message: String?)
-    case unknownResourceException(message: String?)
-}
+public struct RAMErrorType: AWSErrorType {
+    enum Code: String {
+        case idempotentParameterMismatchException = "IdempotentParameterMismatchException"
+        case invalidClientTokenException = "InvalidClientTokenException"
+        case invalidMaxResultsException = "InvalidMaxResultsException"
+        case invalidNextTokenException = "InvalidNextTokenException"
+        case invalidParameterException = "InvalidParameterException"
+        case invalidResourceTypeException = "InvalidResourceTypeException"
+        case invalidStateTransitionException = "InvalidStateTransitionException"
+        case malformedArnException = "MalformedArnException"
+        case missingRequiredParameterException = "MissingRequiredParameterException"
+        case operationNotPermittedException = "OperationNotPermittedException"
+        case resourceArnNotFoundException = "ResourceArnNotFoundException"
+        case resourceShareInvitationAlreadyAcceptedException = "ResourceShareInvitationAlreadyAcceptedException"
+        case resourceShareInvitationAlreadyRejectedException = "ResourceShareInvitationAlreadyRejectedException"
+        case resourceShareInvitationArnNotFoundException = "ResourceShareInvitationArnNotFoundException"
+        case resourceShareInvitationExpiredException = "ResourceShareInvitationExpiredException"
+        case resourceShareLimitExceededException = "ResourceShareLimitExceededException"
+        case serverInternalException = "ServerInternalException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+        case tagLimitExceededException = "TagLimitExceededException"
+        case tagPolicyViolationException = "TagPolicyViolationException"
+        case unknownResourceException = "UnknownResourceException"
+    }
 
-extension RAMErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "IdempotentParameterMismatchException":
-            self = .idempotentParameterMismatchException(message: message)
-        case "InvalidClientTokenException":
-            self = .invalidClientTokenException(message: message)
-        case "InvalidMaxResultsException":
-            self = .invalidMaxResultsException(message: message)
-        case "InvalidNextTokenException":
-            self = .invalidNextTokenException(message: message)
-        case "InvalidParameterException":
-            self = .invalidParameterException(message: message)
-        case "InvalidResourceTypeException":
-            self = .invalidResourceTypeException(message: message)
-        case "InvalidStateTransitionException":
-            self = .invalidStateTransitionException(message: message)
-        case "MalformedArnException":
-            self = .malformedArnException(message: message)
-        case "MissingRequiredParameterException":
-            self = .missingRequiredParameterException(message: message)
-        case "OperationNotPermittedException":
-            self = .operationNotPermittedException(message: message)
-        case "ResourceArnNotFoundException":
-            self = .resourceArnNotFoundException(message: message)
-        case "ResourceShareInvitationAlreadyAcceptedException":
-            self = .resourceShareInvitationAlreadyAcceptedException(message: message)
-        case "ResourceShareInvitationAlreadyRejectedException":
-            self = .resourceShareInvitationAlreadyRejectedException(message: message)
-        case "ResourceShareInvitationArnNotFoundException":
-            self = .resourceShareInvitationArnNotFoundException(message: message)
-        case "ResourceShareInvitationExpiredException":
-            self = .resourceShareInvitationExpiredException(message: message)
-        case "ResourceShareLimitExceededException":
-            self = .resourceShareLimitExceededException(message: message)
-        case "ServerInternalException":
-            self = .serverInternalException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        case "TagLimitExceededException":
-            self = .tagLimitExceededException(message: message)
-        case "TagPolicyViolationException":
-            self = .tagPolicyViolationException(message: message)
-        case "UnknownResourceException":
-            self = .unknownResourceException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var idempotentParameterMismatchException: Self { .init(.idempotentParameterMismatchException) }
+    public static var invalidClientTokenException: Self { .init(.invalidClientTokenException) }
+    public static var invalidMaxResultsException: Self { .init(.invalidMaxResultsException) }
+    public static var invalidNextTokenException: Self { .init(.invalidNextTokenException) }
+    public static var invalidParameterException: Self { .init(.invalidParameterException) }
+    public static var invalidResourceTypeException: Self { .init(.invalidResourceTypeException) }
+    public static var invalidStateTransitionException: Self { .init(.invalidStateTransitionException) }
+    public static var malformedArnException: Self { .init(.malformedArnException) }
+    public static var missingRequiredParameterException: Self { .init(.missingRequiredParameterException) }
+    public static var operationNotPermittedException: Self { .init(.operationNotPermittedException) }
+    public static var resourceArnNotFoundException: Self { .init(.resourceArnNotFoundException) }
+    public static var resourceShareInvitationAlreadyAcceptedException: Self { .init(.resourceShareInvitationAlreadyAcceptedException) }
+    public static var resourceShareInvitationAlreadyRejectedException: Self { .init(.resourceShareInvitationAlreadyRejectedException) }
+    public static var resourceShareInvitationArnNotFoundException: Self { .init(.resourceShareInvitationArnNotFoundException) }
+    public static var resourceShareInvitationExpiredException: Self { .init(.resourceShareInvitationExpiredException) }
+    public static var resourceShareLimitExceededException: Self { .init(.resourceShareLimitExceededException) }
+    public static var serverInternalException: Self { .init(.serverInternalException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+    public static var tagLimitExceededException: Self { .init(.tagLimitExceededException) }
+    public static var tagPolicyViolationException: Self { .init(.tagPolicyViolationException) }
+    public static var unknownResourceException: Self { .init(.unknownResourceException) }
+}
+
+extension RAMErrorType: Equatable {
+    public static func == (lhs: RAMErrorType, rhs: RAMErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension RAMErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .idempotentParameterMismatchException(let message):
-            return "IdempotentParameterMismatchException: \(message ?? "")"
-        case .invalidClientTokenException(let message):
-            return "InvalidClientTokenException: \(message ?? "")"
-        case .invalidMaxResultsException(let message):
-            return "InvalidMaxResultsException: \(message ?? "")"
-        case .invalidNextTokenException(let message):
-            return "InvalidNextTokenException: \(message ?? "")"
-        case .invalidParameterException(let message):
-            return "InvalidParameterException: \(message ?? "")"
-        case .invalidResourceTypeException(let message):
-            return "InvalidResourceTypeException: \(message ?? "")"
-        case .invalidStateTransitionException(let message):
-            return "InvalidStateTransitionException: \(message ?? "")"
-        case .malformedArnException(let message):
-            return "MalformedArnException: \(message ?? "")"
-        case .missingRequiredParameterException(let message):
-            return "MissingRequiredParameterException: \(message ?? "")"
-        case .operationNotPermittedException(let message):
-            return "OperationNotPermittedException: \(message ?? "")"
-        case .resourceArnNotFoundException(let message):
-            return "ResourceArnNotFoundException: \(message ?? "")"
-        case .resourceShareInvitationAlreadyAcceptedException(let message):
-            return "ResourceShareInvitationAlreadyAcceptedException: \(message ?? "")"
-        case .resourceShareInvitationAlreadyRejectedException(let message):
-            return "ResourceShareInvitationAlreadyRejectedException: \(message ?? "")"
-        case .resourceShareInvitationArnNotFoundException(let message):
-            return "ResourceShareInvitationArnNotFoundException: \(message ?? "")"
-        case .resourceShareInvitationExpiredException(let message):
-            return "ResourceShareInvitationExpiredException: \(message ?? "")"
-        case .resourceShareLimitExceededException(let message):
-            return "ResourceShareLimitExceededException: \(message ?? "")"
-        case .serverInternalException(let message):
-            return "ServerInternalException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        case .tagLimitExceededException(let message):
-            return "TagLimitExceededException: \(message ?? "")"
-        case .tagPolicyViolationException(let message):
-            return "TagPolicyViolationException: \(message ?? "")"
-        case .unknownResourceException(let message):
-            return "UnknownResourceException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/RDS/RDS_Error.swift
+++ b/Sources/Soto/Services/RDS/RDS_Error.swift
@@ -17,590 +17,264 @@
 import SotoCore
 
 /// Error enum for RDS
-public enum RDSErrorType: AWSErrorType {
-    case authorizationAlreadyExistsFault(message: String?)
-    case authorizationNotFoundFault(message: String?)
-    case authorizationQuotaExceededFault(message: String?)
-    case backupPolicyNotFoundFault(message: String?)
-    case certificateNotFoundFault(message: String?)
-    case customAvailabilityZoneAlreadyExistsFault(message: String?)
-    case customAvailabilityZoneNotFoundFault(message: String?)
-    case customAvailabilityZoneQuotaExceededFault(message: String?)
-    case dBClusterAlreadyExistsFault(message: String?)
-    case dBClusterBacktrackNotFoundFault(message: String?)
-    case dBClusterEndpointAlreadyExistsFault(message: String?)
-    case dBClusterEndpointNotFoundFault(message: String?)
-    case dBClusterEndpointQuotaExceededFault(message: String?)
-    case dBClusterNotFoundFault(message: String?)
-    case dBClusterParameterGroupNotFoundFault(message: String?)
-    case dBClusterQuotaExceededFault(message: String?)
-    case dBClusterRoleAlreadyExistsFault(message: String?)
-    case dBClusterRoleNotFoundFault(message: String?)
-    case dBClusterRoleQuotaExceededFault(message: String?)
-    case dBClusterSnapshotAlreadyExistsFault(message: String?)
-    case dBClusterSnapshotNotFoundFault(message: String?)
-    case dBInstanceAlreadyExistsFault(message: String?)
-    case dBInstanceAutomatedBackupNotFoundFault(message: String?)
-    case dBInstanceAutomatedBackupQuotaExceededFault(message: String?)
-    case dBInstanceNotFoundFault(message: String?)
-    case dBInstanceRoleAlreadyExistsFault(message: String?)
-    case dBInstanceRoleNotFoundFault(message: String?)
-    case dBInstanceRoleQuotaExceededFault(message: String?)
-    case dBLogFileNotFoundFault(message: String?)
-    case dBParameterGroupAlreadyExistsFault(message: String?)
-    case dBParameterGroupNotFoundFault(message: String?)
-    case dBParameterGroupQuotaExceededFault(message: String?)
-    case dBProxyAlreadyExistsFault(message: String?)
-    case dBProxyNotFoundFault(message: String?)
-    case dBProxyQuotaExceededFault(message: String?)
-    case dBProxyTargetAlreadyRegisteredFault(message: String?)
-    case dBProxyTargetGroupNotFoundFault(message: String?)
-    case dBProxyTargetNotFoundFault(message: String?)
-    case dBSecurityGroupAlreadyExistsFault(message: String?)
-    case dBSecurityGroupNotFoundFault(message: String?)
-    case dBSecurityGroupNotSupportedFault(message: String?)
-    case dBSecurityGroupQuotaExceededFault(message: String?)
-    case dBSnapshotAlreadyExistsFault(message: String?)
-    case dBSnapshotNotFoundFault(message: String?)
-    case dBSubnetGroupAlreadyExistsFault(message: String?)
-    case dBSubnetGroupDoesNotCoverEnoughAZs(message: String?)
-    case dBSubnetGroupNotAllowedFault(message: String?)
-    case dBSubnetGroupNotFoundFault(message: String?)
-    case dBSubnetGroupQuotaExceededFault(message: String?)
-    case dBSubnetQuotaExceededFault(message: String?)
-    case dBUpgradeDependencyFailureFault(message: String?)
-    case domainNotFoundFault(message: String?)
-    case eventSubscriptionQuotaExceededFault(message: String?)
-    case exportTaskAlreadyExistsFault(message: String?)
-    case exportTaskNotFoundFault(message: String?)
-    case globalClusterAlreadyExistsFault(message: String?)
-    case globalClusterNotFoundFault(message: String?)
-    case globalClusterQuotaExceededFault(message: String?)
-    case iamRoleMissingPermissionsFault(message: String?)
-    case iamRoleNotFoundFault(message: String?)
-    case installationMediaAlreadyExistsFault(message: String?)
-    case installationMediaNotFoundFault(message: String?)
-    case instanceQuotaExceededFault(message: String?)
-    case insufficientAvailableIPsInSubnetFault(message: String?)
-    case insufficientDBClusterCapacityFault(message: String?)
-    case insufficientDBInstanceCapacityFault(message: String?)
-    case insufficientStorageClusterCapacityFault(message: String?)
-    case invalidDBClusterCapacityFault(message: String?)
-    case invalidDBClusterEndpointStateFault(message: String?)
-    case invalidDBClusterSnapshotStateFault(message: String?)
-    case invalidDBClusterStateFault(message: String?)
-    case invalidDBInstanceAutomatedBackupStateFault(message: String?)
-    case invalidDBInstanceStateFault(message: String?)
-    case invalidDBParameterGroupStateFault(message: String?)
-    case invalidDBProxyStateFault(message: String?)
-    case invalidDBSecurityGroupStateFault(message: String?)
-    case invalidDBSnapshotStateFault(message: String?)
-    case invalidDBSubnetGroupFault(message: String?)
-    case invalidDBSubnetGroupStateFault(message: String?)
-    case invalidDBSubnetStateFault(message: String?)
-    case invalidEventSubscriptionStateFault(message: String?)
-    case invalidExportOnlyFault(message: String?)
-    case invalidExportSourceStateFault(message: String?)
-    case invalidExportTaskStateFault(message: String?)
-    case invalidGlobalClusterStateFault(message: String?)
-    case invalidOptionGroupStateFault(message: String?)
-    case invalidRestoreFault(message: String?)
-    case invalidS3BucketFault(message: String?)
-    case invalidSubnet(message: String?)
-    case invalidVPCNetworkStateFault(message: String?)
-    case kMSKeyNotAccessibleFault(message: String?)
-    case optionGroupAlreadyExistsFault(message: String?)
-    case optionGroupNotFoundFault(message: String?)
-    case optionGroupQuotaExceededFault(message: String?)
-    case pointInTimeRestoreNotEnabledFault(message: String?)
-    case provisionedIopsNotAvailableInAZFault(message: String?)
-    case reservedDBInstanceAlreadyExistsFault(message: String?)
-    case reservedDBInstanceNotFoundFault(message: String?)
-    case reservedDBInstanceQuotaExceededFault(message: String?)
-    case reservedDBInstancesOfferingNotFoundFault(message: String?)
-    case resourceNotFoundFault(message: String?)
-    case sNSInvalidTopicFault(message: String?)
-    case sNSNoAuthorizationFault(message: String?)
-    case sNSTopicArnNotFoundFault(message: String?)
-    case sharedSnapshotQuotaExceededFault(message: String?)
-    case snapshotQuotaExceededFault(message: String?)
-    case sourceNotFoundFault(message: String?)
-    case storageQuotaExceededFault(message: String?)
-    case storageTypeNotSupportedFault(message: String?)
-    case subnetAlreadyInUse(message: String?)
-    case subscriptionAlreadyExistFault(message: String?)
-    case subscriptionCategoryNotFoundFault(message: String?)
-    case subscriptionNotFoundFault(message: String?)
-}
+public struct RDSErrorType: AWSErrorType {
+    enum Code: String {
+        case authorizationAlreadyExistsFault = "AuthorizationAlreadyExists"
+        case authorizationNotFoundFault = "AuthorizationNotFound"
+        case authorizationQuotaExceededFault = "AuthorizationQuotaExceeded"
+        case backupPolicyNotFoundFault = "BackupPolicyNotFoundFault"
+        case certificateNotFoundFault = "CertificateNotFound"
+        case customAvailabilityZoneAlreadyExistsFault = "CustomAvailabilityZoneAlreadyExists"
+        case customAvailabilityZoneNotFoundFault = "CustomAvailabilityZoneNotFound"
+        case customAvailabilityZoneQuotaExceededFault = "CustomAvailabilityZoneQuotaExceeded"
+        case dBClusterAlreadyExistsFault = "DBClusterAlreadyExistsFault"
+        case dBClusterBacktrackNotFoundFault = "DBClusterBacktrackNotFoundFault"
+        case dBClusterEndpointAlreadyExistsFault = "DBClusterEndpointAlreadyExistsFault"
+        case dBClusterEndpointNotFoundFault = "DBClusterEndpointNotFoundFault"
+        case dBClusterEndpointQuotaExceededFault = "DBClusterEndpointQuotaExceededFault"
+        case dBClusterNotFoundFault = "DBClusterNotFoundFault"
+        case dBClusterParameterGroupNotFoundFault = "DBClusterParameterGroupNotFound"
+        case dBClusterQuotaExceededFault = "DBClusterQuotaExceededFault"
+        case dBClusterRoleAlreadyExistsFault = "DBClusterRoleAlreadyExists"
+        case dBClusterRoleNotFoundFault = "DBClusterRoleNotFound"
+        case dBClusterRoleQuotaExceededFault = "DBClusterRoleQuotaExceeded"
+        case dBClusterSnapshotAlreadyExistsFault = "DBClusterSnapshotAlreadyExistsFault"
+        case dBClusterSnapshotNotFoundFault = "DBClusterSnapshotNotFoundFault"
+        case dBInstanceAlreadyExistsFault = "DBInstanceAlreadyExists"
+        case dBInstanceAutomatedBackupNotFoundFault = "DBInstanceAutomatedBackupNotFound"
+        case dBInstanceAutomatedBackupQuotaExceededFault = "DBInstanceAutomatedBackupQuotaExceeded"
+        case dBInstanceNotFoundFault = "DBInstanceNotFound"
+        case dBInstanceRoleAlreadyExistsFault = "DBInstanceRoleAlreadyExists"
+        case dBInstanceRoleNotFoundFault = "DBInstanceRoleNotFound"
+        case dBInstanceRoleQuotaExceededFault = "DBInstanceRoleQuotaExceeded"
+        case dBLogFileNotFoundFault = "DBLogFileNotFoundFault"
+        case dBParameterGroupAlreadyExistsFault = "DBParameterGroupAlreadyExists"
+        case dBParameterGroupNotFoundFault = "DBParameterGroupNotFound"
+        case dBParameterGroupQuotaExceededFault = "DBParameterGroupQuotaExceeded"
+        case dBProxyAlreadyExistsFault = "DBProxyTargetExistsFault"
+        case dBProxyNotFoundFault = "DBProxyNotFoundFault"
+        case dBProxyQuotaExceededFault = "DBProxyQuotaExceededFault"
+        case dBProxyTargetAlreadyRegisteredFault = "DBProxyTargetAlreadyRegisteredFault"
+        case dBProxyTargetGroupNotFoundFault = "DBProxyTargetGroupNotFoundFault"
+        case dBProxyTargetNotFoundFault = "DBProxyTargetNotFoundFault"
+        case dBSecurityGroupAlreadyExistsFault = "DBSecurityGroupAlreadyExists"
+        case dBSecurityGroupNotFoundFault = "DBSecurityGroupNotFound"
+        case dBSecurityGroupNotSupportedFault = "DBSecurityGroupNotSupported"
+        case dBSecurityGroupQuotaExceededFault = "QuotaExceeded.DBSecurityGroup"
+        case dBSnapshotAlreadyExistsFault = "DBSnapshotAlreadyExists"
+        case dBSnapshotNotFoundFault = "DBSnapshotNotFound"
+        case dBSubnetGroupAlreadyExistsFault = "DBSubnetGroupAlreadyExists"
+        case dBSubnetGroupDoesNotCoverEnoughAZs = "DBSubnetGroupDoesNotCoverEnoughAZs"
+        case dBSubnetGroupNotAllowedFault = "DBSubnetGroupNotAllowedFault"
+        case dBSubnetGroupNotFoundFault = "DBSubnetGroupNotFoundFault"
+        case dBSubnetGroupQuotaExceededFault = "DBSubnetGroupQuotaExceeded"
+        case dBSubnetQuotaExceededFault = "DBSubnetQuotaExceededFault"
+        case dBUpgradeDependencyFailureFault = "DBUpgradeDependencyFailure"
+        case domainNotFoundFault = "DomainNotFoundFault"
+        case eventSubscriptionQuotaExceededFault = "EventSubscriptionQuotaExceeded"
+        case exportTaskAlreadyExistsFault = "ExportTaskAlreadyExists"
+        case exportTaskNotFoundFault = "ExportTaskNotFound"
+        case globalClusterAlreadyExistsFault = "GlobalClusterAlreadyExistsFault"
+        case globalClusterNotFoundFault = "GlobalClusterNotFoundFault"
+        case globalClusterQuotaExceededFault = "GlobalClusterQuotaExceededFault"
+        case iamRoleMissingPermissionsFault = "IamRoleMissingPermissions"
+        case iamRoleNotFoundFault = "IamRoleNotFound"
+        case installationMediaAlreadyExistsFault = "InstallationMediaAlreadyExists"
+        case installationMediaNotFoundFault = "InstallationMediaNotFound"
+        case instanceQuotaExceededFault = "InstanceQuotaExceeded"
+        case insufficientAvailableIPsInSubnetFault = "InsufficientAvailableIPsInSubnetFault"
+        case insufficientDBClusterCapacityFault = "InsufficientDBClusterCapacityFault"
+        case insufficientDBInstanceCapacityFault = "InsufficientDBInstanceCapacity"
+        case insufficientStorageClusterCapacityFault = "InsufficientStorageClusterCapacity"
+        case invalidDBClusterCapacityFault = "InvalidDBClusterCapacityFault"
+        case invalidDBClusterEndpointStateFault = "InvalidDBClusterEndpointStateFault"
+        case invalidDBClusterSnapshotStateFault = "InvalidDBClusterSnapshotStateFault"
+        case invalidDBClusterStateFault = "InvalidDBClusterStateFault"
+        case invalidDBInstanceAutomatedBackupStateFault = "InvalidDBInstanceAutomatedBackupState"
+        case invalidDBInstanceStateFault = "InvalidDBInstanceState"
+        case invalidDBParameterGroupStateFault = "InvalidDBParameterGroupState"
+        case invalidDBProxyStateFault = "InvalidDBProxyStateFault"
+        case invalidDBSecurityGroupStateFault = "InvalidDBSecurityGroupState"
+        case invalidDBSnapshotStateFault = "InvalidDBSnapshotState"
+        case invalidDBSubnetGroupFault = "InvalidDBSubnetGroupFault"
+        case invalidDBSubnetGroupStateFault = "InvalidDBSubnetGroupStateFault"
+        case invalidDBSubnetStateFault = "InvalidDBSubnetStateFault"
+        case invalidEventSubscriptionStateFault = "InvalidEventSubscriptionState"
+        case invalidExportOnlyFault = "InvalidExportOnly"
+        case invalidExportSourceStateFault = "InvalidExportSourceState"
+        case invalidExportTaskStateFault = "InvalidExportTaskStateFault"
+        case invalidGlobalClusterStateFault = "InvalidGlobalClusterStateFault"
+        case invalidOptionGroupStateFault = "InvalidOptionGroupStateFault"
+        case invalidRestoreFault = "InvalidRestoreFault"
+        case invalidS3BucketFault = "InvalidS3BucketFault"
+        case invalidSubnet = "InvalidSubnet"
+        case invalidVPCNetworkStateFault = "InvalidVPCNetworkStateFault"
+        case kMSKeyNotAccessibleFault = "KMSKeyNotAccessibleFault"
+        case optionGroupAlreadyExistsFault = "OptionGroupAlreadyExistsFault"
+        case optionGroupNotFoundFault = "OptionGroupNotFoundFault"
+        case optionGroupQuotaExceededFault = "OptionGroupQuotaExceededFault"
+        case pointInTimeRestoreNotEnabledFault = "PointInTimeRestoreNotEnabled"
+        case provisionedIopsNotAvailableInAZFault = "ProvisionedIopsNotAvailableInAZFault"
+        case reservedDBInstanceAlreadyExistsFault = "ReservedDBInstanceAlreadyExists"
+        case reservedDBInstanceNotFoundFault = "ReservedDBInstanceNotFound"
+        case reservedDBInstanceQuotaExceededFault = "ReservedDBInstanceQuotaExceeded"
+        case reservedDBInstancesOfferingNotFoundFault = "ReservedDBInstancesOfferingNotFound"
+        case resourceNotFoundFault = "ResourceNotFoundFault"
+        case sNSInvalidTopicFault = "SNSInvalidTopic"
+        case sNSNoAuthorizationFault = "SNSNoAuthorization"
+        case sNSTopicArnNotFoundFault = "SNSTopicArnNotFound"
+        case sharedSnapshotQuotaExceededFault = "SharedSnapshotQuotaExceeded"
+        case snapshotQuotaExceededFault = "SnapshotQuotaExceeded"
+        case sourceNotFoundFault = "SourceNotFound"
+        case storageQuotaExceededFault = "StorageQuotaExceeded"
+        case storageTypeNotSupportedFault = "StorageTypeNotSupported"
+        case subnetAlreadyInUse = "SubnetAlreadyInUse"
+        case subscriptionAlreadyExistFault = "SubscriptionAlreadyExist"
+        case subscriptionCategoryNotFoundFault = "SubscriptionCategoryNotFound"
+        case subscriptionNotFoundFault = "SubscriptionNotFound"
+    }
 
-extension RDSErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AuthorizationAlreadyExists":
-            self = .authorizationAlreadyExistsFault(message: message)
-        case "AuthorizationNotFound":
-            self = .authorizationNotFoundFault(message: message)
-        case "AuthorizationQuotaExceeded":
-            self = .authorizationQuotaExceededFault(message: message)
-        case "BackupPolicyNotFoundFault":
-            self = .backupPolicyNotFoundFault(message: message)
-        case "CertificateNotFound":
-            self = .certificateNotFoundFault(message: message)
-        case "CustomAvailabilityZoneAlreadyExists":
-            self = .customAvailabilityZoneAlreadyExistsFault(message: message)
-        case "CustomAvailabilityZoneNotFound":
-            self = .customAvailabilityZoneNotFoundFault(message: message)
-        case "CustomAvailabilityZoneQuotaExceeded":
-            self = .customAvailabilityZoneQuotaExceededFault(message: message)
-        case "DBClusterAlreadyExistsFault":
-            self = .dBClusterAlreadyExistsFault(message: message)
-        case "DBClusterBacktrackNotFoundFault":
-            self = .dBClusterBacktrackNotFoundFault(message: message)
-        case "DBClusterEndpointAlreadyExistsFault":
-            self = .dBClusterEndpointAlreadyExistsFault(message: message)
-        case "DBClusterEndpointNotFoundFault":
-            self = .dBClusterEndpointNotFoundFault(message: message)
-        case "DBClusterEndpointQuotaExceededFault":
-            self = .dBClusterEndpointQuotaExceededFault(message: message)
-        case "DBClusterNotFoundFault":
-            self = .dBClusterNotFoundFault(message: message)
-        case "DBClusterParameterGroupNotFound":
-            self = .dBClusterParameterGroupNotFoundFault(message: message)
-        case "DBClusterQuotaExceededFault":
-            self = .dBClusterQuotaExceededFault(message: message)
-        case "DBClusterRoleAlreadyExists":
-            self = .dBClusterRoleAlreadyExistsFault(message: message)
-        case "DBClusterRoleNotFound":
-            self = .dBClusterRoleNotFoundFault(message: message)
-        case "DBClusterRoleQuotaExceeded":
-            self = .dBClusterRoleQuotaExceededFault(message: message)
-        case "DBClusterSnapshotAlreadyExistsFault":
-            self = .dBClusterSnapshotAlreadyExistsFault(message: message)
-        case "DBClusterSnapshotNotFoundFault":
-            self = .dBClusterSnapshotNotFoundFault(message: message)
-        case "DBInstanceAlreadyExists":
-            self = .dBInstanceAlreadyExistsFault(message: message)
-        case "DBInstanceAutomatedBackupNotFound":
-            self = .dBInstanceAutomatedBackupNotFoundFault(message: message)
-        case "DBInstanceAutomatedBackupQuotaExceeded":
-            self = .dBInstanceAutomatedBackupQuotaExceededFault(message: message)
-        case "DBInstanceNotFound":
-            self = .dBInstanceNotFoundFault(message: message)
-        case "DBInstanceRoleAlreadyExists":
-            self = .dBInstanceRoleAlreadyExistsFault(message: message)
-        case "DBInstanceRoleNotFound":
-            self = .dBInstanceRoleNotFoundFault(message: message)
-        case "DBInstanceRoleQuotaExceeded":
-            self = .dBInstanceRoleQuotaExceededFault(message: message)
-        case "DBLogFileNotFoundFault":
-            self = .dBLogFileNotFoundFault(message: message)
-        case "DBParameterGroupAlreadyExists":
-            self = .dBParameterGroupAlreadyExistsFault(message: message)
-        case "DBParameterGroupNotFound":
-            self = .dBParameterGroupNotFoundFault(message: message)
-        case "DBParameterGroupQuotaExceeded":
-            self = .dBParameterGroupQuotaExceededFault(message: message)
-        case "DBProxyTargetExistsFault":
-            self = .dBProxyAlreadyExistsFault(message: message)
-        case "DBProxyNotFoundFault":
-            self = .dBProxyNotFoundFault(message: message)
-        case "DBProxyQuotaExceededFault":
-            self = .dBProxyQuotaExceededFault(message: message)
-        case "DBProxyTargetAlreadyRegisteredFault":
-            self = .dBProxyTargetAlreadyRegisteredFault(message: message)
-        case "DBProxyTargetGroupNotFoundFault":
-            self = .dBProxyTargetGroupNotFoundFault(message: message)
-        case "DBProxyTargetNotFoundFault":
-            self = .dBProxyTargetNotFoundFault(message: message)
-        case "DBSecurityGroupAlreadyExists":
-            self = .dBSecurityGroupAlreadyExistsFault(message: message)
-        case "DBSecurityGroupNotFound":
-            self = .dBSecurityGroupNotFoundFault(message: message)
-        case "DBSecurityGroupNotSupported":
-            self = .dBSecurityGroupNotSupportedFault(message: message)
-        case "QuotaExceeded.DBSecurityGroup":
-            self = .dBSecurityGroupQuotaExceededFault(message: message)
-        case "DBSnapshotAlreadyExists":
-            self = .dBSnapshotAlreadyExistsFault(message: message)
-        case "DBSnapshotNotFound":
-            self = .dBSnapshotNotFoundFault(message: message)
-        case "DBSubnetGroupAlreadyExists":
-            self = .dBSubnetGroupAlreadyExistsFault(message: message)
-        case "DBSubnetGroupDoesNotCoverEnoughAZs":
-            self = .dBSubnetGroupDoesNotCoverEnoughAZs(message: message)
-        case "DBSubnetGroupNotAllowedFault":
-            self = .dBSubnetGroupNotAllowedFault(message: message)
-        case "DBSubnetGroupNotFoundFault":
-            self = .dBSubnetGroupNotFoundFault(message: message)
-        case "DBSubnetGroupQuotaExceeded":
-            self = .dBSubnetGroupQuotaExceededFault(message: message)
-        case "DBSubnetQuotaExceededFault":
-            self = .dBSubnetQuotaExceededFault(message: message)
-        case "DBUpgradeDependencyFailure":
-            self = .dBUpgradeDependencyFailureFault(message: message)
-        case "DomainNotFoundFault":
-            self = .domainNotFoundFault(message: message)
-        case "EventSubscriptionQuotaExceeded":
-            self = .eventSubscriptionQuotaExceededFault(message: message)
-        case "ExportTaskAlreadyExists":
-            self = .exportTaskAlreadyExistsFault(message: message)
-        case "ExportTaskNotFound":
-            self = .exportTaskNotFoundFault(message: message)
-        case "GlobalClusterAlreadyExistsFault":
-            self = .globalClusterAlreadyExistsFault(message: message)
-        case "GlobalClusterNotFoundFault":
-            self = .globalClusterNotFoundFault(message: message)
-        case "GlobalClusterQuotaExceededFault":
-            self = .globalClusterQuotaExceededFault(message: message)
-        case "IamRoleMissingPermissions":
-            self = .iamRoleMissingPermissionsFault(message: message)
-        case "IamRoleNotFound":
-            self = .iamRoleNotFoundFault(message: message)
-        case "InstallationMediaAlreadyExists":
-            self = .installationMediaAlreadyExistsFault(message: message)
-        case "InstallationMediaNotFound":
-            self = .installationMediaNotFoundFault(message: message)
-        case "InstanceQuotaExceeded":
-            self = .instanceQuotaExceededFault(message: message)
-        case "InsufficientAvailableIPsInSubnetFault":
-            self = .insufficientAvailableIPsInSubnetFault(message: message)
-        case "InsufficientDBClusterCapacityFault":
-            self = .insufficientDBClusterCapacityFault(message: message)
-        case "InsufficientDBInstanceCapacity":
-            self = .insufficientDBInstanceCapacityFault(message: message)
-        case "InsufficientStorageClusterCapacity":
-            self = .insufficientStorageClusterCapacityFault(message: message)
-        case "InvalidDBClusterCapacityFault":
-            self = .invalidDBClusterCapacityFault(message: message)
-        case "InvalidDBClusterEndpointStateFault":
-            self = .invalidDBClusterEndpointStateFault(message: message)
-        case "InvalidDBClusterSnapshotStateFault":
-            self = .invalidDBClusterSnapshotStateFault(message: message)
-        case "InvalidDBClusterStateFault":
-            self = .invalidDBClusterStateFault(message: message)
-        case "InvalidDBInstanceAutomatedBackupState":
-            self = .invalidDBInstanceAutomatedBackupStateFault(message: message)
-        case "InvalidDBInstanceState":
-            self = .invalidDBInstanceStateFault(message: message)
-        case "InvalidDBParameterGroupState":
-            self = .invalidDBParameterGroupStateFault(message: message)
-        case "InvalidDBProxyStateFault":
-            self = .invalidDBProxyStateFault(message: message)
-        case "InvalidDBSecurityGroupState":
-            self = .invalidDBSecurityGroupStateFault(message: message)
-        case "InvalidDBSnapshotState":
-            self = .invalidDBSnapshotStateFault(message: message)
-        case "InvalidDBSubnetGroupFault":
-            self = .invalidDBSubnetGroupFault(message: message)
-        case "InvalidDBSubnetGroupStateFault":
-            self = .invalidDBSubnetGroupStateFault(message: message)
-        case "InvalidDBSubnetStateFault":
-            self = .invalidDBSubnetStateFault(message: message)
-        case "InvalidEventSubscriptionState":
-            self = .invalidEventSubscriptionStateFault(message: message)
-        case "InvalidExportOnly":
-            self = .invalidExportOnlyFault(message: message)
-        case "InvalidExportSourceState":
-            self = .invalidExportSourceStateFault(message: message)
-        case "InvalidExportTaskStateFault":
-            self = .invalidExportTaskStateFault(message: message)
-        case "InvalidGlobalClusterStateFault":
-            self = .invalidGlobalClusterStateFault(message: message)
-        case "InvalidOptionGroupStateFault":
-            self = .invalidOptionGroupStateFault(message: message)
-        case "InvalidRestoreFault":
-            self = .invalidRestoreFault(message: message)
-        case "InvalidS3BucketFault":
-            self = .invalidS3BucketFault(message: message)
-        case "InvalidSubnet":
-            self = .invalidSubnet(message: message)
-        case "InvalidVPCNetworkStateFault":
-            self = .invalidVPCNetworkStateFault(message: message)
-        case "KMSKeyNotAccessibleFault":
-            self = .kMSKeyNotAccessibleFault(message: message)
-        case "OptionGroupAlreadyExistsFault":
-            self = .optionGroupAlreadyExistsFault(message: message)
-        case "OptionGroupNotFoundFault":
-            self = .optionGroupNotFoundFault(message: message)
-        case "OptionGroupQuotaExceededFault":
-            self = .optionGroupQuotaExceededFault(message: message)
-        case "PointInTimeRestoreNotEnabled":
-            self = .pointInTimeRestoreNotEnabledFault(message: message)
-        case "ProvisionedIopsNotAvailableInAZFault":
-            self = .provisionedIopsNotAvailableInAZFault(message: message)
-        case "ReservedDBInstanceAlreadyExists":
-            self = .reservedDBInstanceAlreadyExistsFault(message: message)
-        case "ReservedDBInstanceNotFound":
-            self = .reservedDBInstanceNotFoundFault(message: message)
-        case "ReservedDBInstanceQuotaExceeded":
-            self = .reservedDBInstanceQuotaExceededFault(message: message)
-        case "ReservedDBInstancesOfferingNotFound":
-            self = .reservedDBInstancesOfferingNotFoundFault(message: message)
-        case "ResourceNotFoundFault":
-            self = .resourceNotFoundFault(message: message)
-        case "SNSInvalidTopic":
-            self = .sNSInvalidTopicFault(message: message)
-        case "SNSNoAuthorization":
-            self = .sNSNoAuthorizationFault(message: message)
-        case "SNSTopicArnNotFound":
-            self = .sNSTopicArnNotFoundFault(message: message)
-        case "SharedSnapshotQuotaExceeded":
-            self = .sharedSnapshotQuotaExceededFault(message: message)
-        case "SnapshotQuotaExceeded":
-            self = .snapshotQuotaExceededFault(message: message)
-        case "SourceNotFound":
-            self = .sourceNotFoundFault(message: message)
-        case "StorageQuotaExceeded":
-            self = .storageQuotaExceededFault(message: message)
-        case "StorageTypeNotSupported":
-            self = .storageTypeNotSupportedFault(message: message)
-        case "SubnetAlreadyInUse":
-            self = .subnetAlreadyInUse(message: message)
-        case "SubscriptionAlreadyExist":
-            self = .subscriptionAlreadyExistFault(message: message)
-        case "SubscriptionCategoryNotFound":
-            self = .subscriptionCategoryNotFoundFault(message: message)
-        case "SubscriptionNotFound":
-            self = .subscriptionNotFoundFault(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var authorizationAlreadyExistsFault: Self { .init(.authorizationAlreadyExistsFault) }
+    public static var authorizationNotFoundFault: Self { .init(.authorizationNotFoundFault) }
+    public static var authorizationQuotaExceededFault: Self { .init(.authorizationQuotaExceededFault) }
+    public static var backupPolicyNotFoundFault: Self { .init(.backupPolicyNotFoundFault) }
+    public static var certificateNotFoundFault: Self { .init(.certificateNotFoundFault) }
+    public static var customAvailabilityZoneAlreadyExistsFault: Self { .init(.customAvailabilityZoneAlreadyExistsFault) }
+    public static var customAvailabilityZoneNotFoundFault: Self { .init(.customAvailabilityZoneNotFoundFault) }
+    public static var customAvailabilityZoneQuotaExceededFault: Self { .init(.customAvailabilityZoneQuotaExceededFault) }
+    public static var dBClusterAlreadyExistsFault: Self { .init(.dBClusterAlreadyExistsFault) }
+    public static var dBClusterBacktrackNotFoundFault: Self { .init(.dBClusterBacktrackNotFoundFault) }
+    public static var dBClusterEndpointAlreadyExistsFault: Self { .init(.dBClusterEndpointAlreadyExistsFault) }
+    public static var dBClusterEndpointNotFoundFault: Self { .init(.dBClusterEndpointNotFoundFault) }
+    public static var dBClusterEndpointQuotaExceededFault: Self { .init(.dBClusterEndpointQuotaExceededFault) }
+    public static var dBClusterNotFoundFault: Self { .init(.dBClusterNotFoundFault) }
+    public static var dBClusterParameterGroupNotFoundFault: Self { .init(.dBClusterParameterGroupNotFoundFault) }
+    public static var dBClusterQuotaExceededFault: Self { .init(.dBClusterQuotaExceededFault) }
+    public static var dBClusterRoleAlreadyExistsFault: Self { .init(.dBClusterRoleAlreadyExistsFault) }
+    public static var dBClusterRoleNotFoundFault: Self { .init(.dBClusterRoleNotFoundFault) }
+    public static var dBClusterRoleQuotaExceededFault: Self { .init(.dBClusterRoleQuotaExceededFault) }
+    public static var dBClusterSnapshotAlreadyExistsFault: Self { .init(.dBClusterSnapshotAlreadyExistsFault) }
+    public static var dBClusterSnapshotNotFoundFault: Self { .init(.dBClusterSnapshotNotFoundFault) }
+    public static var dBInstanceAlreadyExistsFault: Self { .init(.dBInstanceAlreadyExistsFault) }
+    public static var dBInstanceAutomatedBackupNotFoundFault: Self { .init(.dBInstanceAutomatedBackupNotFoundFault) }
+    public static var dBInstanceAutomatedBackupQuotaExceededFault: Self { .init(.dBInstanceAutomatedBackupQuotaExceededFault) }
+    public static var dBInstanceNotFoundFault: Self { .init(.dBInstanceNotFoundFault) }
+    public static var dBInstanceRoleAlreadyExistsFault: Self { .init(.dBInstanceRoleAlreadyExistsFault) }
+    public static var dBInstanceRoleNotFoundFault: Self { .init(.dBInstanceRoleNotFoundFault) }
+    public static var dBInstanceRoleQuotaExceededFault: Self { .init(.dBInstanceRoleQuotaExceededFault) }
+    public static var dBLogFileNotFoundFault: Self { .init(.dBLogFileNotFoundFault) }
+    public static var dBParameterGroupAlreadyExistsFault: Self { .init(.dBParameterGroupAlreadyExistsFault) }
+    public static var dBParameterGroupNotFoundFault: Self { .init(.dBParameterGroupNotFoundFault) }
+    public static var dBParameterGroupQuotaExceededFault: Self { .init(.dBParameterGroupQuotaExceededFault) }
+    public static var dBProxyAlreadyExistsFault: Self { .init(.dBProxyAlreadyExistsFault) }
+    public static var dBProxyNotFoundFault: Self { .init(.dBProxyNotFoundFault) }
+    public static var dBProxyQuotaExceededFault: Self { .init(.dBProxyQuotaExceededFault) }
+    public static var dBProxyTargetAlreadyRegisteredFault: Self { .init(.dBProxyTargetAlreadyRegisteredFault) }
+    public static var dBProxyTargetGroupNotFoundFault: Self { .init(.dBProxyTargetGroupNotFoundFault) }
+    public static var dBProxyTargetNotFoundFault: Self { .init(.dBProxyTargetNotFoundFault) }
+    public static var dBSecurityGroupAlreadyExistsFault: Self { .init(.dBSecurityGroupAlreadyExistsFault) }
+    public static var dBSecurityGroupNotFoundFault: Self { .init(.dBSecurityGroupNotFoundFault) }
+    public static var dBSecurityGroupNotSupportedFault: Self { .init(.dBSecurityGroupNotSupportedFault) }
+    public static var dBSecurityGroupQuotaExceededFault: Self { .init(.dBSecurityGroupQuotaExceededFault) }
+    public static var dBSnapshotAlreadyExistsFault: Self { .init(.dBSnapshotAlreadyExistsFault) }
+    public static var dBSnapshotNotFoundFault: Self { .init(.dBSnapshotNotFoundFault) }
+    public static var dBSubnetGroupAlreadyExistsFault: Self { .init(.dBSubnetGroupAlreadyExistsFault) }
+    public static var dBSubnetGroupDoesNotCoverEnoughAZs: Self { .init(.dBSubnetGroupDoesNotCoverEnoughAZs) }
+    public static var dBSubnetGroupNotAllowedFault: Self { .init(.dBSubnetGroupNotAllowedFault) }
+    public static var dBSubnetGroupNotFoundFault: Self { .init(.dBSubnetGroupNotFoundFault) }
+    public static var dBSubnetGroupQuotaExceededFault: Self { .init(.dBSubnetGroupQuotaExceededFault) }
+    public static var dBSubnetQuotaExceededFault: Self { .init(.dBSubnetQuotaExceededFault) }
+    public static var dBUpgradeDependencyFailureFault: Self { .init(.dBUpgradeDependencyFailureFault) }
+    public static var domainNotFoundFault: Self { .init(.domainNotFoundFault) }
+    public static var eventSubscriptionQuotaExceededFault: Self { .init(.eventSubscriptionQuotaExceededFault) }
+    public static var exportTaskAlreadyExistsFault: Self { .init(.exportTaskAlreadyExistsFault) }
+    public static var exportTaskNotFoundFault: Self { .init(.exportTaskNotFoundFault) }
+    public static var globalClusterAlreadyExistsFault: Self { .init(.globalClusterAlreadyExistsFault) }
+    public static var globalClusterNotFoundFault: Self { .init(.globalClusterNotFoundFault) }
+    public static var globalClusterQuotaExceededFault: Self { .init(.globalClusterQuotaExceededFault) }
+    public static var iamRoleMissingPermissionsFault: Self { .init(.iamRoleMissingPermissionsFault) }
+    public static var iamRoleNotFoundFault: Self { .init(.iamRoleNotFoundFault) }
+    public static var installationMediaAlreadyExistsFault: Self { .init(.installationMediaAlreadyExistsFault) }
+    public static var installationMediaNotFoundFault: Self { .init(.installationMediaNotFoundFault) }
+    public static var instanceQuotaExceededFault: Self { .init(.instanceQuotaExceededFault) }
+    public static var insufficientAvailableIPsInSubnetFault: Self { .init(.insufficientAvailableIPsInSubnetFault) }
+    public static var insufficientDBClusterCapacityFault: Self { .init(.insufficientDBClusterCapacityFault) }
+    public static var insufficientDBInstanceCapacityFault: Self { .init(.insufficientDBInstanceCapacityFault) }
+    public static var insufficientStorageClusterCapacityFault: Self { .init(.insufficientStorageClusterCapacityFault) }
+    public static var invalidDBClusterCapacityFault: Self { .init(.invalidDBClusterCapacityFault) }
+    public static var invalidDBClusterEndpointStateFault: Self { .init(.invalidDBClusterEndpointStateFault) }
+    public static var invalidDBClusterSnapshotStateFault: Self { .init(.invalidDBClusterSnapshotStateFault) }
+    public static var invalidDBClusterStateFault: Self { .init(.invalidDBClusterStateFault) }
+    public static var invalidDBInstanceAutomatedBackupStateFault: Self { .init(.invalidDBInstanceAutomatedBackupStateFault) }
+    public static var invalidDBInstanceStateFault: Self { .init(.invalidDBInstanceStateFault) }
+    public static var invalidDBParameterGroupStateFault: Self { .init(.invalidDBParameterGroupStateFault) }
+    public static var invalidDBProxyStateFault: Self { .init(.invalidDBProxyStateFault) }
+    public static var invalidDBSecurityGroupStateFault: Self { .init(.invalidDBSecurityGroupStateFault) }
+    public static var invalidDBSnapshotStateFault: Self { .init(.invalidDBSnapshotStateFault) }
+    public static var invalidDBSubnetGroupFault: Self { .init(.invalidDBSubnetGroupFault) }
+    public static var invalidDBSubnetGroupStateFault: Self { .init(.invalidDBSubnetGroupStateFault) }
+    public static var invalidDBSubnetStateFault: Self { .init(.invalidDBSubnetStateFault) }
+    public static var invalidEventSubscriptionStateFault: Self { .init(.invalidEventSubscriptionStateFault) }
+    public static var invalidExportOnlyFault: Self { .init(.invalidExportOnlyFault) }
+    public static var invalidExportSourceStateFault: Self { .init(.invalidExportSourceStateFault) }
+    public static var invalidExportTaskStateFault: Self { .init(.invalidExportTaskStateFault) }
+    public static var invalidGlobalClusterStateFault: Self { .init(.invalidGlobalClusterStateFault) }
+    public static var invalidOptionGroupStateFault: Self { .init(.invalidOptionGroupStateFault) }
+    public static var invalidRestoreFault: Self { .init(.invalidRestoreFault) }
+    public static var invalidS3BucketFault: Self { .init(.invalidS3BucketFault) }
+    public static var invalidSubnet: Self { .init(.invalidSubnet) }
+    public static var invalidVPCNetworkStateFault: Self { .init(.invalidVPCNetworkStateFault) }
+    public static var kMSKeyNotAccessibleFault: Self { .init(.kMSKeyNotAccessibleFault) }
+    public static var optionGroupAlreadyExistsFault: Self { .init(.optionGroupAlreadyExistsFault) }
+    public static var optionGroupNotFoundFault: Self { .init(.optionGroupNotFoundFault) }
+    public static var optionGroupQuotaExceededFault: Self { .init(.optionGroupQuotaExceededFault) }
+    public static var pointInTimeRestoreNotEnabledFault: Self { .init(.pointInTimeRestoreNotEnabledFault) }
+    public static var provisionedIopsNotAvailableInAZFault: Self { .init(.provisionedIopsNotAvailableInAZFault) }
+    public static var reservedDBInstanceAlreadyExistsFault: Self { .init(.reservedDBInstanceAlreadyExistsFault) }
+    public static var reservedDBInstanceNotFoundFault: Self { .init(.reservedDBInstanceNotFoundFault) }
+    public static var reservedDBInstanceQuotaExceededFault: Self { .init(.reservedDBInstanceQuotaExceededFault) }
+    public static var reservedDBInstancesOfferingNotFoundFault: Self { .init(.reservedDBInstancesOfferingNotFoundFault) }
+    public static var resourceNotFoundFault: Self { .init(.resourceNotFoundFault) }
+    public static var sNSInvalidTopicFault: Self { .init(.sNSInvalidTopicFault) }
+    public static var sNSNoAuthorizationFault: Self { .init(.sNSNoAuthorizationFault) }
+    public static var sNSTopicArnNotFoundFault: Self { .init(.sNSTopicArnNotFoundFault) }
+    public static var sharedSnapshotQuotaExceededFault: Self { .init(.sharedSnapshotQuotaExceededFault) }
+    public static var snapshotQuotaExceededFault: Self { .init(.snapshotQuotaExceededFault) }
+    public static var sourceNotFoundFault: Self { .init(.sourceNotFoundFault) }
+    public static var storageQuotaExceededFault: Self { .init(.storageQuotaExceededFault) }
+    public static var storageTypeNotSupportedFault: Self { .init(.storageTypeNotSupportedFault) }
+    public static var subnetAlreadyInUse: Self { .init(.subnetAlreadyInUse) }
+    public static var subscriptionAlreadyExistFault: Self { .init(.subscriptionAlreadyExistFault) }
+    public static var subscriptionCategoryNotFoundFault: Self { .init(.subscriptionCategoryNotFoundFault) }
+    public static var subscriptionNotFoundFault: Self { .init(.subscriptionNotFoundFault) }
+}
+
+extension RDSErrorType: Equatable {
+    public static func == (lhs: RDSErrorType, rhs: RDSErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension RDSErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .authorizationAlreadyExistsFault(let message):
-            return "AuthorizationAlreadyExists: \(message ?? "")"
-        case .authorizationNotFoundFault(let message):
-            return "AuthorizationNotFound: \(message ?? "")"
-        case .authorizationQuotaExceededFault(let message):
-            return "AuthorizationQuotaExceeded: \(message ?? "")"
-        case .backupPolicyNotFoundFault(let message):
-            return "BackupPolicyNotFoundFault: \(message ?? "")"
-        case .certificateNotFoundFault(let message):
-            return "CertificateNotFound: \(message ?? "")"
-        case .customAvailabilityZoneAlreadyExistsFault(let message):
-            return "CustomAvailabilityZoneAlreadyExists: \(message ?? "")"
-        case .customAvailabilityZoneNotFoundFault(let message):
-            return "CustomAvailabilityZoneNotFound: \(message ?? "")"
-        case .customAvailabilityZoneQuotaExceededFault(let message):
-            return "CustomAvailabilityZoneQuotaExceeded: \(message ?? "")"
-        case .dBClusterAlreadyExistsFault(let message):
-            return "DBClusterAlreadyExistsFault: \(message ?? "")"
-        case .dBClusterBacktrackNotFoundFault(let message):
-            return "DBClusterBacktrackNotFoundFault: \(message ?? "")"
-        case .dBClusterEndpointAlreadyExistsFault(let message):
-            return "DBClusterEndpointAlreadyExistsFault: \(message ?? "")"
-        case .dBClusterEndpointNotFoundFault(let message):
-            return "DBClusterEndpointNotFoundFault: \(message ?? "")"
-        case .dBClusterEndpointQuotaExceededFault(let message):
-            return "DBClusterEndpointQuotaExceededFault: \(message ?? "")"
-        case .dBClusterNotFoundFault(let message):
-            return "DBClusterNotFoundFault: \(message ?? "")"
-        case .dBClusterParameterGroupNotFoundFault(let message):
-            return "DBClusterParameterGroupNotFound: \(message ?? "")"
-        case .dBClusterQuotaExceededFault(let message):
-            return "DBClusterQuotaExceededFault: \(message ?? "")"
-        case .dBClusterRoleAlreadyExistsFault(let message):
-            return "DBClusterRoleAlreadyExists: \(message ?? "")"
-        case .dBClusterRoleNotFoundFault(let message):
-            return "DBClusterRoleNotFound: \(message ?? "")"
-        case .dBClusterRoleQuotaExceededFault(let message):
-            return "DBClusterRoleQuotaExceeded: \(message ?? "")"
-        case .dBClusterSnapshotAlreadyExistsFault(let message):
-            return "DBClusterSnapshotAlreadyExistsFault: \(message ?? "")"
-        case .dBClusterSnapshotNotFoundFault(let message):
-            return "DBClusterSnapshotNotFoundFault: \(message ?? "")"
-        case .dBInstanceAlreadyExistsFault(let message):
-            return "DBInstanceAlreadyExists: \(message ?? "")"
-        case .dBInstanceAutomatedBackupNotFoundFault(let message):
-            return "DBInstanceAutomatedBackupNotFound: \(message ?? "")"
-        case .dBInstanceAutomatedBackupQuotaExceededFault(let message):
-            return "DBInstanceAutomatedBackupQuotaExceeded: \(message ?? "")"
-        case .dBInstanceNotFoundFault(let message):
-            return "DBInstanceNotFound: \(message ?? "")"
-        case .dBInstanceRoleAlreadyExistsFault(let message):
-            return "DBInstanceRoleAlreadyExists: \(message ?? "")"
-        case .dBInstanceRoleNotFoundFault(let message):
-            return "DBInstanceRoleNotFound: \(message ?? "")"
-        case .dBInstanceRoleQuotaExceededFault(let message):
-            return "DBInstanceRoleQuotaExceeded: \(message ?? "")"
-        case .dBLogFileNotFoundFault(let message):
-            return "DBLogFileNotFoundFault: \(message ?? "")"
-        case .dBParameterGroupAlreadyExistsFault(let message):
-            return "DBParameterGroupAlreadyExists: \(message ?? "")"
-        case .dBParameterGroupNotFoundFault(let message):
-            return "DBParameterGroupNotFound: \(message ?? "")"
-        case .dBParameterGroupQuotaExceededFault(let message):
-            return "DBParameterGroupQuotaExceeded: \(message ?? "")"
-        case .dBProxyAlreadyExistsFault(let message):
-            return "DBProxyTargetExistsFault: \(message ?? "")"
-        case .dBProxyNotFoundFault(let message):
-            return "DBProxyNotFoundFault: \(message ?? "")"
-        case .dBProxyQuotaExceededFault(let message):
-            return "DBProxyQuotaExceededFault: \(message ?? "")"
-        case .dBProxyTargetAlreadyRegisteredFault(let message):
-            return "DBProxyTargetAlreadyRegisteredFault: \(message ?? "")"
-        case .dBProxyTargetGroupNotFoundFault(let message):
-            return "DBProxyTargetGroupNotFoundFault: \(message ?? "")"
-        case .dBProxyTargetNotFoundFault(let message):
-            return "DBProxyTargetNotFoundFault: \(message ?? "")"
-        case .dBSecurityGroupAlreadyExistsFault(let message):
-            return "DBSecurityGroupAlreadyExists: \(message ?? "")"
-        case .dBSecurityGroupNotFoundFault(let message):
-            return "DBSecurityGroupNotFound: \(message ?? "")"
-        case .dBSecurityGroupNotSupportedFault(let message):
-            return "DBSecurityGroupNotSupported: \(message ?? "")"
-        case .dBSecurityGroupQuotaExceededFault(let message):
-            return "QuotaExceeded.DBSecurityGroup: \(message ?? "")"
-        case .dBSnapshotAlreadyExistsFault(let message):
-            return "DBSnapshotAlreadyExists: \(message ?? "")"
-        case .dBSnapshotNotFoundFault(let message):
-            return "DBSnapshotNotFound: \(message ?? "")"
-        case .dBSubnetGroupAlreadyExistsFault(let message):
-            return "DBSubnetGroupAlreadyExists: \(message ?? "")"
-        case .dBSubnetGroupDoesNotCoverEnoughAZs(let message):
-            return "DBSubnetGroupDoesNotCoverEnoughAZs: \(message ?? "")"
-        case .dBSubnetGroupNotAllowedFault(let message):
-            return "DBSubnetGroupNotAllowedFault: \(message ?? "")"
-        case .dBSubnetGroupNotFoundFault(let message):
-            return "DBSubnetGroupNotFoundFault: \(message ?? "")"
-        case .dBSubnetGroupQuotaExceededFault(let message):
-            return "DBSubnetGroupQuotaExceeded: \(message ?? "")"
-        case .dBSubnetQuotaExceededFault(let message):
-            return "DBSubnetQuotaExceededFault: \(message ?? "")"
-        case .dBUpgradeDependencyFailureFault(let message):
-            return "DBUpgradeDependencyFailure: \(message ?? "")"
-        case .domainNotFoundFault(let message):
-            return "DomainNotFoundFault: \(message ?? "")"
-        case .eventSubscriptionQuotaExceededFault(let message):
-            return "EventSubscriptionQuotaExceeded: \(message ?? "")"
-        case .exportTaskAlreadyExistsFault(let message):
-            return "ExportTaskAlreadyExists: \(message ?? "")"
-        case .exportTaskNotFoundFault(let message):
-            return "ExportTaskNotFound: \(message ?? "")"
-        case .globalClusterAlreadyExistsFault(let message):
-            return "GlobalClusterAlreadyExistsFault: \(message ?? "")"
-        case .globalClusterNotFoundFault(let message):
-            return "GlobalClusterNotFoundFault: \(message ?? "")"
-        case .globalClusterQuotaExceededFault(let message):
-            return "GlobalClusterQuotaExceededFault: \(message ?? "")"
-        case .iamRoleMissingPermissionsFault(let message):
-            return "IamRoleMissingPermissions: \(message ?? "")"
-        case .iamRoleNotFoundFault(let message):
-            return "IamRoleNotFound: \(message ?? "")"
-        case .installationMediaAlreadyExistsFault(let message):
-            return "InstallationMediaAlreadyExists: \(message ?? "")"
-        case .installationMediaNotFoundFault(let message):
-            return "InstallationMediaNotFound: \(message ?? "")"
-        case .instanceQuotaExceededFault(let message):
-            return "InstanceQuotaExceeded: \(message ?? "")"
-        case .insufficientAvailableIPsInSubnetFault(let message):
-            return "InsufficientAvailableIPsInSubnetFault: \(message ?? "")"
-        case .insufficientDBClusterCapacityFault(let message):
-            return "InsufficientDBClusterCapacityFault: \(message ?? "")"
-        case .insufficientDBInstanceCapacityFault(let message):
-            return "InsufficientDBInstanceCapacity: \(message ?? "")"
-        case .insufficientStorageClusterCapacityFault(let message):
-            return "InsufficientStorageClusterCapacity: \(message ?? "")"
-        case .invalidDBClusterCapacityFault(let message):
-            return "InvalidDBClusterCapacityFault: \(message ?? "")"
-        case .invalidDBClusterEndpointStateFault(let message):
-            return "InvalidDBClusterEndpointStateFault: \(message ?? "")"
-        case .invalidDBClusterSnapshotStateFault(let message):
-            return "InvalidDBClusterSnapshotStateFault: \(message ?? "")"
-        case .invalidDBClusterStateFault(let message):
-            return "InvalidDBClusterStateFault: \(message ?? "")"
-        case .invalidDBInstanceAutomatedBackupStateFault(let message):
-            return "InvalidDBInstanceAutomatedBackupState: \(message ?? "")"
-        case .invalidDBInstanceStateFault(let message):
-            return "InvalidDBInstanceState: \(message ?? "")"
-        case .invalidDBParameterGroupStateFault(let message):
-            return "InvalidDBParameterGroupState: \(message ?? "")"
-        case .invalidDBProxyStateFault(let message):
-            return "InvalidDBProxyStateFault: \(message ?? "")"
-        case .invalidDBSecurityGroupStateFault(let message):
-            return "InvalidDBSecurityGroupState: \(message ?? "")"
-        case .invalidDBSnapshotStateFault(let message):
-            return "InvalidDBSnapshotState: \(message ?? "")"
-        case .invalidDBSubnetGroupFault(let message):
-            return "InvalidDBSubnetGroupFault: \(message ?? "")"
-        case .invalidDBSubnetGroupStateFault(let message):
-            return "InvalidDBSubnetGroupStateFault: \(message ?? "")"
-        case .invalidDBSubnetStateFault(let message):
-            return "InvalidDBSubnetStateFault: \(message ?? "")"
-        case .invalidEventSubscriptionStateFault(let message):
-            return "InvalidEventSubscriptionState: \(message ?? "")"
-        case .invalidExportOnlyFault(let message):
-            return "InvalidExportOnly: \(message ?? "")"
-        case .invalidExportSourceStateFault(let message):
-            return "InvalidExportSourceState: \(message ?? "")"
-        case .invalidExportTaskStateFault(let message):
-            return "InvalidExportTaskStateFault: \(message ?? "")"
-        case .invalidGlobalClusterStateFault(let message):
-            return "InvalidGlobalClusterStateFault: \(message ?? "")"
-        case .invalidOptionGroupStateFault(let message):
-            return "InvalidOptionGroupStateFault: \(message ?? "")"
-        case .invalidRestoreFault(let message):
-            return "InvalidRestoreFault: \(message ?? "")"
-        case .invalidS3BucketFault(let message):
-            return "InvalidS3BucketFault: \(message ?? "")"
-        case .invalidSubnet(let message):
-            return "InvalidSubnet: \(message ?? "")"
-        case .invalidVPCNetworkStateFault(let message):
-            return "InvalidVPCNetworkStateFault: \(message ?? "")"
-        case .kMSKeyNotAccessibleFault(let message):
-            return "KMSKeyNotAccessibleFault: \(message ?? "")"
-        case .optionGroupAlreadyExistsFault(let message):
-            return "OptionGroupAlreadyExistsFault: \(message ?? "")"
-        case .optionGroupNotFoundFault(let message):
-            return "OptionGroupNotFoundFault: \(message ?? "")"
-        case .optionGroupQuotaExceededFault(let message):
-            return "OptionGroupQuotaExceededFault: \(message ?? "")"
-        case .pointInTimeRestoreNotEnabledFault(let message):
-            return "PointInTimeRestoreNotEnabled: \(message ?? "")"
-        case .provisionedIopsNotAvailableInAZFault(let message):
-            return "ProvisionedIopsNotAvailableInAZFault: \(message ?? "")"
-        case .reservedDBInstanceAlreadyExistsFault(let message):
-            return "ReservedDBInstanceAlreadyExists: \(message ?? "")"
-        case .reservedDBInstanceNotFoundFault(let message):
-            return "ReservedDBInstanceNotFound: \(message ?? "")"
-        case .reservedDBInstanceQuotaExceededFault(let message):
-            return "ReservedDBInstanceQuotaExceeded: \(message ?? "")"
-        case .reservedDBInstancesOfferingNotFoundFault(let message):
-            return "ReservedDBInstancesOfferingNotFound: \(message ?? "")"
-        case .resourceNotFoundFault(let message):
-            return "ResourceNotFoundFault: \(message ?? "")"
-        case .sNSInvalidTopicFault(let message):
-            return "SNSInvalidTopic: \(message ?? "")"
-        case .sNSNoAuthorizationFault(let message):
-            return "SNSNoAuthorization: \(message ?? "")"
-        case .sNSTopicArnNotFoundFault(let message):
-            return "SNSTopicArnNotFound: \(message ?? "")"
-        case .sharedSnapshotQuotaExceededFault(let message):
-            return "SharedSnapshotQuotaExceeded: \(message ?? "")"
-        case .snapshotQuotaExceededFault(let message):
-            return "SnapshotQuotaExceeded: \(message ?? "")"
-        case .sourceNotFoundFault(let message):
-            return "SourceNotFound: \(message ?? "")"
-        case .storageQuotaExceededFault(let message):
-            return "StorageQuotaExceeded: \(message ?? "")"
-        case .storageTypeNotSupportedFault(let message):
-            return "StorageTypeNotSupported: \(message ?? "")"
-        case .subnetAlreadyInUse(let message):
-            return "SubnetAlreadyInUse: \(message ?? "")"
-        case .subscriptionAlreadyExistFault(let message):
-            return "SubscriptionAlreadyExist: \(message ?? "")"
-        case .subscriptionCategoryNotFoundFault(let message):
-            return "SubscriptionCategoryNotFound: \(message ?? "")"
-        case .subscriptionNotFoundFault(let message):
-            return "SubscriptionNotFound: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/RDSDataService/RDSDataService_Error.swift
+++ b/Sources/Soto/Services/RDSDataService/RDSDataService_Error.swift
@@ -17,55 +17,50 @@
 import SotoCore
 
 /// Error enum for RDSDataService
-public enum RDSDataServiceErrorType: AWSErrorType {
-    case badRequestException(message: String?)
-    case forbiddenException(message: String?)
-    case internalServerErrorException(message: String?)
-    case notFoundException(message: String?)
-    case serviceUnavailableError(message: String?)
-    case statementTimeoutException(message: String?)
-}
+public struct RDSDataServiceErrorType: AWSErrorType {
+    enum Code: String {
+        case badRequestException = "BadRequestException"
+        case forbiddenException = "ForbiddenException"
+        case internalServerErrorException = "InternalServerErrorException"
+        case notFoundException = "NotFoundException"
+        case serviceUnavailableError = "ServiceUnavailableError"
+        case statementTimeoutException = "StatementTimeoutException"
+    }
 
-extension RDSDataServiceErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        case "ForbiddenException":
-            self = .forbiddenException(message: message)
-        case "InternalServerErrorException":
-            self = .internalServerErrorException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "ServiceUnavailableError":
-            self = .serviceUnavailableError(message: message)
-        case "StatementTimeoutException":
-            self = .statementTimeoutException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var badRequestException: Self { .init(.badRequestException) }
+    public static var forbiddenException: Self { .init(.forbiddenException) }
+    public static var internalServerErrorException: Self { .init(.internalServerErrorException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var serviceUnavailableError: Self { .init(.serviceUnavailableError) }
+    public static var statementTimeoutException: Self { .init(.statementTimeoutException) }
+}
+
+extension RDSDataServiceErrorType: Equatable {
+    public static func == (lhs: RDSDataServiceErrorType, rhs: RDSDataServiceErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension RDSDataServiceErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        case .forbiddenException(let message):
-            return "ForbiddenException: \(message ?? "")"
-        case .internalServerErrorException(let message):
-            return "InternalServerErrorException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .serviceUnavailableError(let message):
-            return "ServiceUnavailableError: \(message ?? "")"
-        case .statementTimeoutException(let message):
-            return "StatementTimeoutException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Redshift/Redshift_Error.swift
+++ b/Sources/Soto/Services/Redshift/Redshift_Error.swift
@@ -17,560 +17,252 @@
 import SotoCore
 
 /// Error enum for Redshift
-public enum RedshiftErrorType: AWSErrorType {
-    case accessToSnapshotDeniedFault(message: String?)
-    case authorizationAlreadyExistsFault(message: String?)
-    case authorizationNotFoundFault(message: String?)
-    case authorizationQuotaExceededFault(message: String?)
-    case batchDeleteRequestSizeExceededFault(message: String?)
-    case batchModifyClusterSnapshotsLimitExceededFault(message: String?)
-    case bucketNotFoundFault(message: String?)
-    case clusterAlreadyExistsFault(message: String?)
-    case clusterNotFoundFault(message: String?)
-    case clusterOnLatestRevisionFault(message: String?)
-    case clusterParameterGroupAlreadyExistsFault(message: String?)
-    case clusterParameterGroupNotFoundFault(message: String?)
-    case clusterParameterGroupQuotaExceededFault(message: String?)
-    case clusterQuotaExceededFault(message: String?)
-    case clusterSecurityGroupAlreadyExistsFault(message: String?)
-    case clusterSecurityGroupNotFoundFault(message: String?)
-    case clusterSecurityGroupQuotaExceededFault(message: String?)
-    case clusterSnapshotAlreadyExistsFault(message: String?)
-    case clusterSnapshotNotFoundFault(message: String?)
-    case clusterSnapshotQuotaExceededFault(message: String?)
-    case clusterSubnetGroupAlreadyExistsFault(message: String?)
-    case clusterSubnetGroupNotFoundFault(message: String?)
-    case clusterSubnetGroupQuotaExceededFault(message: String?)
-    case clusterSubnetQuotaExceededFault(message: String?)
-    case copyToRegionDisabledFault(message: String?)
-    case dependentServiceRequestThrottlingFault(message: String?)
-    case dependentServiceUnavailableFault(message: String?)
-    case eventSubscriptionQuotaExceededFault(message: String?)
-    case hsmClientCertificateAlreadyExistsFault(message: String?)
-    case hsmClientCertificateNotFoundFault(message: String?)
-    case hsmClientCertificateQuotaExceededFault(message: String?)
-    case hsmConfigurationAlreadyExistsFault(message: String?)
-    case hsmConfigurationNotFoundFault(message: String?)
-    case hsmConfigurationQuotaExceededFault(message: String?)
-    case inProgressTableRestoreQuotaExceededFault(message: String?)
-    case incompatibleOrderableOptions(message: String?)
-    case insufficientClusterCapacityFault(message: String?)
-    case insufficientS3BucketPolicyFault(message: String?)
-    case invalidClusterParameterGroupStateFault(message: String?)
-    case invalidClusterSecurityGroupStateFault(message: String?)
-    case invalidClusterSnapshotScheduleStateFault(message: String?)
-    case invalidClusterSnapshotStateFault(message: String?)
-    case invalidClusterStateFault(message: String?)
-    case invalidClusterSubnetGroupStateFault(message: String?)
-    case invalidClusterSubnetStateFault(message: String?)
-    case invalidClusterTrackFault(message: String?)
-    case invalidElasticIpFault(message: String?)
-    case invalidHsmClientCertificateStateFault(message: String?)
-    case invalidHsmConfigurationStateFault(message: String?)
-    case invalidReservedNodeStateFault(message: String?)
-    case invalidRestoreFault(message: String?)
-    case invalidRetentionPeriodFault(message: String?)
-    case invalidS3BucketNameFault(message: String?)
-    case invalidS3KeyPrefixFault(message: String?)
-    case invalidScheduleFault(message: String?)
-    case invalidScheduledActionFault(message: String?)
-    case invalidSnapshotCopyGrantStateFault(message: String?)
-    case invalidSubnet(message: String?)
-    case invalidSubscriptionStateFault(message: String?)
-    case invalidTableRestoreArgumentFault(message: String?)
-    case invalidTagFault(message: String?)
-    case invalidUsageLimitFault(message: String?)
-    case invalidVPCNetworkStateFault(message: String?)
-    case limitExceededFault(message: String?)
-    case numberOfNodesPerClusterLimitExceededFault(message: String?)
-    case numberOfNodesQuotaExceededFault(message: String?)
-    case reservedNodeAlreadyExistsFault(message: String?)
-    case reservedNodeAlreadyMigratedFault(message: String?)
-    case reservedNodeNotFoundFault(message: String?)
-    case reservedNodeOfferingNotFoundFault(message: String?)
-    case reservedNodeQuotaExceededFault(message: String?)
-    case resizeNotFoundFault(message: String?)
-    case resourceNotFoundFault(message: String?)
-    case sNSInvalidTopicFault(message: String?)
-    case sNSNoAuthorizationFault(message: String?)
-    case sNSTopicArnNotFoundFault(message: String?)
-    case scheduleDefinitionTypeUnsupportedFault(message: String?)
-    case scheduledActionAlreadyExistsFault(message: String?)
-    case scheduledActionNotFoundFault(message: String?)
-    case scheduledActionQuotaExceededFault(message: String?)
-    case scheduledActionTypeUnsupportedFault(message: String?)
-    case snapshotCopyAlreadyDisabledFault(message: String?)
-    case snapshotCopyAlreadyEnabledFault(message: String?)
-    case snapshotCopyDisabledFault(message: String?)
-    case snapshotCopyGrantAlreadyExistsFault(message: String?)
-    case snapshotCopyGrantNotFoundFault(message: String?)
-    case snapshotCopyGrantQuotaExceededFault(message: String?)
-    case snapshotScheduleAlreadyExistsFault(message: String?)
-    case snapshotScheduleNotFoundFault(message: String?)
-    case snapshotScheduleQuotaExceededFault(message: String?)
-    case snapshotScheduleUpdateInProgressFault(message: String?)
-    case sourceNotFoundFault(message: String?)
-    case subnetAlreadyInUse(message: String?)
-    case subscriptionAlreadyExistFault(message: String?)
-    case subscriptionCategoryNotFoundFault(message: String?)
-    case subscriptionEventIdNotFoundFault(message: String?)
-    case subscriptionNotFoundFault(message: String?)
-    case subscriptionSeverityNotFoundFault(message: String?)
-    case tableLimitExceededFault(message: String?)
-    case tableRestoreNotFoundFault(message: String?)
-    case tagLimitExceededFault(message: String?)
-    case unauthorizedOperation(message: String?)
-    case unknownSnapshotCopyRegionFault(message: String?)
-    case unsupportedOperationFault(message: String?)
-    case unsupportedOptionFault(message: String?)
-    case usageLimitAlreadyExistsFault(message: String?)
-    case usageLimitNotFoundFault(message: String?)
-}
+public struct RedshiftErrorType: AWSErrorType {
+    enum Code: String {
+        case accessToSnapshotDeniedFault = "AccessToSnapshotDenied"
+        case authorizationAlreadyExistsFault = "AuthorizationAlreadyExists"
+        case authorizationNotFoundFault = "AuthorizationNotFound"
+        case authorizationQuotaExceededFault = "AuthorizationQuotaExceeded"
+        case batchDeleteRequestSizeExceededFault = "BatchDeleteRequestSizeExceeded"
+        case batchModifyClusterSnapshotsLimitExceededFault = "BatchModifyClusterSnapshotsLimitExceededFault"
+        case bucketNotFoundFault = "BucketNotFoundFault"
+        case clusterAlreadyExistsFault = "ClusterAlreadyExists"
+        case clusterNotFoundFault = "ClusterNotFound"
+        case clusterOnLatestRevisionFault = "ClusterOnLatestRevision"
+        case clusterParameterGroupAlreadyExistsFault = "ClusterParameterGroupAlreadyExists"
+        case clusterParameterGroupNotFoundFault = "ClusterParameterGroupNotFound"
+        case clusterParameterGroupQuotaExceededFault = "ClusterParameterGroupQuotaExceeded"
+        case clusterQuotaExceededFault = "ClusterQuotaExceeded"
+        case clusterSecurityGroupAlreadyExistsFault = "ClusterSecurityGroupAlreadyExists"
+        case clusterSecurityGroupNotFoundFault = "ClusterSecurityGroupNotFound"
+        case clusterSecurityGroupQuotaExceededFault = "QuotaExceeded.ClusterSecurityGroup"
+        case clusterSnapshotAlreadyExistsFault = "ClusterSnapshotAlreadyExists"
+        case clusterSnapshotNotFoundFault = "ClusterSnapshotNotFound"
+        case clusterSnapshotQuotaExceededFault = "ClusterSnapshotQuotaExceeded"
+        case clusterSubnetGroupAlreadyExistsFault = "ClusterSubnetGroupAlreadyExists"
+        case clusterSubnetGroupNotFoundFault = "ClusterSubnetGroupNotFoundFault"
+        case clusterSubnetGroupQuotaExceededFault = "ClusterSubnetGroupQuotaExceeded"
+        case clusterSubnetQuotaExceededFault = "ClusterSubnetQuotaExceededFault"
+        case copyToRegionDisabledFault = "CopyToRegionDisabledFault"
+        case dependentServiceRequestThrottlingFault = "DependentServiceRequestThrottlingFault"
+        case dependentServiceUnavailableFault = "DependentServiceUnavailableFault"
+        case eventSubscriptionQuotaExceededFault = "EventSubscriptionQuotaExceeded"
+        case hsmClientCertificateAlreadyExistsFault = "HsmClientCertificateAlreadyExistsFault"
+        case hsmClientCertificateNotFoundFault = "HsmClientCertificateNotFoundFault"
+        case hsmClientCertificateQuotaExceededFault = "HsmClientCertificateQuotaExceededFault"
+        case hsmConfigurationAlreadyExistsFault = "HsmConfigurationAlreadyExistsFault"
+        case hsmConfigurationNotFoundFault = "HsmConfigurationNotFoundFault"
+        case hsmConfigurationQuotaExceededFault = "HsmConfigurationQuotaExceededFault"
+        case inProgressTableRestoreQuotaExceededFault = "InProgressTableRestoreQuotaExceededFault"
+        case incompatibleOrderableOptions = "IncompatibleOrderableOptions"
+        case insufficientClusterCapacityFault = "InsufficientClusterCapacity"
+        case insufficientS3BucketPolicyFault = "InsufficientS3BucketPolicyFault"
+        case invalidClusterParameterGroupStateFault = "InvalidClusterParameterGroupState"
+        case invalidClusterSecurityGroupStateFault = "InvalidClusterSecurityGroupState"
+        case invalidClusterSnapshotScheduleStateFault = "InvalidClusterSnapshotScheduleState"
+        case invalidClusterSnapshotStateFault = "InvalidClusterSnapshotState"
+        case invalidClusterStateFault = "InvalidClusterState"
+        case invalidClusterSubnetGroupStateFault = "InvalidClusterSubnetGroupStateFault"
+        case invalidClusterSubnetStateFault = "InvalidClusterSubnetStateFault"
+        case invalidClusterTrackFault = "InvalidClusterTrack"
+        case invalidElasticIpFault = "InvalidElasticIpFault"
+        case invalidHsmClientCertificateStateFault = "InvalidHsmClientCertificateStateFault"
+        case invalidHsmConfigurationStateFault = "InvalidHsmConfigurationStateFault"
+        case invalidReservedNodeStateFault = "InvalidReservedNodeState"
+        case invalidRestoreFault = "InvalidRestore"
+        case invalidRetentionPeriodFault = "InvalidRetentionPeriodFault"
+        case invalidS3BucketNameFault = "InvalidS3BucketNameFault"
+        case invalidS3KeyPrefixFault = "InvalidS3KeyPrefixFault"
+        case invalidScheduleFault = "InvalidSchedule"
+        case invalidScheduledActionFault = "InvalidScheduledAction"
+        case invalidSnapshotCopyGrantStateFault = "InvalidSnapshotCopyGrantStateFault"
+        case invalidSubnet = "InvalidSubnet"
+        case invalidSubscriptionStateFault = "InvalidSubscriptionStateFault"
+        case invalidTableRestoreArgumentFault = "InvalidTableRestoreArgument"
+        case invalidTagFault = "InvalidTagFault"
+        case invalidUsageLimitFault = "InvalidUsageLimit"
+        case invalidVPCNetworkStateFault = "InvalidVPCNetworkStateFault"
+        case limitExceededFault = "LimitExceededFault"
+        case numberOfNodesPerClusterLimitExceededFault = "NumberOfNodesPerClusterLimitExceeded"
+        case numberOfNodesQuotaExceededFault = "NumberOfNodesQuotaExceeded"
+        case reservedNodeAlreadyExistsFault = "ReservedNodeAlreadyExists"
+        case reservedNodeAlreadyMigratedFault = "ReservedNodeAlreadyMigrated"
+        case reservedNodeNotFoundFault = "ReservedNodeNotFound"
+        case reservedNodeOfferingNotFoundFault = "ReservedNodeOfferingNotFound"
+        case reservedNodeQuotaExceededFault = "ReservedNodeQuotaExceeded"
+        case resizeNotFoundFault = "ResizeNotFound"
+        case resourceNotFoundFault = "ResourceNotFoundFault"
+        case sNSInvalidTopicFault = "SNSInvalidTopic"
+        case sNSNoAuthorizationFault = "SNSNoAuthorization"
+        case sNSTopicArnNotFoundFault = "SNSTopicArnNotFound"
+        case scheduleDefinitionTypeUnsupportedFault = "ScheduleDefinitionTypeUnsupported"
+        case scheduledActionAlreadyExistsFault = "ScheduledActionAlreadyExists"
+        case scheduledActionNotFoundFault = "ScheduledActionNotFound"
+        case scheduledActionQuotaExceededFault = "ScheduledActionQuotaExceeded"
+        case scheduledActionTypeUnsupportedFault = "ScheduledActionTypeUnsupported"
+        case snapshotCopyAlreadyDisabledFault = "SnapshotCopyAlreadyDisabledFault"
+        case snapshotCopyAlreadyEnabledFault = "SnapshotCopyAlreadyEnabledFault"
+        case snapshotCopyDisabledFault = "SnapshotCopyDisabledFault"
+        case snapshotCopyGrantAlreadyExistsFault = "SnapshotCopyGrantAlreadyExistsFault"
+        case snapshotCopyGrantNotFoundFault = "SnapshotCopyGrantNotFoundFault"
+        case snapshotCopyGrantQuotaExceededFault = "SnapshotCopyGrantQuotaExceededFault"
+        case snapshotScheduleAlreadyExistsFault = "SnapshotScheduleAlreadyExists"
+        case snapshotScheduleNotFoundFault = "SnapshotScheduleNotFound"
+        case snapshotScheduleQuotaExceededFault = "SnapshotScheduleQuotaExceeded"
+        case snapshotScheduleUpdateInProgressFault = "SnapshotScheduleUpdateInProgress"
+        case sourceNotFoundFault = "SourceNotFound"
+        case subnetAlreadyInUse = "SubnetAlreadyInUse"
+        case subscriptionAlreadyExistFault = "SubscriptionAlreadyExist"
+        case subscriptionCategoryNotFoundFault = "SubscriptionCategoryNotFound"
+        case subscriptionEventIdNotFoundFault = "SubscriptionEventIdNotFound"
+        case subscriptionNotFoundFault = "SubscriptionNotFound"
+        case subscriptionSeverityNotFoundFault = "SubscriptionSeverityNotFound"
+        case tableLimitExceededFault = "TableLimitExceeded"
+        case tableRestoreNotFoundFault = "TableRestoreNotFoundFault"
+        case tagLimitExceededFault = "TagLimitExceededFault"
+        case unauthorizedOperation = "UnauthorizedOperation"
+        case unknownSnapshotCopyRegionFault = "UnknownSnapshotCopyRegionFault"
+        case unsupportedOperationFault = "UnsupportedOperation"
+        case unsupportedOptionFault = "UnsupportedOptionFault"
+        case usageLimitAlreadyExistsFault = "UsageLimitAlreadyExists"
+        case usageLimitNotFoundFault = "UsageLimitNotFound"
+    }
 
-extension RedshiftErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessToSnapshotDenied":
-            self = .accessToSnapshotDeniedFault(message: message)
-        case "AuthorizationAlreadyExists":
-            self = .authorizationAlreadyExistsFault(message: message)
-        case "AuthorizationNotFound":
-            self = .authorizationNotFoundFault(message: message)
-        case "AuthorizationQuotaExceeded":
-            self = .authorizationQuotaExceededFault(message: message)
-        case "BatchDeleteRequestSizeExceeded":
-            self = .batchDeleteRequestSizeExceededFault(message: message)
-        case "BatchModifyClusterSnapshotsLimitExceededFault":
-            self = .batchModifyClusterSnapshotsLimitExceededFault(message: message)
-        case "BucketNotFoundFault":
-            self = .bucketNotFoundFault(message: message)
-        case "ClusterAlreadyExists":
-            self = .clusterAlreadyExistsFault(message: message)
-        case "ClusterNotFound":
-            self = .clusterNotFoundFault(message: message)
-        case "ClusterOnLatestRevision":
-            self = .clusterOnLatestRevisionFault(message: message)
-        case "ClusterParameterGroupAlreadyExists":
-            self = .clusterParameterGroupAlreadyExistsFault(message: message)
-        case "ClusterParameterGroupNotFound":
-            self = .clusterParameterGroupNotFoundFault(message: message)
-        case "ClusterParameterGroupQuotaExceeded":
-            self = .clusterParameterGroupQuotaExceededFault(message: message)
-        case "ClusterQuotaExceeded":
-            self = .clusterQuotaExceededFault(message: message)
-        case "ClusterSecurityGroupAlreadyExists":
-            self = .clusterSecurityGroupAlreadyExistsFault(message: message)
-        case "ClusterSecurityGroupNotFound":
-            self = .clusterSecurityGroupNotFoundFault(message: message)
-        case "QuotaExceeded.ClusterSecurityGroup":
-            self = .clusterSecurityGroupQuotaExceededFault(message: message)
-        case "ClusterSnapshotAlreadyExists":
-            self = .clusterSnapshotAlreadyExistsFault(message: message)
-        case "ClusterSnapshotNotFound":
-            self = .clusterSnapshotNotFoundFault(message: message)
-        case "ClusterSnapshotQuotaExceeded":
-            self = .clusterSnapshotQuotaExceededFault(message: message)
-        case "ClusterSubnetGroupAlreadyExists":
-            self = .clusterSubnetGroupAlreadyExistsFault(message: message)
-        case "ClusterSubnetGroupNotFoundFault":
-            self = .clusterSubnetGroupNotFoundFault(message: message)
-        case "ClusterSubnetGroupQuotaExceeded":
-            self = .clusterSubnetGroupQuotaExceededFault(message: message)
-        case "ClusterSubnetQuotaExceededFault":
-            self = .clusterSubnetQuotaExceededFault(message: message)
-        case "CopyToRegionDisabledFault":
-            self = .copyToRegionDisabledFault(message: message)
-        case "DependentServiceRequestThrottlingFault":
-            self = .dependentServiceRequestThrottlingFault(message: message)
-        case "DependentServiceUnavailableFault":
-            self = .dependentServiceUnavailableFault(message: message)
-        case "EventSubscriptionQuotaExceeded":
-            self = .eventSubscriptionQuotaExceededFault(message: message)
-        case "HsmClientCertificateAlreadyExistsFault":
-            self = .hsmClientCertificateAlreadyExistsFault(message: message)
-        case "HsmClientCertificateNotFoundFault":
-            self = .hsmClientCertificateNotFoundFault(message: message)
-        case "HsmClientCertificateQuotaExceededFault":
-            self = .hsmClientCertificateQuotaExceededFault(message: message)
-        case "HsmConfigurationAlreadyExistsFault":
-            self = .hsmConfigurationAlreadyExistsFault(message: message)
-        case "HsmConfigurationNotFoundFault":
-            self = .hsmConfigurationNotFoundFault(message: message)
-        case "HsmConfigurationQuotaExceededFault":
-            self = .hsmConfigurationQuotaExceededFault(message: message)
-        case "InProgressTableRestoreQuotaExceededFault":
-            self = .inProgressTableRestoreQuotaExceededFault(message: message)
-        case "IncompatibleOrderableOptions":
-            self = .incompatibleOrderableOptions(message: message)
-        case "InsufficientClusterCapacity":
-            self = .insufficientClusterCapacityFault(message: message)
-        case "InsufficientS3BucketPolicyFault":
-            self = .insufficientS3BucketPolicyFault(message: message)
-        case "InvalidClusterParameterGroupState":
-            self = .invalidClusterParameterGroupStateFault(message: message)
-        case "InvalidClusterSecurityGroupState":
-            self = .invalidClusterSecurityGroupStateFault(message: message)
-        case "InvalidClusterSnapshotScheduleState":
-            self = .invalidClusterSnapshotScheduleStateFault(message: message)
-        case "InvalidClusterSnapshotState":
-            self = .invalidClusterSnapshotStateFault(message: message)
-        case "InvalidClusterState":
-            self = .invalidClusterStateFault(message: message)
-        case "InvalidClusterSubnetGroupStateFault":
-            self = .invalidClusterSubnetGroupStateFault(message: message)
-        case "InvalidClusterSubnetStateFault":
-            self = .invalidClusterSubnetStateFault(message: message)
-        case "InvalidClusterTrack":
-            self = .invalidClusterTrackFault(message: message)
-        case "InvalidElasticIpFault":
-            self = .invalidElasticIpFault(message: message)
-        case "InvalidHsmClientCertificateStateFault":
-            self = .invalidHsmClientCertificateStateFault(message: message)
-        case "InvalidHsmConfigurationStateFault":
-            self = .invalidHsmConfigurationStateFault(message: message)
-        case "InvalidReservedNodeState":
-            self = .invalidReservedNodeStateFault(message: message)
-        case "InvalidRestore":
-            self = .invalidRestoreFault(message: message)
-        case "InvalidRetentionPeriodFault":
-            self = .invalidRetentionPeriodFault(message: message)
-        case "InvalidS3BucketNameFault":
-            self = .invalidS3BucketNameFault(message: message)
-        case "InvalidS3KeyPrefixFault":
-            self = .invalidS3KeyPrefixFault(message: message)
-        case "InvalidSchedule":
-            self = .invalidScheduleFault(message: message)
-        case "InvalidScheduledAction":
-            self = .invalidScheduledActionFault(message: message)
-        case "InvalidSnapshotCopyGrantStateFault":
-            self = .invalidSnapshotCopyGrantStateFault(message: message)
-        case "InvalidSubnet":
-            self = .invalidSubnet(message: message)
-        case "InvalidSubscriptionStateFault":
-            self = .invalidSubscriptionStateFault(message: message)
-        case "InvalidTableRestoreArgument":
-            self = .invalidTableRestoreArgumentFault(message: message)
-        case "InvalidTagFault":
-            self = .invalidTagFault(message: message)
-        case "InvalidUsageLimit":
-            self = .invalidUsageLimitFault(message: message)
-        case "InvalidVPCNetworkStateFault":
-            self = .invalidVPCNetworkStateFault(message: message)
-        case "LimitExceededFault":
-            self = .limitExceededFault(message: message)
-        case "NumberOfNodesPerClusterLimitExceeded":
-            self = .numberOfNodesPerClusterLimitExceededFault(message: message)
-        case "NumberOfNodesQuotaExceeded":
-            self = .numberOfNodesQuotaExceededFault(message: message)
-        case "ReservedNodeAlreadyExists":
-            self = .reservedNodeAlreadyExistsFault(message: message)
-        case "ReservedNodeAlreadyMigrated":
-            self = .reservedNodeAlreadyMigratedFault(message: message)
-        case "ReservedNodeNotFound":
-            self = .reservedNodeNotFoundFault(message: message)
-        case "ReservedNodeOfferingNotFound":
-            self = .reservedNodeOfferingNotFoundFault(message: message)
-        case "ReservedNodeQuotaExceeded":
-            self = .reservedNodeQuotaExceededFault(message: message)
-        case "ResizeNotFound":
-            self = .resizeNotFoundFault(message: message)
-        case "ResourceNotFoundFault":
-            self = .resourceNotFoundFault(message: message)
-        case "SNSInvalidTopic":
-            self = .sNSInvalidTopicFault(message: message)
-        case "SNSNoAuthorization":
-            self = .sNSNoAuthorizationFault(message: message)
-        case "SNSTopicArnNotFound":
-            self = .sNSTopicArnNotFoundFault(message: message)
-        case "ScheduleDefinitionTypeUnsupported":
-            self = .scheduleDefinitionTypeUnsupportedFault(message: message)
-        case "ScheduledActionAlreadyExists":
-            self = .scheduledActionAlreadyExistsFault(message: message)
-        case "ScheduledActionNotFound":
-            self = .scheduledActionNotFoundFault(message: message)
-        case "ScheduledActionQuotaExceeded":
-            self = .scheduledActionQuotaExceededFault(message: message)
-        case "ScheduledActionTypeUnsupported":
-            self = .scheduledActionTypeUnsupportedFault(message: message)
-        case "SnapshotCopyAlreadyDisabledFault":
-            self = .snapshotCopyAlreadyDisabledFault(message: message)
-        case "SnapshotCopyAlreadyEnabledFault":
-            self = .snapshotCopyAlreadyEnabledFault(message: message)
-        case "SnapshotCopyDisabledFault":
-            self = .snapshotCopyDisabledFault(message: message)
-        case "SnapshotCopyGrantAlreadyExistsFault":
-            self = .snapshotCopyGrantAlreadyExistsFault(message: message)
-        case "SnapshotCopyGrantNotFoundFault":
-            self = .snapshotCopyGrantNotFoundFault(message: message)
-        case "SnapshotCopyGrantQuotaExceededFault":
-            self = .snapshotCopyGrantQuotaExceededFault(message: message)
-        case "SnapshotScheduleAlreadyExists":
-            self = .snapshotScheduleAlreadyExistsFault(message: message)
-        case "SnapshotScheduleNotFound":
-            self = .snapshotScheduleNotFoundFault(message: message)
-        case "SnapshotScheduleQuotaExceeded":
-            self = .snapshotScheduleQuotaExceededFault(message: message)
-        case "SnapshotScheduleUpdateInProgress":
-            self = .snapshotScheduleUpdateInProgressFault(message: message)
-        case "SourceNotFound":
-            self = .sourceNotFoundFault(message: message)
-        case "SubnetAlreadyInUse":
-            self = .subnetAlreadyInUse(message: message)
-        case "SubscriptionAlreadyExist":
-            self = .subscriptionAlreadyExistFault(message: message)
-        case "SubscriptionCategoryNotFound":
-            self = .subscriptionCategoryNotFoundFault(message: message)
-        case "SubscriptionEventIdNotFound":
-            self = .subscriptionEventIdNotFoundFault(message: message)
-        case "SubscriptionNotFound":
-            self = .subscriptionNotFoundFault(message: message)
-        case "SubscriptionSeverityNotFound":
-            self = .subscriptionSeverityNotFoundFault(message: message)
-        case "TableLimitExceeded":
-            self = .tableLimitExceededFault(message: message)
-        case "TableRestoreNotFoundFault":
-            self = .tableRestoreNotFoundFault(message: message)
-        case "TagLimitExceededFault":
-            self = .tagLimitExceededFault(message: message)
-        case "UnauthorizedOperation":
-            self = .unauthorizedOperation(message: message)
-        case "UnknownSnapshotCopyRegionFault":
-            self = .unknownSnapshotCopyRegionFault(message: message)
-        case "UnsupportedOperation":
-            self = .unsupportedOperationFault(message: message)
-        case "UnsupportedOptionFault":
-            self = .unsupportedOptionFault(message: message)
-        case "UsageLimitAlreadyExists":
-            self = .usageLimitAlreadyExistsFault(message: message)
-        case "UsageLimitNotFound":
-            self = .usageLimitNotFoundFault(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessToSnapshotDeniedFault: Self { .init(.accessToSnapshotDeniedFault) }
+    public static var authorizationAlreadyExistsFault: Self { .init(.authorizationAlreadyExistsFault) }
+    public static var authorizationNotFoundFault: Self { .init(.authorizationNotFoundFault) }
+    public static var authorizationQuotaExceededFault: Self { .init(.authorizationQuotaExceededFault) }
+    public static var batchDeleteRequestSizeExceededFault: Self { .init(.batchDeleteRequestSizeExceededFault) }
+    public static var batchModifyClusterSnapshotsLimitExceededFault: Self { .init(.batchModifyClusterSnapshotsLimitExceededFault) }
+    public static var bucketNotFoundFault: Self { .init(.bucketNotFoundFault) }
+    public static var clusterAlreadyExistsFault: Self { .init(.clusterAlreadyExistsFault) }
+    public static var clusterNotFoundFault: Self { .init(.clusterNotFoundFault) }
+    public static var clusterOnLatestRevisionFault: Self { .init(.clusterOnLatestRevisionFault) }
+    public static var clusterParameterGroupAlreadyExistsFault: Self { .init(.clusterParameterGroupAlreadyExistsFault) }
+    public static var clusterParameterGroupNotFoundFault: Self { .init(.clusterParameterGroupNotFoundFault) }
+    public static var clusterParameterGroupQuotaExceededFault: Self { .init(.clusterParameterGroupQuotaExceededFault) }
+    public static var clusterQuotaExceededFault: Self { .init(.clusterQuotaExceededFault) }
+    public static var clusterSecurityGroupAlreadyExistsFault: Self { .init(.clusterSecurityGroupAlreadyExistsFault) }
+    public static var clusterSecurityGroupNotFoundFault: Self { .init(.clusterSecurityGroupNotFoundFault) }
+    public static var clusterSecurityGroupQuotaExceededFault: Self { .init(.clusterSecurityGroupQuotaExceededFault) }
+    public static var clusterSnapshotAlreadyExistsFault: Self { .init(.clusterSnapshotAlreadyExistsFault) }
+    public static var clusterSnapshotNotFoundFault: Self { .init(.clusterSnapshotNotFoundFault) }
+    public static var clusterSnapshotQuotaExceededFault: Self { .init(.clusterSnapshotQuotaExceededFault) }
+    public static var clusterSubnetGroupAlreadyExistsFault: Self { .init(.clusterSubnetGroupAlreadyExistsFault) }
+    public static var clusterSubnetGroupNotFoundFault: Self { .init(.clusterSubnetGroupNotFoundFault) }
+    public static var clusterSubnetGroupQuotaExceededFault: Self { .init(.clusterSubnetGroupQuotaExceededFault) }
+    public static var clusterSubnetQuotaExceededFault: Self { .init(.clusterSubnetQuotaExceededFault) }
+    public static var copyToRegionDisabledFault: Self { .init(.copyToRegionDisabledFault) }
+    public static var dependentServiceRequestThrottlingFault: Self { .init(.dependentServiceRequestThrottlingFault) }
+    public static var dependentServiceUnavailableFault: Self { .init(.dependentServiceUnavailableFault) }
+    public static var eventSubscriptionQuotaExceededFault: Self { .init(.eventSubscriptionQuotaExceededFault) }
+    public static var hsmClientCertificateAlreadyExistsFault: Self { .init(.hsmClientCertificateAlreadyExistsFault) }
+    public static var hsmClientCertificateNotFoundFault: Self { .init(.hsmClientCertificateNotFoundFault) }
+    public static var hsmClientCertificateQuotaExceededFault: Self { .init(.hsmClientCertificateQuotaExceededFault) }
+    public static var hsmConfigurationAlreadyExistsFault: Self { .init(.hsmConfigurationAlreadyExistsFault) }
+    public static var hsmConfigurationNotFoundFault: Self { .init(.hsmConfigurationNotFoundFault) }
+    public static var hsmConfigurationQuotaExceededFault: Self { .init(.hsmConfigurationQuotaExceededFault) }
+    public static var inProgressTableRestoreQuotaExceededFault: Self { .init(.inProgressTableRestoreQuotaExceededFault) }
+    public static var incompatibleOrderableOptions: Self { .init(.incompatibleOrderableOptions) }
+    public static var insufficientClusterCapacityFault: Self { .init(.insufficientClusterCapacityFault) }
+    public static var insufficientS3BucketPolicyFault: Self { .init(.insufficientS3BucketPolicyFault) }
+    public static var invalidClusterParameterGroupStateFault: Self { .init(.invalidClusterParameterGroupStateFault) }
+    public static var invalidClusterSecurityGroupStateFault: Self { .init(.invalidClusterSecurityGroupStateFault) }
+    public static var invalidClusterSnapshotScheduleStateFault: Self { .init(.invalidClusterSnapshotScheduleStateFault) }
+    public static var invalidClusterSnapshotStateFault: Self { .init(.invalidClusterSnapshotStateFault) }
+    public static var invalidClusterStateFault: Self { .init(.invalidClusterStateFault) }
+    public static var invalidClusterSubnetGroupStateFault: Self { .init(.invalidClusterSubnetGroupStateFault) }
+    public static var invalidClusterSubnetStateFault: Self { .init(.invalidClusterSubnetStateFault) }
+    public static var invalidClusterTrackFault: Self { .init(.invalidClusterTrackFault) }
+    public static var invalidElasticIpFault: Self { .init(.invalidElasticIpFault) }
+    public static var invalidHsmClientCertificateStateFault: Self { .init(.invalidHsmClientCertificateStateFault) }
+    public static var invalidHsmConfigurationStateFault: Self { .init(.invalidHsmConfigurationStateFault) }
+    public static var invalidReservedNodeStateFault: Self { .init(.invalidReservedNodeStateFault) }
+    public static var invalidRestoreFault: Self { .init(.invalidRestoreFault) }
+    public static var invalidRetentionPeriodFault: Self { .init(.invalidRetentionPeriodFault) }
+    public static var invalidS3BucketNameFault: Self { .init(.invalidS3BucketNameFault) }
+    public static var invalidS3KeyPrefixFault: Self { .init(.invalidS3KeyPrefixFault) }
+    public static var invalidScheduleFault: Self { .init(.invalidScheduleFault) }
+    public static var invalidScheduledActionFault: Self { .init(.invalidScheduledActionFault) }
+    public static var invalidSnapshotCopyGrantStateFault: Self { .init(.invalidSnapshotCopyGrantStateFault) }
+    public static var invalidSubnet: Self { .init(.invalidSubnet) }
+    public static var invalidSubscriptionStateFault: Self { .init(.invalidSubscriptionStateFault) }
+    public static var invalidTableRestoreArgumentFault: Self { .init(.invalidTableRestoreArgumentFault) }
+    public static var invalidTagFault: Self { .init(.invalidTagFault) }
+    public static var invalidUsageLimitFault: Self { .init(.invalidUsageLimitFault) }
+    public static var invalidVPCNetworkStateFault: Self { .init(.invalidVPCNetworkStateFault) }
+    public static var limitExceededFault: Self { .init(.limitExceededFault) }
+    public static var numberOfNodesPerClusterLimitExceededFault: Self { .init(.numberOfNodesPerClusterLimitExceededFault) }
+    public static var numberOfNodesQuotaExceededFault: Self { .init(.numberOfNodesQuotaExceededFault) }
+    public static var reservedNodeAlreadyExistsFault: Self { .init(.reservedNodeAlreadyExistsFault) }
+    public static var reservedNodeAlreadyMigratedFault: Self { .init(.reservedNodeAlreadyMigratedFault) }
+    public static var reservedNodeNotFoundFault: Self { .init(.reservedNodeNotFoundFault) }
+    public static var reservedNodeOfferingNotFoundFault: Self { .init(.reservedNodeOfferingNotFoundFault) }
+    public static var reservedNodeQuotaExceededFault: Self { .init(.reservedNodeQuotaExceededFault) }
+    public static var resizeNotFoundFault: Self { .init(.resizeNotFoundFault) }
+    public static var resourceNotFoundFault: Self { .init(.resourceNotFoundFault) }
+    public static var sNSInvalidTopicFault: Self { .init(.sNSInvalidTopicFault) }
+    public static var sNSNoAuthorizationFault: Self { .init(.sNSNoAuthorizationFault) }
+    public static var sNSTopicArnNotFoundFault: Self { .init(.sNSTopicArnNotFoundFault) }
+    public static var scheduleDefinitionTypeUnsupportedFault: Self { .init(.scheduleDefinitionTypeUnsupportedFault) }
+    public static var scheduledActionAlreadyExistsFault: Self { .init(.scheduledActionAlreadyExistsFault) }
+    public static var scheduledActionNotFoundFault: Self { .init(.scheduledActionNotFoundFault) }
+    public static var scheduledActionQuotaExceededFault: Self { .init(.scheduledActionQuotaExceededFault) }
+    public static var scheduledActionTypeUnsupportedFault: Self { .init(.scheduledActionTypeUnsupportedFault) }
+    public static var snapshotCopyAlreadyDisabledFault: Self { .init(.snapshotCopyAlreadyDisabledFault) }
+    public static var snapshotCopyAlreadyEnabledFault: Self { .init(.snapshotCopyAlreadyEnabledFault) }
+    public static var snapshotCopyDisabledFault: Self { .init(.snapshotCopyDisabledFault) }
+    public static var snapshotCopyGrantAlreadyExistsFault: Self { .init(.snapshotCopyGrantAlreadyExistsFault) }
+    public static var snapshotCopyGrantNotFoundFault: Self { .init(.snapshotCopyGrantNotFoundFault) }
+    public static var snapshotCopyGrantQuotaExceededFault: Self { .init(.snapshotCopyGrantQuotaExceededFault) }
+    public static var snapshotScheduleAlreadyExistsFault: Self { .init(.snapshotScheduleAlreadyExistsFault) }
+    public static var snapshotScheduleNotFoundFault: Self { .init(.snapshotScheduleNotFoundFault) }
+    public static var snapshotScheduleQuotaExceededFault: Self { .init(.snapshotScheduleQuotaExceededFault) }
+    public static var snapshotScheduleUpdateInProgressFault: Self { .init(.snapshotScheduleUpdateInProgressFault) }
+    public static var sourceNotFoundFault: Self { .init(.sourceNotFoundFault) }
+    public static var subnetAlreadyInUse: Self { .init(.subnetAlreadyInUse) }
+    public static var subscriptionAlreadyExistFault: Self { .init(.subscriptionAlreadyExistFault) }
+    public static var subscriptionCategoryNotFoundFault: Self { .init(.subscriptionCategoryNotFoundFault) }
+    public static var subscriptionEventIdNotFoundFault: Self { .init(.subscriptionEventIdNotFoundFault) }
+    public static var subscriptionNotFoundFault: Self { .init(.subscriptionNotFoundFault) }
+    public static var subscriptionSeverityNotFoundFault: Self { .init(.subscriptionSeverityNotFoundFault) }
+    public static var tableLimitExceededFault: Self { .init(.tableLimitExceededFault) }
+    public static var tableRestoreNotFoundFault: Self { .init(.tableRestoreNotFoundFault) }
+    public static var tagLimitExceededFault: Self { .init(.tagLimitExceededFault) }
+    public static var unauthorizedOperation: Self { .init(.unauthorizedOperation) }
+    public static var unknownSnapshotCopyRegionFault: Self { .init(.unknownSnapshotCopyRegionFault) }
+    public static var unsupportedOperationFault: Self { .init(.unsupportedOperationFault) }
+    public static var unsupportedOptionFault: Self { .init(.unsupportedOptionFault) }
+    public static var usageLimitAlreadyExistsFault: Self { .init(.usageLimitAlreadyExistsFault) }
+    public static var usageLimitNotFoundFault: Self { .init(.usageLimitNotFoundFault) }
+}
+
+extension RedshiftErrorType: Equatable {
+    public static func == (lhs: RedshiftErrorType, rhs: RedshiftErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension RedshiftErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessToSnapshotDeniedFault(let message):
-            return "AccessToSnapshotDenied: \(message ?? "")"
-        case .authorizationAlreadyExistsFault(let message):
-            return "AuthorizationAlreadyExists: \(message ?? "")"
-        case .authorizationNotFoundFault(let message):
-            return "AuthorizationNotFound: \(message ?? "")"
-        case .authorizationQuotaExceededFault(let message):
-            return "AuthorizationQuotaExceeded: \(message ?? "")"
-        case .batchDeleteRequestSizeExceededFault(let message):
-            return "BatchDeleteRequestSizeExceeded: \(message ?? "")"
-        case .batchModifyClusterSnapshotsLimitExceededFault(let message):
-            return "BatchModifyClusterSnapshotsLimitExceededFault: \(message ?? "")"
-        case .bucketNotFoundFault(let message):
-            return "BucketNotFoundFault: \(message ?? "")"
-        case .clusterAlreadyExistsFault(let message):
-            return "ClusterAlreadyExists: \(message ?? "")"
-        case .clusterNotFoundFault(let message):
-            return "ClusterNotFound: \(message ?? "")"
-        case .clusterOnLatestRevisionFault(let message):
-            return "ClusterOnLatestRevision: \(message ?? "")"
-        case .clusterParameterGroupAlreadyExistsFault(let message):
-            return "ClusterParameterGroupAlreadyExists: \(message ?? "")"
-        case .clusterParameterGroupNotFoundFault(let message):
-            return "ClusterParameterGroupNotFound: \(message ?? "")"
-        case .clusterParameterGroupQuotaExceededFault(let message):
-            return "ClusterParameterGroupQuotaExceeded: \(message ?? "")"
-        case .clusterQuotaExceededFault(let message):
-            return "ClusterQuotaExceeded: \(message ?? "")"
-        case .clusterSecurityGroupAlreadyExistsFault(let message):
-            return "ClusterSecurityGroupAlreadyExists: \(message ?? "")"
-        case .clusterSecurityGroupNotFoundFault(let message):
-            return "ClusterSecurityGroupNotFound: \(message ?? "")"
-        case .clusterSecurityGroupQuotaExceededFault(let message):
-            return "QuotaExceeded.ClusterSecurityGroup: \(message ?? "")"
-        case .clusterSnapshotAlreadyExistsFault(let message):
-            return "ClusterSnapshotAlreadyExists: \(message ?? "")"
-        case .clusterSnapshotNotFoundFault(let message):
-            return "ClusterSnapshotNotFound: \(message ?? "")"
-        case .clusterSnapshotQuotaExceededFault(let message):
-            return "ClusterSnapshotQuotaExceeded: \(message ?? "")"
-        case .clusterSubnetGroupAlreadyExistsFault(let message):
-            return "ClusterSubnetGroupAlreadyExists: \(message ?? "")"
-        case .clusterSubnetGroupNotFoundFault(let message):
-            return "ClusterSubnetGroupNotFoundFault: \(message ?? "")"
-        case .clusterSubnetGroupQuotaExceededFault(let message):
-            return "ClusterSubnetGroupQuotaExceeded: \(message ?? "")"
-        case .clusterSubnetQuotaExceededFault(let message):
-            return "ClusterSubnetQuotaExceededFault: \(message ?? "")"
-        case .copyToRegionDisabledFault(let message):
-            return "CopyToRegionDisabledFault: \(message ?? "")"
-        case .dependentServiceRequestThrottlingFault(let message):
-            return "DependentServiceRequestThrottlingFault: \(message ?? "")"
-        case .dependentServiceUnavailableFault(let message):
-            return "DependentServiceUnavailableFault: \(message ?? "")"
-        case .eventSubscriptionQuotaExceededFault(let message):
-            return "EventSubscriptionQuotaExceeded: \(message ?? "")"
-        case .hsmClientCertificateAlreadyExistsFault(let message):
-            return "HsmClientCertificateAlreadyExistsFault: \(message ?? "")"
-        case .hsmClientCertificateNotFoundFault(let message):
-            return "HsmClientCertificateNotFoundFault: \(message ?? "")"
-        case .hsmClientCertificateQuotaExceededFault(let message):
-            return "HsmClientCertificateQuotaExceededFault: \(message ?? "")"
-        case .hsmConfigurationAlreadyExistsFault(let message):
-            return "HsmConfigurationAlreadyExistsFault: \(message ?? "")"
-        case .hsmConfigurationNotFoundFault(let message):
-            return "HsmConfigurationNotFoundFault: \(message ?? "")"
-        case .hsmConfigurationQuotaExceededFault(let message):
-            return "HsmConfigurationQuotaExceededFault: \(message ?? "")"
-        case .inProgressTableRestoreQuotaExceededFault(let message):
-            return "InProgressTableRestoreQuotaExceededFault: \(message ?? "")"
-        case .incompatibleOrderableOptions(let message):
-            return "IncompatibleOrderableOptions: \(message ?? "")"
-        case .insufficientClusterCapacityFault(let message):
-            return "InsufficientClusterCapacity: \(message ?? "")"
-        case .insufficientS3BucketPolicyFault(let message):
-            return "InsufficientS3BucketPolicyFault: \(message ?? "")"
-        case .invalidClusterParameterGroupStateFault(let message):
-            return "InvalidClusterParameterGroupState: \(message ?? "")"
-        case .invalidClusterSecurityGroupStateFault(let message):
-            return "InvalidClusterSecurityGroupState: \(message ?? "")"
-        case .invalidClusterSnapshotScheduleStateFault(let message):
-            return "InvalidClusterSnapshotScheduleState: \(message ?? "")"
-        case .invalidClusterSnapshotStateFault(let message):
-            return "InvalidClusterSnapshotState: \(message ?? "")"
-        case .invalidClusterStateFault(let message):
-            return "InvalidClusterState: \(message ?? "")"
-        case .invalidClusterSubnetGroupStateFault(let message):
-            return "InvalidClusterSubnetGroupStateFault: \(message ?? "")"
-        case .invalidClusterSubnetStateFault(let message):
-            return "InvalidClusterSubnetStateFault: \(message ?? "")"
-        case .invalidClusterTrackFault(let message):
-            return "InvalidClusterTrack: \(message ?? "")"
-        case .invalidElasticIpFault(let message):
-            return "InvalidElasticIpFault: \(message ?? "")"
-        case .invalidHsmClientCertificateStateFault(let message):
-            return "InvalidHsmClientCertificateStateFault: \(message ?? "")"
-        case .invalidHsmConfigurationStateFault(let message):
-            return "InvalidHsmConfigurationStateFault: \(message ?? "")"
-        case .invalidReservedNodeStateFault(let message):
-            return "InvalidReservedNodeState: \(message ?? "")"
-        case .invalidRestoreFault(let message):
-            return "InvalidRestore: \(message ?? "")"
-        case .invalidRetentionPeriodFault(let message):
-            return "InvalidRetentionPeriodFault: \(message ?? "")"
-        case .invalidS3BucketNameFault(let message):
-            return "InvalidS3BucketNameFault: \(message ?? "")"
-        case .invalidS3KeyPrefixFault(let message):
-            return "InvalidS3KeyPrefixFault: \(message ?? "")"
-        case .invalidScheduleFault(let message):
-            return "InvalidSchedule: \(message ?? "")"
-        case .invalidScheduledActionFault(let message):
-            return "InvalidScheduledAction: \(message ?? "")"
-        case .invalidSnapshotCopyGrantStateFault(let message):
-            return "InvalidSnapshotCopyGrantStateFault: \(message ?? "")"
-        case .invalidSubnet(let message):
-            return "InvalidSubnet: \(message ?? "")"
-        case .invalidSubscriptionStateFault(let message):
-            return "InvalidSubscriptionStateFault: \(message ?? "")"
-        case .invalidTableRestoreArgumentFault(let message):
-            return "InvalidTableRestoreArgument: \(message ?? "")"
-        case .invalidTagFault(let message):
-            return "InvalidTagFault: \(message ?? "")"
-        case .invalidUsageLimitFault(let message):
-            return "InvalidUsageLimit: \(message ?? "")"
-        case .invalidVPCNetworkStateFault(let message):
-            return "InvalidVPCNetworkStateFault: \(message ?? "")"
-        case .limitExceededFault(let message):
-            return "LimitExceededFault: \(message ?? "")"
-        case .numberOfNodesPerClusterLimitExceededFault(let message):
-            return "NumberOfNodesPerClusterLimitExceeded: \(message ?? "")"
-        case .numberOfNodesQuotaExceededFault(let message):
-            return "NumberOfNodesQuotaExceeded: \(message ?? "")"
-        case .reservedNodeAlreadyExistsFault(let message):
-            return "ReservedNodeAlreadyExists: \(message ?? "")"
-        case .reservedNodeAlreadyMigratedFault(let message):
-            return "ReservedNodeAlreadyMigrated: \(message ?? "")"
-        case .reservedNodeNotFoundFault(let message):
-            return "ReservedNodeNotFound: \(message ?? "")"
-        case .reservedNodeOfferingNotFoundFault(let message):
-            return "ReservedNodeOfferingNotFound: \(message ?? "")"
-        case .reservedNodeQuotaExceededFault(let message):
-            return "ReservedNodeQuotaExceeded: \(message ?? "")"
-        case .resizeNotFoundFault(let message):
-            return "ResizeNotFound: \(message ?? "")"
-        case .resourceNotFoundFault(let message):
-            return "ResourceNotFoundFault: \(message ?? "")"
-        case .sNSInvalidTopicFault(let message):
-            return "SNSInvalidTopic: \(message ?? "")"
-        case .sNSNoAuthorizationFault(let message):
-            return "SNSNoAuthorization: \(message ?? "")"
-        case .sNSTopicArnNotFoundFault(let message):
-            return "SNSTopicArnNotFound: \(message ?? "")"
-        case .scheduleDefinitionTypeUnsupportedFault(let message):
-            return "ScheduleDefinitionTypeUnsupported: \(message ?? "")"
-        case .scheduledActionAlreadyExistsFault(let message):
-            return "ScheduledActionAlreadyExists: \(message ?? "")"
-        case .scheduledActionNotFoundFault(let message):
-            return "ScheduledActionNotFound: \(message ?? "")"
-        case .scheduledActionQuotaExceededFault(let message):
-            return "ScheduledActionQuotaExceeded: \(message ?? "")"
-        case .scheduledActionTypeUnsupportedFault(let message):
-            return "ScheduledActionTypeUnsupported: \(message ?? "")"
-        case .snapshotCopyAlreadyDisabledFault(let message):
-            return "SnapshotCopyAlreadyDisabledFault: \(message ?? "")"
-        case .snapshotCopyAlreadyEnabledFault(let message):
-            return "SnapshotCopyAlreadyEnabledFault: \(message ?? "")"
-        case .snapshotCopyDisabledFault(let message):
-            return "SnapshotCopyDisabledFault: \(message ?? "")"
-        case .snapshotCopyGrantAlreadyExistsFault(let message):
-            return "SnapshotCopyGrantAlreadyExistsFault: \(message ?? "")"
-        case .snapshotCopyGrantNotFoundFault(let message):
-            return "SnapshotCopyGrantNotFoundFault: \(message ?? "")"
-        case .snapshotCopyGrantQuotaExceededFault(let message):
-            return "SnapshotCopyGrantQuotaExceededFault: \(message ?? "")"
-        case .snapshotScheduleAlreadyExistsFault(let message):
-            return "SnapshotScheduleAlreadyExists: \(message ?? "")"
-        case .snapshotScheduleNotFoundFault(let message):
-            return "SnapshotScheduleNotFound: \(message ?? "")"
-        case .snapshotScheduleQuotaExceededFault(let message):
-            return "SnapshotScheduleQuotaExceeded: \(message ?? "")"
-        case .snapshotScheduleUpdateInProgressFault(let message):
-            return "SnapshotScheduleUpdateInProgress: \(message ?? "")"
-        case .sourceNotFoundFault(let message):
-            return "SourceNotFound: \(message ?? "")"
-        case .subnetAlreadyInUse(let message):
-            return "SubnetAlreadyInUse: \(message ?? "")"
-        case .subscriptionAlreadyExistFault(let message):
-            return "SubscriptionAlreadyExist: \(message ?? "")"
-        case .subscriptionCategoryNotFoundFault(let message):
-            return "SubscriptionCategoryNotFound: \(message ?? "")"
-        case .subscriptionEventIdNotFoundFault(let message):
-            return "SubscriptionEventIdNotFound: \(message ?? "")"
-        case .subscriptionNotFoundFault(let message):
-            return "SubscriptionNotFound: \(message ?? "")"
-        case .subscriptionSeverityNotFoundFault(let message):
-            return "SubscriptionSeverityNotFound: \(message ?? "")"
-        case .tableLimitExceededFault(let message):
-            return "TableLimitExceeded: \(message ?? "")"
-        case .tableRestoreNotFoundFault(let message):
-            return "TableRestoreNotFoundFault: \(message ?? "")"
-        case .tagLimitExceededFault(let message):
-            return "TagLimitExceededFault: \(message ?? "")"
-        case .unauthorizedOperation(let message):
-            return "UnauthorizedOperation: \(message ?? "")"
-        case .unknownSnapshotCopyRegionFault(let message):
-            return "UnknownSnapshotCopyRegionFault: \(message ?? "")"
-        case .unsupportedOperationFault(let message):
-            return "UnsupportedOperation: \(message ?? "")"
-        case .unsupportedOptionFault(let message):
-            return "UnsupportedOptionFault: \(message ?? "")"
-        case .usageLimitAlreadyExistsFault(let message):
-            return "UsageLimitAlreadyExists: \(message ?? "")"
-        case .usageLimitNotFoundFault(let message):
-            return "UsageLimitNotFound: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/RedshiftDataAPIService/RedshiftDataAPIService_Error.swift
+++ b/Sources/Soto/Services/RedshiftDataAPIService/RedshiftDataAPIService_Error.swift
@@ -17,45 +17,46 @@
 import SotoCore
 
 /// Error enum for RedshiftDataAPIService
-public enum RedshiftDataAPIServiceErrorType: AWSErrorType {
-    case executeStatementException(message: String?)
-    case internalServerException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case validationException(message: String?)
-}
+public struct RedshiftDataAPIServiceErrorType: AWSErrorType {
+    enum Code: String {
+        case executeStatementException = "ExecuteStatementException"
+        case internalServerException = "InternalServerException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case validationException = "ValidationException"
+    }
 
-extension RedshiftDataAPIServiceErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ExecuteStatementException":
-            self = .executeStatementException(message: message)
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var executeStatementException: Self { .init(.executeStatementException) }
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension RedshiftDataAPIServiceErrorType: Equatable {
+    public static func == (lhs: RedshiftDataAPIServiceErrorType, rhs: RedshiftDataAPIServiceErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension RedshiftDataAPIServiceErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .executeStatementException(let message):
-            return "ExecuteStatementException: \(message ?? "")"
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Rekognition/Rekognition_Error.swift
+++ b/Sources/Soto/Services/Rekognition/Rekognition_Error.swift
@@ -17,110 +17,72 @@
 import SotoCore
 
 /// Error enum for Rekognition
-public enum RekognitionErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case humanLoopQuotaExceededException(message: String?)
-    case idempotentParameterMismatchException(message: String?)
-    case imageTooLargeException(message: String?)
-    case internalServerError(message: String?)
-    case invalidImageFormatException(message: String?)
-    case invalidPaginationTokenException(message: String?)
-    case invalidParameterException(message: String?)
-    case invalidS3ObjectException(message: String?)
-    case limitExceededException(message: String?)
-    case provisionedThroughputExceededException(message: String?)
-    case resourceAlreadyExistsException(message: String?)
-    case resourceInUseException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case resourceNotReadyException(message: String?)
-    case throttlingException(message: String?)
-    case videoTooLargeException(message: String?)
-}
+public struct RekognitionErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case humanLoopQuotaExceededException = "HumanLoopQuotaExceededException"
+        case idempotentParameterMismatchException = "IdempotentParameterMismatchException"
+        case imageTooLargeException = "ImageTooLargeException"
+        case internalServerError = "InternalServerError"
+        case invalidImageFormatException = "InvalidImageFormatException"
+        case invalidPaginationTokenException = "InvalidPaginationTokenException"
+        case invalidParameterException = "InvalidParameterException"
+        case invalidS3ObjectException = "InvalidS3ObjectException"
+        case limitExceededException = "LimitExceededException"
+        case provisionedThroughputExceededException = "ProvisionedThroughputExceededException"
+        case resourceAlreadyExistsException = "ResourceAlreadyExistsException"
+        case resourceInUseException = "ResourceInUseException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case resourceNotReadyException = "ResourceNotReadyException"
+        case throttlingException = "ThrottlingException"
+        case videoTooLargeException = "VideoTooLargeException"
+    }
 
-extension RekognitionErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "HumanLoopQuotaExceededException":
-            self = .humanLoopQuotaExceededException(message: message)
-        case "IdempotentParameterMismatchException":
-            self = .idempotentParameterMismatchException(message: message)
-        case "ImageTooLargeException":
-            self = .imageTooLargeException(message: message)
-        case "InternalServerError":
-            self = .internalServerError(message: message)
-        case "InvalidImageFormatException":
-            self = .invalidImageFormatException(message: message)
-        case "InvalidPaginationTokenException":
-            self = .invalidPaginationTokenException(message: message)
-        case "InvalidParameterException":
-            self = .invalidParameterException(message: message)
-        case "InvalidS3ObjectException":
-            self = .invalidS3ObjectException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ProvisionedThroughputExceededException":
-            self = .provisionedThroughputExceededException(message: message)
-        case "ResourceAlreadyExistsException":
-            self = .resourceAlreadyExistsException(message: message)
-        case "ResourceInUseException":
-            self = .resourceInUseException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ResourceNotReadyException":
-            self = .resourceNotReadyException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        case "VideoTooLargeException":
-            self = .videoTooLargeException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var humanLoopQuotaExceededException: Self { .init(.humanLoopQuotaExceededException) }
+    public static var idempotentParameterMismatchException: Self { .init(.idempotentParameterMismatchException) }
+    public static var imageTooLargeException: Self { .init(.imageTooLargeException) }
+    public static var internalServerError: Self { .init(.internalServerError) }
+    public static var invalidImageFormatException: Self { .init(.invalidImageFormatException) }
+    public static var invalidPaginationTokenException: Self { .init(.invalidPaginationTokenException) }
+    public static var invalidParameterException: Self { .init(.invalidParameterException) }
+    public static var invalidS3ObjectException: Self { .init(.invalidS3ObjectException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var provisionedThroughputExceededException: Self { .init(.provisionedThroughputExceededException) }
+    public static var resourceAlreadyExistsException: Self { .init(.resourceAlreadyExistsException) }
+    public static var resourceInUseException: Self { .init(.resourceInUseException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var resourceNotReadyException: Self { .init(.resourceNotReadyException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+    public static var videoTooLargeException: Self { .init(.videoTooLargeException) }
+}
+
+extension RekognitionErrorType: Equatable {
+    public static func == (lhs: RekognitionErrorType, rhs: RekognitionErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension RekognitionErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .humanLoopQuotaExceededException(let message):
-            return "HumanLoopQuotaExceededException: \(message ?? "")"
-        case .idempotentParameterMismatchException(let message):
-            return "IdempotentParameterMismatchException: \(message ?? "")"
-        case .imageTooLargeException(let message):
-            return "ImageTooLargeException: \(message ?? "")"
-        case .internalServerError(let message):
-            return "InternalServerError: \(message ?? "")"
-        case .invalidImageFormatException(let message):
-            return "InvalidImageFormatException: \(message ?? "")"
-        case .invalidPaginationTokenException(let message):
-            return "InvalidPaginationTokenException: \(message ?? "")"
-        case .invalidParameterException(let message):
-            return "InvalidParameterException: \(message ?? "")"
-        case .invalidS3ObjectException(let message):
-            return "InvalidS3ObjectException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .provisionedThroughputExceededException(let message):
-            return "ProvisionedThroughputExceededException: \(message ?? "")"
-        case .resourceAlreadyExistsException(let message):
-            return "ResourceAlreadyExistsException: \(message ?? "")"
-        case .resourceInUseException(let message):
-            return "ResourceInUseException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .resourceNotReadyException(let message):
-            return "ResourceNotReadyException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        case .videoTooLargeException(let message):
-            return "VideoTooLargeException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/ResourceGroups/ResourceGroups_Error.swift
+++ b/Sources/Soto/Services/ResourceGroups/ResourceGroups_Error.swift
@@ -17,60 +17,52 @@
 import SotoCore
 
 /// Error enum for ResourceGroups
-public enum ResourceGroupsErrorType: AWSErrorType {
-    case badRequestException(message: String?)
-    case forbiddenException(message: String?)
-    case internalServerErrorException(message: String?)
-    case methodNotAllowedException(message: String?)
-    case notFoundException(message: String?)
-    case tooManyRequestsException(message: String?)
-    case unauthorizedException(message: String?)
-}
+public struct ResourceGroupsErrorType: AWSErrorType {
+    enum Code: String {
+        case badRequestException = "BadRequestException"
+        case forbiddenException = "ForbiddenException"
+        case internalServerErrorException = "InternalServerErrorException"
+        case methodNotAllowedException = "MethodNotAllowedException"
+        case notFoundException = "NotFoundException"
+        case tooManyRequestsException = "TooManyRequestsException"
+        case unauthorizedException = "UnauthorizedException"
+    }
 
-extension ResourceGroupsErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        case "ForbiddenException":
-            self = .forbiddenException(message: message)
-        case "InternalServerErrorException":
-            self = .internalServerErrorException(message: message)
-        case "MethodNotAllowedException":
-            self = .methodNotAllowedException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "TooManyRequestsException":
-            self = .tooManyRequestsException(message: message)
-        case "UnauthorizedException":
-            self = .unauthorizedException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var badRequestException: Self { .init(.badRequestException) }
+    public static var forbiddenException: Self { .init(.forbiddenException) }
+    public static var internalServerErrorException: Self { .init(.internalServerErrorException) }
+    public static var methodNotAllowedException: Self { .init(.methodNotAllowedException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var tooManyRequestsException: Self { .init(.tooManyRequestsException) }
+    public static var unauthorizedException: Self { .init(.unauthorizedException) }
+}
+
+extension ResourceGroupsErrorType: Equatable {
+    public static func == (lhs: ResourceGroupsErrorType, rhs: ResourceGroupsErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ResourceGroupsErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        case .forbiddenException(let message):
-            return "ForbiddenException: \(message ?? "")"
-        case .internalServerErrorException(let message):
-            return "InternalServerErrorException: \(message ?? "")"
-        case .methodNotAllowedException(let message):
-            return "MethodNotAllowedException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .tooManyRequestsException(let message):
-            return "TooManyRequestsException: \(message ?? "")"
-        case .unauthorizedException(let message):
-            return "UnauthorizedException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/ResourceGroupsTaggingAPI/ResourceGroupsTaggingAPI_Error.swift
+++ b/Sources/Soto/Services/ResourceGroupsTaggingAPI/ResourceGroupsTaggingAPI_Error.swift
@@ -17,55 +17,50 @@
 import SotoCore
 
 /// Error enum for ResourceGroupsTaggingAPI
-public enum ResourceGroupsTaggingAPIErrorType: AWSErrorType {
-    case concurrentModificationException(message: String?)
-    case constraintViolationException(message: String?)
-    case internalServiceException(message: String?)
-    case invalidParameterException(message: String?)
-    case paginationTokenExpiredException(message: String?)
-    case throttledException(message: String?)
-}
+public struct ResourceGroupsTaggingAPIErrorType: AWSErrorType {
+    enum Code: String {
+        case concurrentModificationException = "ConcurrentModificationException"
+        case constraintViolationException = "ConstraintViolationException"
+        case internalServiceException = "InternalServiceException"
+        case invalidParameterException = "InvalidParameterException"
+        case paginationTokenExpiredException = "PaginationTokenExpiredException"
+        case throttledException = "ThrottledException"
+    }
 
-extension ResourceGroupsTaggingAPIErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ConcurrentModificationException":
-            self = .concurrentModificationException(message: message)
-        case "ConstraintViolationException":
-            self = .constraintViolationException(message: message)
-        case "InternalServiceException":
-            self = .internalServiceException(message: message)
-        case "InvalidParameterException":
-            self = .invalidParameterException(message: message)
-        case "PaginationTokenExpiredException":
-            self = .paginationTokenExpiredException(message: message)
-        case "ThrottledException":
-            self = .throttledException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var concurrentModificationException: Self { .init(.concurrentModificationException) }
+    public static var constraintViolationException: Self { .init(.constraintViolationException) }
+    public static var internalServiceException: Self { .init(.internalServiceException) }
+    public static var invalidParameterException: Self { .init(.invalidParameterException) }
+    public static var paginationTokenExpiredException: Self { .init(.paginationTokenExpiredException) }
+    public static var throttledException: Self { .init(.throttledException) }
+}
+
+extension ResourceGroupsTaggingAPIErrorType: Equatable {
+    public static func == (lhs: ResourceGroupsTaggingAPIErrorType, rhs: ResourceGroupsTaggingAPIErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ResourceGroupsTaggingAPIErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .concurrentModificationException(let message):
-            return "ConcurrentModificationException: \(message ?? "")"
-        case .constraintViolationException(let message):
-            return "ConstraintViolationException: \(message ?? "")"
-        case .internalServiceException(let message):
-            return "InternalServiceException: \(message ?? "")"
-        case .invalidParameterException(let message):
-            return "InvalidParameterException: \(message ?? "")"
-        case .paginationTokenExpiredException(let message):
-            return "PaginationTokenExpiredException: \(message ?? "")"
-        case .throttledException(let message):
-            return "ThrottledException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/RoboMaker/RoboMaker_Error.swift
+++ b/Sources/Soto/Services/RoboMaker/RoboMaker_Error.swift
@@ -17,70 +17,56 @@
 import SotoCore
 
 /// Error enum for RoboMaker
-public enum RoboMakerErrorType: AWSErrorType {
-    case concurrentDeploymentException(message: String?)
-    case idempotentParameterMismatchException(message: String?)
-    case internalServerException(message: String?)
-    case invalidParameterException(message: String?)
-    case limitExceededException(message: String?)
-    case resourceAlreadyExistsException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceUnavailableException(message: String?)
-    case throttlingException(message: String?)
-}
+public struct RoboMakerErrorType: AWSErrorType {
+    enum Code: String {
+        case concurrentDeploymentException = "ConcurrentDeploymentException"
+        case idempotentParameterMismatchException = "IdempotentParameterMismatchException"
+        case internalServerException = "InternalServerException"
+        case invalidParameterException = "InvalidParameterException"
+        case limitExceededException = "LimitExceededException"
+        case resourceAlreadyExistsException = "ResourceAlreadyExistsException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+        case throttlingException = "ThrottlingException"
+    }
 
-extension RoboMakerErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ConcurrentDeploymentException":
-            self = .concurrentDeploymentException(message: message)
-        case "IdempotentParameterMismatchException":
-            self = .idempotentParameterMismatchException(message: message)
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "InvalidParameterException":
-            self = .invalidParameterException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ResourceAlreadyExistsException":
-            self = .resourceAlreadyExistsException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var concurrentDeploymentException: Self { .init(.concurrentDeploymentException) }
+    public static var idempotentParameterMismatchException: Self { .init(.idempotentParameterMismatchException) }
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var invalidParameterException: Self { .init(.invalidParameterException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var resourceAlreadyExistsException: Self { .init(.resourceAlreadyExistsException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+}
+
+extension RoboMakerErrorType: Equatable {
+    public static func == (lhs: RoboMakerErrorType, rhs: RoboMakerErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension RoboMakerErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .concurrentDeploymentException(let message):
-            return "ConcurrentDeploymentException: \(message ?? "")"
-        case .idempotentParameterMismatchException(let message):
-            return "IdempotentParameterMismatchException: \(message ?? "")"
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .invalidParameterException(let message):
-            return "InvalidParameterException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .resourceAlreadyExistsException(let message):
-            return "ResourceAlreadyExistsException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Route53/Route53_Error.swift
+++ b/Sources/Soto/Services/Route53/Route53_Error.swift
@@ -17,280 +17,140 @@
 import SotoCore
 
 /// Error enum for Route53
-public enum Route53ErrorType: AWSErrorType {
-    case concurrentModification(message: String?)
-    case conflictingDomainExists(message: String?)
-    case conflictingTypes(message: String?)
-    case delegationSetAlreadyCreated(message: String?)
-    case delegationSetAlreadyReusable(message: String?)
-    case delegationSetInUse(message: String?)
-    case delegationSetNotAvailable(message: String?)
-    case delegationSetNotReusable(message: String?)
-    case healthCheckAlreadyExists(message: String?)
-    case healthCheckInUse(message: String?)
-    case healthCheckVersionMismatch(message: String?)
-    case hostedZoneAlreadyExists(message: String?)
-    case hostedZoneNotEmpty(message: String?)
-    case hostedZoneNotFound(message: String?)
-    case hostedZoneNotPrivate(message: String?)
-    case incompatibleVersion(message: String?)
-    case insufficientCloudWatchLogsResourcePolicy(message: String?)
-    case invalidArgument(message: String?)
-    case invalidChangeBatch(message: String?)
-    case invalidDomainName(message: String?)
-    case invalidInput(message: String?)
-    case invalidPaginationToken(message: String?)
-    case invalidTrafficPolicyDocument(message: String?)
-    case invalidVPCId(message: String?)
-    case lastVPCAssociation(message: String?)
-    case limitsExceeded(message: String?)
-    case noSuchChange(message: String?)
-    case noSuchCloudWatchLogsLogGroup(message: String?)
-    case noSuchDelegationSet(message: String?)
-    case noSuchGeoLocation(message: String?)
-    case noSuchHealthCheck(message: String?)
-    case noSuchHostedZone(message: String?)
-    case noSuchQueryLoggingConfig(message: String?)
-    case noSuchTrafficPolicy(message: String?)
-    case noSuchTrafficPolicyInstance(message: String?)
-    case notAuthorizedException(message: String?)
-    case priorRequestNotComplete(message: String?)
-    case publicZoneVPCAssociation(message: String?)
-    case queryLoggingConfigAlreadyExists(message: String?)
-    case throttlingException(message: String?)
-    case tooManyHealthChecks(message: String?)
-    case tooManyHostedZones(message: String?)
-    case tooManyTrafficPolicies(message: String?)
-    case tooManyTrafficPolicyInstances(message: String?)
-    case tooManyTrafficPolicyVersionsForCurrentPolicy(message: String?)
-    case tooManyVPCAssociationAuthorizations(message: String?)
-    case trafficPolicyAlreadyExists(message: String?)
-    case trafficPolicyInUse(message: String?)
-    case trafficPolicyInstanceAlreadyExists(message: String?)
-    case vPCAssociationAuthorizationNotFound(message: String?)
-    case vPCAssociationNotFound(message: String?)
-}
+public struct Route53ErrorType: AWSErrorType {
+    enum Code: String {
+        case concurrentModification = "ConcurrentModification"
+        case conflictingDomainExists = "ConflictingDomainExists"
+        case conflictingTypes = "ConflictingTypes"
+        case delegationSetAlreadyCreated = "DelegationSetAlreadyCreated"
+        case delegationSetAlreadyReusable = "DelegationSetAlreadyReusable"
+        case delegationSetInUse = "DelegationSetInUse"
+        case delegationSetNotAvailable = "DelegationSetNotAvailable"
+        case delegationSetNotReusable = "DelegationSetNotReusable"
+        case healthCheckAlreadyExists = "HealthCheckAlreadyExists"
+        case healthCheckInUse = "HealthCheckInUse"
+        case healthCheckVersionMismatch = "HealthCheckVersionMismatch"
+        case hostedZoneAlreadyExists = "HostedZoneAlreadyExists"
+        case hostedZoneNotEmpty = "HostedZoneNotEmpty"
+        case hostedZoneNotFound = "HostedZoneNotFound"
+        case hostedZoneNotPrivate = "HostedZoneNotPrivate"
+        case incompatibleVersion = "IncompatibleVersion"
+        case insufficientCloudWatchLogsResourcePolicy = "InsufficientCloudWatchLogsResourcePolicy"
+        case invalidArgument = "InvalidArgument"
+        case invalidChangeBatch = "InvalidChangeBatch"
+        case invalidDomainName = "InvalidDomainName"
+        case invalidInput = "InvalidInput"
+        case invalidPaginationToken = "InvalidPaginationToken"
+        case invalidTrafficPolicyDocument = "InvalidTrafficPolicyDocument"
+        case invalidVPCId = "InvalidVPCId"
+        case lastVPCAssociation = "LastVPCAssociation"
+        case limitsExceeded = "LimitsExceeded"
+        case noSuchChange = "NoSuchChange"
+        case noSuchCloudWatchLogsLogGroup = "NoSuchCloudWatchLogsLogGroup"
+        case noSuchDelegationSet = "NoSuchDelegationSet"
+        case noSuchGeoLocation = "NoSuchGeoLocation"
+        case noSuchHealthCheck = "NoSuchHealthCheck"
+        case noSuchHostedZone = "NoSuchHostedZone"
+        case noSuchQueryLoggingConfig = "NoSuchQueryLoggingConfig"
+        case noSuchTrafficPolicy = "NoSuchTrafficPolicy"
+        case noSuchTrafficPolicyInstance = "NoSuchTrafficPolicyInstance"
+        case notAuthorizedException = "NotAuthorizedException"
+        case priorRequestNotComplete = "PriorRequestNotComplete"
+        case publicZoneVPCAssociation = "PublicZoneVPCAssociation"
+        case queryLoggingConfigAlreadyExists = "QueryLoggingConfigAlreadyExists"
+        case throttlingException = "ThrottlingException"
+        case tooManyHealthChecks = "TooManyHealthChecks"
+        case tooManyHostedZones = "TooManyHostedZones"
+        case tooManyTrafficPolicies = "TooManyTrafficPolicies"
+        case tooManyTrafficPolicyInstances = "TooManyTrafficPolicyInstances"
+        case tooManyTrafficPolicyVersionsForCurrentPolicy = "TooManyTrafficPolicyVersionsForCurrentPolicy"
+        case tooManyVPCAssociationAuthorizations = "TooManyVPCAssociationAuthorizations"
+        case trafficPolicyAlreadyExists = "TrafficPolicyAlreadyExists"
+        case trafficPolicyInUse = "TrafficPolicyInUse"
+        case trafficPolicyInstanceAlreadyExists = "TrafficPolicyInstanceAlreadyExists"
+        case vPCAssociationAuthorizationNotFound = "VPCAssociationAuthorizationNotFound"
+        case vPCAssociationNotFound = "VPCAssociationNotFound"
+    }
 
-extension Route53ErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ConcurrentModification":
-            self = .concurrentModification(message: message)
-        case "ConflictingDomainExists":
-            self = .conflictingDomainExists(message: message)
-        case "ConflictingTypes":
-            self = .conflictingTypes(message: message)
-        case "DelegationSetAlreadyCreated":
-            self = .delegationSetAlreadyCreated(message: message)
-        case "DelegationSetAlreadyReusable":
-            self = .delegationSetAlreadyReusable(message: message)
-        case "DelegationSetInUse":
-            self = .delegationSetInUse(message: message)
-        case "DelegationSetNotAvailable":
-            self = .delegationSetNotAvailable(message: message)
-        case "DelegationSetNotReusable":
-            self = .delegationSetNotReusable(message: message)
-        case "HealthCheckAlreadyExists":
-            self = .healthCheckAlreadyExists(message: message)
-        case "HealthCheckInUse":
-            self = .healthCheckInUse(message: message)
-        case "HealthCheckVersionMismatch":
-            self = .healthCheckVersionMismatch(message: message)
-        case "HostedZoneAlreadyExists":
-            self = .hostedZoneAlreadyExists(message: message)
-        case "HostedZoneNotEmpty":
-            self = .hostedZoneNotEmpty(message: message)
-        case "HostedZoneNotFound":
-            self = .hostedZoneNotFound(message: message)
-        case "HostedZoneNotPrivate":
-            self = .hostedZoneNotPrivate(message: message)
-        case "IncompatibleVersion":
-            self = .incompatibleVersion(message: message)
-        case "InsufficientCloudWatchLogsResourcePolicy":
-            self = .insufficientCloudWatchLogsResourcePolicy(message: message)
-        case "InvalidArgument":
-            self = .invalidArgument(message: message)
-        case "InvalidChangeBatch":
-            self = .invalidChangeBatch(message: message)
-        case "InvalidDomainName":
-            self = .invalidDomainName(message: message)
-        case "InvalidInput":
-            self = .invalidInput(message: message)
-        case "InvalidPaginationToken":
-            self = .invalidPaginationToken(message: message)
-        case "InvalidTrafficPolicyDocument":
-            self = .invalidTrafficPolicyDocument(message: message)
-        case "InvalidVPCId":
-            self = .invalidVPCId(message: message)
-        case "LastVPCAssociation":
-            self = .lastVPCAssociation(message: message)
-        case "LimitsExceeded":
-            self = .limitsExceeded(message: message)
-        case "NoSuchChange":
-            self = .noSuchChange(message: message)
-        case "NoSuchCloudWatchLogsLogGroup":
-            self = .noSuchCloudWatchLogsLogGroup(message: message)
-        case "NoSuchDelegationSet":
-            self = .noSuchDelegationSet(message: message)
-        case "NoSuchGeoLocation":
-            self = .noSuchGeoLocation(message: message)
-        case "NoSuchHealthCheck":
-            self = .noSuchHealthCheck(message: message)
-        case "NoSuchHostedZone":
-            self = .noSuchHostedZone(message: message)
-        case "NoSuchQueryLoggingConfig":
-            self = .noSuchQueryLoggingConfig(message: message)
-        case "NoSuchTrafficPolicy":
-            self = .noSuchTrafficPolicy(message: message)
-        case "NoSuchTrafficPolicyInstance":
-            self = .noSuchTrafficPolicyInstance(message: message)
-        case "NotAuthorizedException":
-            self = .notAuthorizedException(message: message)
-        case "PriorRequestNotComplete":
-            self = .priorRequestNotComplete(message: message)
-        case "PublicZoneVPCAssociation":
-            self = .publicZoneVPCAssociation(message: message)
-        case "QueryLoggingConfigAlreadyExists":
-            self = .queryLoggingConfigAlreadyExists(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        case "TooManyHealthChecks":
-            self = .tooManyHealthChecks(message: message)
-        case "TooManyHostedZones":
-            self = .tooManyHostedZones(message: message)
-        case "TooManyTrafficPolicies":
-            self = .tooManyTrafficPolicies(message: message)
-        case "TooManyTrafficPolicyInstances":
-            self = .tooManyTrafficPolicyInstances(message: message)
-        case "TooManyTrafficPolicyVersionsForCurrentPolicy":
-            self = .tooManyTrafficPolicyVersionsForCurrentPolicy(message: message)
-        case "TooManyVPCAssociationAuthorizations":
-            self = .tooManyVPCAssociationAuthorizations(message: message)
-        case "TrafficPolicyAlreadyExists":
-            self = .trafficPolicyAlreadyExists(message: message)
-        case "TrafficPolicyInUse":
-            self = .trafficPolicyInUse(message: message)
-        case "TrafficPolicyInstanceAlreadyExists":
-            self = .trafficPolicyInstanceAlreadyExists(message: message)
-        case "VPCAssociationAuthorizationNotFound":
-            self = .vPCAssociationAuthorizationNotFound(message: message)
-        case "VPCAssociationNotFound":
-            self = .vPCAssociationNotFound(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var concurrentModification: Self { .init(.concurrentModification) }
+    public static var conflictingDomainExists: Self { .init(.conflictingDomainExists) }
+    public static var conflictingTypes: Self { .init(.conflictingTypes) }
+    public static var delegationSetAlreadyCreated: Self { .init(.delegationSetAlreadyCreated) }
+    public static var delegationSetAlreadyReusable: Self { .init(.delegationSetAlreadyReusable) }
+    public static var delegationSetInUse: Self { .init(.delegationSetInUse) }
+    public static var delegationSetNotAvailable: Self { .init(.delegationSetNotAvailable) }
+    public static var delegationSetNotReusable: Self { .init(.delegationSetNotReusable) }
+    public static var healthCheckAlreadyExists: Self { .init(.healthCheckAlreadyExists) }
+    public static var healthCheckInUse: Self { .init(.healthCheckInUse) }
+    public static var healthCheckVersionMismatch: Self { .init(.healthCheckVersionMismatch) }
+    public static var hostedZoneAlreadyExists: Self { .init(.hostedZoneAlreadyExists) }
+    public static var hostedZoneNotEmpty: Self { .init(.hostedZoneNotEmpty) }
+    public static var hostedZoneNotFound: Self { .init(.hostedZoneNotFound) }
+    public static var hostedZoneNotPrivate: Self { .init(.hostedZoneNotPrivate) }
+    public static var incompatibleVersion: Self { .init(.incompatibleVersion) }
+    public static var insufficientCloudWatchLogsResourcePolicy: Self { .init(.insufficientCloudWatchLogsResourcePolicy) }
+    public static var invalidArgument: Self { .init(.invalidArgument) }
+    public static var invalidChangeBatch: Self { .init(.invalidChangeBatch) }
+    public static var invalidDomainName: Self { .init(.invalidDomainName) }
+    public static var invalidInput: Self { .init(.invalidInput) }
+    public static var invalidPaginationToken: Self { .init(.invalidPaginationToken) }
+    public static var invalidTrafficPolicyDocument: Self { .init(.invalidTrafficPolicyDocument) }
+    public static var invalidVPCId: Self { .init(.invalidVPCId) }
+    public static var lastVPCAssociation: Self { .init(.lastVPCAssociation) }
+    public static var limitsExceeded: Self { .init(.limitsExceeded) }
+    public static var noSuchChange: Self { .init(.noSuchChange) }
+    public static var noSuchCloudWatchLogsLogGroup: Self { .init(.noSuchCloudWatchLogsLogGroup) }
+    public static var noSuchDelegationSet: Self { .init(.noSuchDelegationSet) }
+    public static var noSuchGeoLocation: Self { .init(.noSuchGeoLocation) }
+    public static var noSuchHealthCheck: Self { .init(.noSuchHealthCheck) }
+    public static var noSuchHostedZone: Self { .init(.noSuchHostedZone) }
+    public static var noSuchQueryLoggingConfig: Self { .init(.noSuchQueryLoggingConfig) }
+    public static var noSuchTrafficPolicy: Self { .init(.noSuchTrafficPolicy) }
+    public static var noSuchTrafficPolicyInstance: Self { .init(.noSuchTrafficPolicyInstance) }
+    public static var notAuthorizedException: Self { .init(.notAuthorizedException) }
+    public static var priorRequestNotComplete: Self { .init(.priorRequestNotComplete) }
+    public static var publicZoneVPCAssociation: Self { .init(.publicZoneVPCAssociation) }
+    public static var queryLoggingConfigAlreadyExists: Self { .init(.queryLoggingConfigAlreadyExists) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+    public static var tooManyHealthChecks: Self { .init(.tooManyHealthChecks) }
+    public static var tooManyHostedZones: Self { .init(.tooManyHostedZones) }
+    public static var tooManyTrafficPolicies: Self { .init(.tooManyTrafficPolicies) }
+    public static var tooManyTrafficPolicyInstances: Self { .init(.tooManyTrafficPolicyInstances) }
+    public static var tooManyTrafficPolicyVersionsForCurrentPolicy: Self { .init(.tooManyTrafficPolicyVersionsForCurrentPolicy) }
+    public static var tooManyVPCAssociationAuthorizations: Self { .init(.tooManyVPCAssociationAuthorizations) }
+    public static var trafficPolicyAlreadyExists: Self { .init(.trafficPolicyAlreadyExists) }
+    public static var trafficPolicyInUse: Self { .init(.trafficPolicyInUse) }
+    public static var trafficPolicyInstanceAlreadyExists: Self { .init(.trafficPolicyInstanceAlreadyExists) }
+    public static var vPCAssociationAuthorizationNotFound: Self { .init(.vPCAssociationAuthorizationNotFound) }
+    public static var vPCAssociationNotFound: Self { .init(.vPCAssociationNotFound) }
+}
+
+extension Route53ErrorType: Equatable {
+    public static func == (lhs: Route53ErrorType, rhs: Route53ErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension Route53ErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .concurrentModification(let message):
-            return "ConcurrentModification: \(message ?? "")"
-        case .conflictingDomainExists(let message):
-            return "ConflictingDomainExists: \(message ?? "")"
-        case .conflictingTypes(let message):
-            return "ConflictingTypes: \(message ?? "")"
-        case .delegationSetAlreadyCreated(let message):
-            return "DelegationSetAlreadyCreated: \(message ?? "")"
-        case .delegationSetAlreadyReusable(let message):
-            return "DelegationSetAlreadyReusable: \(message ?? "")"
-        case .delegationSetInUse(let message):
-            return "DelegationSetInUse: \(message ?? "")"
-        case .delegationSetNotAvailable(let message):
-            return "DelegationSetNotAvailable: \(message ?? "")"
-        case .delegationSetNotReusable(let message):
-            return "DelegationSetNotReusable: \(message ?? "")"
-        case .healthCheckAlreadyExists(let message):
-            return "HealthCheckAlreadyExists: \(message ?? "")"
-        case .healthCheckInUse(let message):
-            return "HealthCheckInUse: \(message ?? "")"
-        case .healthCheckVersionMismatch(let message):
-            return "HealthCheckVersionMismatch: \(message ?? "")"
-        case .hostedZoneAlreadyExists(let message):
-            return "HostedZoneAlreadyExists: \(message ?? "")"
-        case .hostedZoneNotEmpty(let message):
-            return "HostedZoneNotEmpty: \(message ?? "")"
-        case .hostedZoneNotFound(let message):
-            return "HostedZoneNotFound: \(message ?? "")"
-        case .hostedZoneNotPrivate(let message):
-            return "HostedZoneNotPrivate: \(message ?? "")"
-        case .incompatibleVersion(let message):
-            return "IncompatibleVersion: \(message ?? "")"
-        case .insufficientCloudWatchLogsResourcePolicy(let message):
-            return "InsufficientCloudWatchLogsResourcePolicy: \(message ?? "")"
-        case .invalidArgument(let message):
-            return "InvalidArgument: \(message ?? "")"
-        case .invalidChangeBatch(let message):
-            return "InvalidChangeBatch: \(message ?? "")"
-        case .invalidDomainName(let message):
-            return "InvalidDomainName: \(message ?? "")"
-        case .invalidInput(let message):
-            return "InvalidInput: \(message ?? "")"
-        case .invalidPaginationToken(let message):
-            return "InvalidPaginationToken: \(message ?? "")"
-        case .invalidTrafficPolicyDocument(let message):
-            return "InvalidTrafficPolicyDocument: \(message ?? "")"
-        case .invalidVPCId(let message):
-            return "InvalidVPCId: \(message ?? "")"
-        case .lastVPCAssociation(let message):
-            return "LastVPCAssociation: \(message ?? "")"
-        case .limitsExceeded(let message):
-            return "LimitsExceeded: \(message ?? "")"
-        case .noSuchChange(let message):
-            return "NoSuchChange: \(message ?? "")"
-        case .noSuchCloudWatchLogsLogGroup(let message):
-            return "NoSuchCloudWatchLogsLogGroup: \(message ?? "")"
-        case .noSuchDelegationSet(let message):
-            return "NoSuchDelegationSet: \(message ?? "")"
-        case .noSuchGeoLocation(let message):
-            return "NoSuchGeoLocation: \(message ?? "")"
-        case .noSuchHealthCheck(let message):
-            return "NoSuchHealthCheck: \(message ?? "")"
-        case .noSuchHostedZone(let message):
-            return "NoSuchHostedZone: \(message ?? "")"
-        case .noSuchQueryLoggingConfig(let message):
-            return "NoSuchQueryLoggingConfig: \(message ?? "")"
-        case .noSuchTrafficPolicy(let message):
-            return "NoSuchTrafficPolicy: \(message ?? "")"
-        case .noSuchTrafficPolicyInstance(let message):
-            return "NoSuchTrafficPolicyInstance: \(message ?? "")"
-        case .notAuthorizedException(let message):
-            return "NotAuthorizedException: \(message ?? "")"
-        case .priorRequestNotComplete(let message):
-            return "PriorRequestNotComplete: \(message ?? "")"
-        case .publicZoneVPCAssociation(let message):
-            return "PublicZoneVPCAssociation: \(message ?? "")"
-        case .queryLoggingConfigAlreadyExists(let message):
-            return "QueryLoggingConfigAlreadyExists: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        case .tooManyHealthChecks(let message):
-            return "TooManyHealthChecks: \(message ?? "")"
-        case .tooManyHostedZones(let message):
-            return "TooManyHostedZones: \(message ?? "")"
-        case .tooManyTrafficPolicies(let message):
-            return "TooManyTrafficPolicies: \(message ?? "")"
-        case .tooManyTrafficPolicyInstances(let message):
-            return "TooManyTrafficPolicyInstances: \(message ?? "")"
-        case .tooManyTrafficPolicyVersionsForCurrentPolicy(let message):
-            return "TooManyTrafficPolicyVersionsForCurrentPolicy: \(message ?? "")"
-        case .tooManyVPCAssociationAuthorizations(let message):
-            return "TooManyVPCAssociationAuthorizations: \(message ?? "")"
-        case .trafficPolicyAlreadyExists(let message):
-            return "TrafficPolicyAlreadyExists: \(message ?? "")"
-        case .trafficPolicyInUse(let message):
-            return "TrafficPolicyInUse: \(message ?? "")"
-        case .trafficPolicyInstanceAlreadyExists(let message):
-            return "TrafficPolicyInstanceAlreadyExists: \(message ?? "")"
-        case .vPCAssociationAuthorizationNotFound(let message):
-            return "VPCAssociationAuthorizationNotFound: \(message ?? "")"
-        case .vPCAssociationNotFound(let message):
-            return "VPCAssociationNotFound: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Route53Domains/Route53Domains_Error.swift
+++ b/Sources/Soto/Services/Route53Domains/Route53Domains_Error.swift
@@ -17,55 +17,50 @@
 import SotoCore
 
 /// Error enum for Route53Domains
-public enum Route53DomainsErrorType: AWSErrorType {
-    case domainLimitExceeded(message: String?)
-    case duplicateRequest(message: String?)
-    case invalidInput(message: String?)
-    case operationLimitExceeded(message: String?)
-    case tLDRulesViolation(message: String?)
-    case unsupportedTLD(message: String?)
-}
+public struct Route53DomainsErrorType: AWSErrorType {
+    enum Code: String {
+        case domainLimitExceeded = "DomainLimitExceeded"
+        case duplicateRequest = "DuplicateRequest"
+        case invalidInput = "InvalidInput"
+        case operationLimitExceeded = "OperationLimitExceeded"
+        case tLDRulesViolation = "TLDRulesViolation"
+        case unsupportedTLD = "UnsupportedTLD"
+    }
 
-extension Route53DomainsErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "DomainLimitExceeded":
-            self = .domainLimitExceeded(message: message)
-        case "DuplicateRequest":
-            self = .duplicateRequest(message: message)
-        case "InvalidInput":
-            self = .invalidInput(message: message)
-        case "OperationLimitExceeded":
-            self = .operationLimitExceeded(message: message)
-        case "TLDRulesViolation":
-            self = .tLDRulesViolation(message: message)
-        case "UnsupportedTLD":
-            self = .unsupportedTLD(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var domainLimitExceeded: Self { .init(.domainLimitExceeded) }
+    public static var duplicateRequest: Self { .init(.duplicateRequest) }
+    public static var invalidInput: Self { .init(.invalidInput) }
+    public static var operationLimitExceeded: Self { .init(.operationLimitExceeded) }
+    public static var tLDRulesViolation: Self { .init(.tLDRulesViolation) }
+    public static var unsupportedTLD: Self { .init(.unsupportedTLD) }
+}
+
+extension Route53DomainsErrorType: Equatable {
+    public static func == (lhs: Route53DomainsErrorType, rhs: Route53DomainsErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension Route53DomainsErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .domainLimitExceeded(let message):
-            return "DomainLimitExceeded: \(message ?? "")"
-        case .duplicateRequest(let message):
-            return "DuplicateRequest: \(message ?? "")"
-        case .invalidInput(let message):
-            return "InvalidInput: \(message ?? "")"
-        case .operationLimitExceeded(let message):
-            return "OperationLimitExceeded: \(message ?? "")"
-        case .tLDRulesViolation(let message):
-            return "TLDRulesViolation: \(message ?? "")"
-        case .unsupportedTLD(let message):
-            return "UnsupportedTLD: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Route53Resolver/Route53Resolver_Error.swift
+++ b/Sources/Soto/Services/Route53Resolver/Route53Resolver_Error.swift
@@ -17,95 +17,66 @@
 import SotoCore
 
 /// Error enum for Route53Resolver
-public enum Route53ResolverErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case internalServiceErrorException(message: String?)
-    case invalidNextTokenException(message: String?)
-    case invalidParameterException(message: String?)
-    case invalidPolicyDocument(message: String?)
-    case invalidRequestException(message: String?)
-    case invalidTagException(message: String?)
-    case limitExceededException(message: String?)
-    case resourceExistsException(message: String?)
-    case resourceInUseException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case resourceUnavailableException(message: String?)
-    case throttlingException(message: String?)
-    case unknownResourceException(message: String?)
-}
+public struct Route53ResolverErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case internalServiceErrorException = "InternalServiceErrorException"
+        case invalidNextTokenException = "InvalidNextTokenException"
+        case invalidParameterException = "InvalidParameterException"
+        case invalidPolicyDocument = "InvalidPolicyDocument"
+        case invalidRequestException = "InvalidRequestException"
+        case invalidTagException = "InvalidTagException"
+        case limitExceededException = "LimitExceededException"
+        case resourceExistsException = "ResourceExistsException"
+        case resourceInUseException = "ResourceInUseException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case resourceUnavailableException = "ResourceUnavailableException"
+        case throttlingException = "ThrottlingException"
+        case unknownResourceException = "UnknownResourceException"
+    }
 
-extension Route53ResolverErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "InternalServiceErrorException":
-            self = .internalServiceErrorException(message: message)
-        case "InvalidNextTokenException":
-            self = .invalidNextTokenException(message: message)
-        case "InvalidParameterException":
-            self = .invalidParameterException(message: message)
-        case "InvalidPolicyDocument":
-            self = .invalidPolicyDocument(message: message)
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        case "InvalidTagException":
-            self = .invalidTagException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ResourceExistsException":
-            self = .resourceExistsException(message: message)
-        case "ResourceInUseException":
-            self = .resourceInUseException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ResourceUnavailableException":
-            self = .resourceUnavailableException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        case "UnknownResourceException":
-            self = .unknownResourceException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var internalServiceErrorException: Self { .init(.internalServiceErrorException) }
+    public static var invalidNextTokenException: Self { .init(.invalidNextTokenException) }
+    public static var invalidParameterException: Self { .init(.invalidParameterException) }
+    public static var invalidPolicyDocument: Self { .init(.invalidPolicyDocument) }
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+    public static var invalidTagException: Self { .init(.invalidTagException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var resourceExistsException: Self { .init(.resourceExistsException) }
+    public static var resourceInUseException: Self { .init(.resourceInUseException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var resourceUnavailableException: Self { .init(.resourceUnavailableException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+    public static var unknownResourceException: Self { .init(.unknownResourceException) }
+}
+
+extension Route53ResolverErrorType: Equatable {
+    public static func == (lhs: Route53ResolverErrorType, rhs: Route53ResolverErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension Route53ResolverErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .internalServiceErrorException(let message):
-            return "InternalServiceErrorException: \(message ?? "")"
-        case .invalidNextTokenException(let message):
-            return "InvalidNextTokenException: \(message ?? "")"
-        case .invalidParameterException(let message):
-            return "InvalidParameterException: \(message ?? "")"
-        case .invalidPolicyDocument(let message):
-            return "InvalidPolicyDocument: \(message ?? "")"
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        case .invalidTagException(let message):
-            return "InvalidTagException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .resourceExistsException(let message):
-            return "ResourceExistsException: \(message ?? "")"
-        case .resourceInUseException(let message):
-            return "ResourceInUseException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .resourceUnavailableException(let message):
-            return "ResourceUnavailableException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        case .unknownResourceException(let message):
-            return "UnknownResourceException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/S3/S3_Error.swift
+++ b/Sources/Soto/Services/S3/S3_Error.swift
@@ -17,60 +17,52 @@
 import SotoCore
 
 /// Error enum for S3
-public enum S3ErrorType: AWSErrorType {
-    case bucketAlreadyExists(message: String?)
-    case bucketAlreadyOwnedByYou(message: String?)
-    case noSuchBucket(message: String?)
-    case noSuchKey(message: String?)
-    case noSuchUpload(message: String?)
-    case objectAlreadyInActiveTierError(message: String?)
-    case objectNotInActiveTierError(message: String?)
-}
+public struct S3ErrorType: AWSErrorType {
+    enum Code: String {
+        case bucketAlreadyExists = "BucketAlreadyExists"
+        case bucketAlreadyOwnedByYou = "BucketAlreadyOwnedByYou"
+        case noSuchBucket = "NoSuchBucket"
+        case noSuchKey = "NoSuchKey"
+        case noSuchUpload = "NoSuchUpload"
+        case objectAlreadyInActiveTierError = "ObjectAlreadyInActiveTierError"
+        case objectNotInActiveTierError = "ObjectNotInActiveTierError"
+    }
 
-extension S3ErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "BucketAlreadyExists":
-            self = .bucketAlreadyExists(message: message)
-        case "BucketAlreadyOwnedByYou":
-            self = .bucketAlreadyOwnedByYou(message: message)
-        case "NoSuchBucket":
-            self = .noSuchBucket(message: message)
-        case "NoSuchKey":
-            self = .noSuchKey(message: message)
-        case "NoSuchUpload":
-            self = .noSuchUpload(message: message)
-        case "ObjectAlreadyInActiveTierError":
-            self = .objectAlreadyInActiveTierError(message: message)
-        case "ObjectNotInActiveTierError":
-            self = .objectNotInActiveTierError(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var bucketAlreadyExists: Self { .init(.bucketAlreadyExists) }
+    public static var bucketAlreadyOwnedByYou: Self { .init(.bucketAlreadyOwnedByYou) }
+    public static var noSuchBucket: Self { .init(.noSuchBucket) }
+    public static var noSuchKey: Self { .init(.noSuchKey) }
+    public static var noSuchUpload: Self { .init(.noSuchUpload) }
+    public static var objectAlreadyInActiveTierError: Self { .init(.objectAlreadyInActiveTierError) }
+    public static var objectNotInActiveTierError: Self { .init(.objectNotInActiveTierError) }
+}
+
+extension S3ErrorType: Equatable {
+    public static func == (lhs: S3ErrorType, rhs: S3ErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension S3ErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .bucketAlreadyExists(let message):
-            return "BucketAlreadyExists: \(message ?? "")"
-        case .bucketAlreadyOwnedByYou(let message):
-            return "BucketAlreadyOwnedByYou: \(message ?? "")"
-        case .noSuchBucket(let message):
-            return "NoSuchBucket: \(message ?? "")"
-        case .noSuchKey(let message):
-            return "NoSuchKey: \(message ?? "")"
-        case .noSuchUpload(let message):
-            return "NoSuchUpload: \(message ?? "")"
-        case .objectAlreadyInActiveTierError(let message):
-            return "ObjectAlreadyInActiveTierError: \(message ?? "")"
-        case .objectNotInActiveTierError(let message):
-            return "ObjectNotInActiveTierError: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/S3Control/S3Control_Error.swift
+++ b/Sources/Soto/Services/S3Control/S3Control_Error.swift
@@ -17,85 +17,62 @@
 import SotoCore
 
 /// Error enum for S3Control
-public enum S3ControlErrorType: AWSErrorType {
-    case badRequestException(message: String?)
-    case bucketAlreadyExists(message: String?)
-    case bucketAlreadyOwnedByYou(message: String?)
-    case idempotencyException(message: String?)
-    case internalServiceException(message: String?)
-    case invalidNextTokenException(message: String?)
-    case invalidRequestException(message: String?)
-    case jobStatusException(message: String?)
-    case noSuchPublicAccessBlockConfiguration(message: String?)
-    case notFoundException(message: String?)
-    case tooManyRequestsException(message: String?)
-    case tooManyTagsException(message: String?)
-}
+public struct S3ControlErrorType: AWSErrorType {
+    enum Code: String {
+        case badRequestException = "BadRequestException"
+        case bucketAlreadyExists = "BucketAlreadyExists"
+        case bucketAlreadyOwnedByYou = "BucketAlreadyOwnedByYou"
+        case idempotencyException = "IdempotencyException"
+        case internalServiceException = "InternalServiceException"
+        case invalidNextTokenException = "InvalidNextTokenException"
+        case invalidRequestException = "InvalidRequestException"
+        case jobStatusException = "JobStatusException"
+        case noSuchPublicAccessBlockConfiguration = "NoSuchPublicAccessBlockConfiguration"
+        case notFoundException = "NotFoundException"
+        case tooManyRequestsException = "TooManyRequestsException"
+        case tooManyTagsException = "TooManyTagsException"
+    }
 
-extension S3ControlErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        case "BucketAlreadyExists":
-            self = .bucketAlreadyExists(message: message)
-        case "BucketAlreadyOwnedByYou":
-            self = .bucketAlreadyOwnedByYou(message: message)
-        case "IdempotencyException":
-            self = .idempotencyException(message: message)
-        case "InternalServiceException":
-            self = .internalServiceException(message: message)
-        case "InvalidNextTokenException":
-            self = .invalidNextTokenException(message: message)
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        case "JobStatusException":
-            self = .jobStatusException(message: message)
-        case "NoSuchPublicAccessBlockConfiguration":
-            self = .noSuchPublicAccessBlockConfiguration(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "TooManyRequestsException":
-            self = .tooManyRequestsException(message: message)
-        case "TooManyTagsException":
-            self = .tooManyTagsException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var badRequestException: Self { .init(.badRequestException) }
+    public static var bucketAlreadyExists: Self { .init(.bucketAlreadyExists) }
+    public static var bucketAlreadyOwnedByYou: Self { .init(.bucketAlreadyOwnedByYou) }
+    public static var idempotencyException: Self { .init(.idempotencyException) }
+    public static var internalServiceException: Self { .init(.internalServiceException) }
+    public static var invalidNextTokenException: Self { .init(.invalidNextTokenException) }
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+    public static var jobStatusException: Self { .init(.jobStatusException) }
+    public static var noSuchPublicAccessBlockConfiguration: Self { .init(.noSuchPublicAccessBlockConfiguration) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var tooManyRequestsException: Self { .init(.tooManyRequestsException) }
+    public static var tooManyTagsException: Self { .init(.tooManyTagsException) }
+}
+
+extension S3ControlErrorType: Equatable {
+    public static func == (lhs: S3ControlErrorType, rhs: S3ControlErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension S3ControlErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        case .bucketAlreadyExists(let message):
-            return "BucketAlreadyExists: \(message ?? "")"
-        case .bucketAlreadyOwnedByYou(let message):
-            return "BucketAlreadyOwnedByYou: \(message ?? "")"
-        case .idempotencyException(let message):
-            return "IdempotencyException: \(message ?? "")"
-        case .internalServiceException(let message):
-            return "InternalServiceException: \(message ?? "")"
-        case .invalidNextTokenException(let message):
-            return "InvalidNextTokenException: \(message ?? "")"
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        case .jobStatusException(let message):
-            return "JobStatusException: \(message ?? "")"
-        case .noSuchPublicAccessBlockConfiguration(let message):
-            return "NoSuchPublicAccessBlockConfiguration: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .tooManyRequestsException(let message):
-            return "TooManyRequestsException: \(message ?? "")"
-        case .tooManyTagsException(let message):
-            return "TooManyTagsException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/S3Outposts/S3Outposts_Error.swift
+++ b/Sources/Soto/Services/S3Outposts/S3Outposts_Error.swift
@@ -17,50 +17,48 @@
 import SotoCore
 
 /// Error enum for S3Outposts
-public enum S3OutpostsErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case conflictException(message: String?)
-    case internalServerException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case validationException(message: String?)
-}
+public struct S3OutpostsErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case conflictException = "ConflictException"
+        case internalServerException = "InternalServerException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case validationException = "ValidationException"
+    }
 
-extension S3OutpostsErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension S3OutpostsErrorType: Equatable {
+    public static func == (lhs: S3OutpostsErrorType, rhs: S3OutpostsErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension S3OutpostsErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/SES/SES_Error.swift
+++ b/Sources/Soto/Services/SES/SES_Error.swift
@@ -17,195 +17,106 @@
 import SotoCore
 
 /// Error enum for SES
-public enum SESErrorType: AWSErrorType {
-    case accountSendingPausedException(message: String?)
-    case alreadyExistsException(message: String?)
-    case cannotDeleteException(message: String?)
-    case configurationSetAlreadyExistsException(message: String?)
-    case configurationSetDoesNotExistException(message: String?)
-    case configurationSetSendingPausedException(message: String?)
-    case customVerificationEmailInvalidContentException(message: String?)
-    case customVerificationEmailTemplateAlreadyExistsException(message: String?)
-    case customVerificationEmailTemplateDoesNotExistException(message: String?)
-    case eventDestinationAlreadyExistsException(message: String?)
-    case eventDestinationDoesNotExistException(message: String?)
-    case fromEmailAddressNotVerifiedException(message: String?)
-    case invalidCloudWatchDestinationException(message: String?)
-    case invalidConfigurationSetException(message: String?)
-    case invalidDeliveryOptionsException(message: String?)
-    case invalidFirehoseDestinationException(message: String?)
-    case invalidLambdaFunctionException(message: String?)
-    case invalidPolicyException(message: String?)
-    case invalidRenderingParameterException(message: String?)
-    case invalidS3ConfigurationException(message: String?)
-    case invalidSNSDestinationException(message: String?)
-    case invalidSnsTopicException(message: String?)
-    case invalidTemplateException(message: String?)
-    case invalidTrackingOptionsException(message: String?)
-    case limitExceededException(message: String?)
-    case mailFromDomainNotVerifiedException(message: String?)
-    case messageRejected(message: String?)
-    case missingRenderingAttributeException(message: String?)
-    case productionAccessNotGrantedException(message: String?)
-    case ruleDoesNotExistException(message: String?)
-    case ruleSetDoesNotExistException(message: String?)
-    case templateDoesNotExistException(message: String?)
-    case trackingOptionsAlreadyExistsException(message: String?)
-    case trackingOptionsDoesNotExistException(message: String?)
-}
+public struct SESErrorType: AWSErrorType {
+    enum Code: String {
+        case accountSendingPausedException = "AccountSendingPausedException"
+        case alreadyExistsException = "AlreadyExists"
+        case cannotDeleteException = "CannotDelete"
+        case configurationSetAlreadyExistsException = "ConfigurationSetAlreadyExists"
+        case configurationSetDoesNotExistException = "ConfigurationSetDoesNotExist"
+        case configurationSetSendingPausedException = "ConfigurationSetSendingPausedException"
+        case customVerificationEmailInvalidContentException = "CustomVerificationEmailInvalidContent"
+        case customVerificationEmailTemplateAlreadyExistsException = "CustomVerificationEmailTemplateAlreadyExists"
+        case customVerificationEmailTemplateDoesNotExistException = "CustomVerificationEmailTemplateDoesNotExist"
+        case eventDestinationAlreadyExistsException = "EventDestinationAlreadyExists"
+        case eventDestinationDoesNotExistException = "EventDestinationDoesNotExist"
+        case fromEmailAddressNotVerifiedException = "FromEmailAddressNotVerified"
+        case invalidCloudWatchDestinationException = "InvalidCloudWatchDestination"
+        case invalidConfigurationSetException = "InvalidConfigurationSet"
+        case invalidDeliveryOptionsException = "InvalidDeliveryOptions"
+        case invalidFirehoseDestinationException = "InvalidFirehoseDestination"
+        case invalidLambdaFunctionException = "InvalidLambdaFunction"
+        case invalidPolicyException = "InvalidPolicy"
+        case invalidRenderingParameterException = "InvalidRenderingParameter"
+        case invalidS3ConfigurationException = "InvalidS3Configuration"
+        case invalidSNSDestinationException = "InvalidSNSDestination"
+        case invalidSnsTopicException = "InvalidSnsTopic"
+        case invalidTemplateException = "InvalidTemplate"
+        case invalidTrackingOptionsException = "InvalidTrackingOptions"
+        case limitExceededException = "LimitExceeded"
+        case mailFromDomainNotVerifiedException = "MailFromDomainNotVerifiedException"
+        case messageRejected = "MessageRejected"
+        case missingRenderingAttributeException = "MissingRenderingAttribute"
+        case productionAccessNotGrantedException = "ProductionAccessNotGranted"
+        case ruleDoesNotExistException = "RuleDoesNotExist"
+        case ruleSetDoesNotExistException = "RuleSetDoesNotExist"
+        case templateDoesNotExistException = "TemplateDoesNotExist"
+        case trackingOptionsAlreadyExistsException = "TrackingOptionsAlreadyExistsException"
+        case trackingOptionsDoesNotExistException = "TrackingOptionsDoesNotExistException"
+    }
 
-extension SESErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccountSendingPausedException":
-            self = .accountSendingPausedException(message: message)
-        case "AlreadyExists":
-            self = .alreadyExistsException(message: message)
-        case "CannotDelete":
-            self = .cannotDeleteException(message: message)
-        case "ConfigurationSetAlreadyExists":
-            self = .configurationSetAlreadyExistsException(message: message)
-        case "ConfigurationSetDoesNotExist":
-            self = .configurationSetDoesNotExistException(message: message)
-        case "ConfigurationSetSendingPausedException":
-            self = .configurationSetSendingPausedException(message: message)
-        case "CustomVerificationEmailInvalidContent":
-            self = .customVerificationEmailInvalidContentException(message: message)
-        case "CustomVerificationEmailTemplateAlreadyExists":
-            self = .customVerificationEmailTemplateAlreadyExistsException(message: message)
-        case "CustomVerificationEmailTemplateDoesNotExist":
-            self = .customVerificationEmailTemplateDoesNotExistException(message: message)
-        case "EventDestinationAlreadyExists":
-            self = .eventDestinationAlreadyExistsException(message: message)
-        case "EventDestinationDoesNotExist":
-            self = .eventDestinationDoesNotExistException(message: message)
-        case "FromEmailAddressNotVerified":
-            self = .fromEmailAddressNotVerifiedException(message: message)
-        case "InvalidCloudWatchDestination":
-            self = .invalidCloudWatchDestinationException(message: message)
-        case "InvalidConfigurationSet":
-            self = .invalidConfigurationSetException(message: message)
-        case "InvalidDeliveryOptions":
-            self = .invalidDeliveryOptionsException(message: message)
-        case "InvalidFirehoseDestination":
-            self = .invalidFirehoseDestinationException(message: message)
-        case "InvalidLambdaFunction":
-            self = .invalidLambdaFunctionException(message: message)
-        case "InvalidPolicy":
-            self = .invalidPolicyException(message: message)
-        case "InvalidRenderingParameter":
-            self = .invalidRenderingParameterException(message: message)
-        case "InvalidS3Configuration":
-            self = .invalidS3ConfigurationException(message: message)
-        case "InvalidSNSDestination":
-            self = .invalidSNSDestinationException(message: message)
-        case "InvalidSnsTopic":
-            self = .invalidSnsTopicException(message: message)
-        case "InvalidTemplate":
-            self = .invalidTemplateException(message: message)
-        case "InvalidTrackingOptions":
-            self = .invalidTrackingOptionsException(message: message)
-        case "LimitExceeded":
-            self = .limitExceededException(message: message)
-        case "MailFromDomainNotVerifiedException":
-            self = .mailFromDomainNotVerifiedException(message: message)
-        case "MessageRejected":
-            self = .messageRejected(message: message)
-        case "MissingRenderingAttribute":
-            self = .missingRenderingAttributeException(message: message)
-        case "ProductionAccessNotGranted":
-            self = .productionAccessNotGrantedException(message: message)
-        case "RuleDoesNotExist":
-            self = .ruleDoesNotExistException(message: message)
-        case "RuleSetDoesNotExist":
-            self = .ruleSetDoesNotExistException(message: message)
-        case "TemplateDoesNotExist":
-            self = .templateDoesNotExistException(message: message)
-        case "TrackingOptionsAlreadyExistsException":
-            self = .trackingOptionsAlreadyExistsException(message: message)
-        case "TrackingOptionsDoesNotExistException":
-            self = .trackingOptionsDoesNotExistException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accountSendingPausedException: Self { .init(.accountSendingPausedException) }
+    public static var alreadyExistsException: Self { .init(.alreadyExistsException) }
+    public static var cannotDeleteException: Self { .init(.cannotDeleteException) }
+    public static var configurationSetAlreadyExistsException: Self { .init(.configurationSetAlreadyExistsException) }
+    public static var configurationSetDoesNotExistException: Self { .init(.configurationSetDoesNotExistException) }
+    public static var configurationSetSendingPausedException: Self { .init(.configurationSetSendingPausedException) }
+    public static var customVerificationEmailInvalidContentException: Self { .init(.customVerificationEmailInvalidContentException) }
+    public static var customVerificationEmailTemplateAlreadyExistsException: Self { .init(.customVerificationEmailTemplateAlreadyExistsException) }
+    public static var customVerificationEmailTemplateDoesNotExistException: Self { .init(.customVerificationEmailTemplateDoesNotExistException) }
+    public static var eventDestinationAlreadyExistsException: Self { .init(.eventDestinationAlreadyExistsException) }
+    public static var eventDestinationDoesNotExistException: Self { .init(.eventDestinationDoesNotExistException) }
+    public static var fromEmailAddressNotVerifiedException: Self { .init(.fromEmailAddressNotVerifiedException) }
+    public static var invalidCloudWatchDestinationException: Self { .init(.invalidCloudWatchDestinationException) }
+    public static var invalidConfigurationSetException: Self { .init(.invalidConfigurationSetException) }
+    public static var invalidDeliveryOptionsException: Self { .init(.invalidDeliveryOptionsException) }
+    public static var invalidFirehoseDestinationException: Self { .init(.invalidFirehoseDestinationException) }
+    public static var invalidLambdaFunctionException: Self { .init(.invalidLambdaFunctionException) }
+    public static var invalidPolicyException: Self { .init(.invalidPolicyException) }
+    public static var invalidRenderingParameterException: Self { .init(.invalidRenderingParameterException) }
+    public static var invalidS3ConfigurationException: Self { .init(.invalidS3ConfigurationException) }
+    public static var invalidSNSDestinationException: Self { .init(.invalidSNSDestinationException) }
+    public static var invalidSnsTopicException: Self { .init(.invalidSnsTopicException) }
+    public static var invalidTemplateException: Self { .init(.invalidTemplateException) }
+    public static var invalidTrackingOptionsException: Self { .init(.invalidTrackingOptionsException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var mailFromDomainNotVerifiedException: Self { .init(.mailFromDomainNotVerifiedException) }
+    public static var messageRejected: Self { .init(.messageRejected) }
+    public static var missingRenderingAttributeException: Self { .init(.missingRenderingAttributeException) }
+    public static var productionAccessNotGrantedException: Self { .init(.productionAccessNotGrantedException) }
+    public static var ruleDoesNotExistException: Self { .init(.ruleDoesNotExistException) }
+    public static var ruleSetDoesNotExistException: Self { .init(.ruleSetDoesNotExistException) }
+    public static var templateDoesNotExistException: Self { .init(.templateDoesNotExistException) }
+    public static var trackingOptionsAlreadyExistsException: Self { .init(.trackingOptionsAlreadyExistsException) }
+    public static var trackingOptionsDoesNotExistException: Self { .init(.trackingOptionsDoesNotExistException) }
+}
+
+extension SESErrorType: Equatable {
+    public static func == (lhs: SESErrorType, rhs: SESErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension SESErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accountSendingPausedException(let message):
-            return "AccountSendingPausedException: \(message ?? "")"
-        case .alreadyExistsException(let message):
-            return "AlreadyExists: \(message ?? "")"
-        case .cannotDeleteException(let message):
-            return "CannotDelete: \(message ?? "")"
-        case .configurationSetAlreadyExistsException(let message):
-            return "ConfigurationSetAlreadyExists: \(message ?? "")"
-        case .configurationSetDoesNotExistException(let message):
-            return "ConfigurationSetDoesNotExist: \(message ?? "")"
-        case .configurationSetSendingPausedException(let message):
-            return "ConfigurationSetSendingPausedException: \(message ?? "")"
-        case .customVerificationEmailInvalidContentException(let message):
-            return "CustomVerificationEmailInvalidContent: \(message ?? "")"
-        case .customVerificationEmailTemplateAlreadyExistsException(let message):
-            return "CustomVerificationEmailTemplateAlreadyExists: \(message ?? "")"
-        case .customVerificationEmailTemplateDoesNotExistException(let message):
-            return "CustomVerificationEmailTemplateDoesNotExist: \(message ?? "")"
-        case .eventDestinationAlreadyExistsException(let message):
-            return "EventDestinationAlreadyExists: \(message ?? "")"
-        case .eventDestinationDoesNotExistException(let message):
-            return "EventDestinationDoesNotExist: \(message ?? "")"
-        case .fromEmailAddressNotVerifiedException(let message):
-            return "FromEmailAddressNotVerified: \(message ?? "")"
-        case .invalidCloudWatchDestinationException(let message):
-            return "InvalidCloudWatchDestination: \(message ?? "")"
-        case .invalidConfigurationSetException(let message):
-            return "InvalidConfigurationSet: \(message ?? "")"
-        case .invalidDeliveryOptionsException(let message):
-            return "InvalidDeliveryOptions: \(message ?? "")"
-        case .invalidFirehoseDestinationException(let message):
-            return "InvalidFirehoseDestination: \(message ?? "")"
-        case .invalidLambdaFunctionException(let message):
-            return "InvalidLambdaFunction: \(message ?? "")"
-        case .invalidPolicyException(let message):
-            return "InvalidPolicy: \(message ?? "")"
-        case .invalidRenderingParameterException(let message):
-            return "InvalidRenderingParameter: \(message ?? "")"
-        case .invalidS3ConfigurationException(let message):
-            return "InvalidS3Configuration: \(message ?? "")"
-        case .invalidSNSDestinationException(let message):
-            return "InvalidSNSDestination: \(message ?? "")"
-        case .invalidSnsTopicException(let message):
-            return "InvalidSnsTopic: \(message ?? "")"
-        case .invalidTemplateException(let message):
-            return "InvalidTemplate: \(message ?? "")"
-        case .invalidTrackingOptionsException(let message):
-            return "InvalidTrackingOptions: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceeded: \(message ?? "")"
-        case .mailFromDomainNotVerifiedException(let message):
-            return "MailFromDomainNotVerifiedException: \(message ?? "")"
-        case .messageRejected(let message):
-            return "MessageRejected: \(message ?? "")"
-        case .missingRenderingAttributeException(let message):
-            return "MissingRenderingAttribute: \(message ?? "")"
-        case .productionAccessNotGrantedException(let message):
-            return "ProductionAccessNotGranted: \(message ?? "")"
-        case .ruleDoesNotExistException(let message):
-            return "RuleDoesNotExist: \(message ?? "")"
-        case .ruleSetDoesNotExistException(let message):
-            return "RuleSetDoesNotExist: \(message ?? "")"
-        case .templateDoesNotExistException(let message):
-            return "TemplateDoesNotExist: \(message ?? "")"
-        case .trackingOptionsAlreadyExistsException(let message):
-            return "TrackingOptionsAlreadyExistsException: \(message ?? "")"
-        case .trackingOptionsDoesNotExistException(let message):
-            return "TrackingOptionsDoesNotExistException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/SESV2/SESV2_Error.swift
+++ b/Sources/Soto/Services/SESV2/SESV2_Error.swift
@@ -17,85 +17,62 @@
 import SotoCore
 
 /// Error enum for SESV2
-public enum SESV2ErrorType: AWSErrorType {
-    case accountSuspendedException(message: String?)
-    case alreadyExistsException(message: String?)
-    case badRequestException(message: String?)
-    case concurrentModificationException(message: String?)
-    case conflictException(message: String?)
-    case invalidNextTokenException(message: String?)
-    case limitExceededException(message: String?)
-    case mailFromDomainNotVerifiedException(message: String?)
-    case messageRejected(message: String?)
-    case notFoundException(message: String?)
-    case sendingPausedException(message: String?)
-    case tooManyRequestsException(message: String?)
-}
+public struct SESV2ErrorType: AWSErrorType {
+    enum Code: String {
+        case accountSuspendedException = "AccountSuspendedException"
+        case alreadyExistsException = "AlreadyExistsException"
+        case badRequestException = "BadRequestException"
+        case concurrentModificationException = "ConcurrentModificationException"
+        case conflictException = "ConflictException"
+        case invalidNextTokenException = "InvalidNextTokenException"
+        case limitExceededException = "LimitExceededException"
+        case mailFromDomainNotVerifiedException = "MailFromDomainNotVerifiedException"
+        case messageRejected = "MessageRejected"
+        case notFoundException = "NotFoundException"
+        case sendingPausedException = "SendingPausedException"
+        case tooManyRequestsException = "TooManyRequestsException"
+    }
 
-extension SESV2ErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccountSuspendedException":
-            self = .accountSuspendedException(message: message)
-        case "AlreadyExistsException":
-            self = .alreadyExistsException(message: message)
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        case "ConcurrentModificationException":
-            self = .concurrentModificationException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "InvalidNextTokenException":
-            self = .invalidNextTokenException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "MailFromDomainNotVerifiedException":
-            self = .mailFromDomainNotVerifiedException(message: message)
-        case "MessageRejected":
-            self = .messageRejected(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "SendingPausedException":
-            self = .sendingPausedException(message: message)
-        case "TooManyRequestsException":
-            self = .tooManyRequestsException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accountSuspendedException: Self { .init(.accountSuspendedException) }
+    public static var alreadyExistsException: Self { .init(.alreadyExistsException) }
+    public static var badRequestException: Self { .init(.badRequestException) }
+    public static var concurrentModificationException: Self { .init(.concurrentModificationException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var invalidNextTokenException: Self { .init(.invalidNextTokenException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var mailFromDomainNotVerifiedException: Self { .init(.mailFromDomainNotVerifiedException) }
+    public static var messageRejected: Self { .init(.messageRejected) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var sendingPausedException: Self { .init(.sendingPausedException) }
+    public static var tooManyRequestsException: Self { .init(.tooManyRequestsException) }
+}
+
+extension SESV2ErrorType: Equatable {
+    public static func == (lhs: SESV2ErrorType, rhs: SESV2ErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension SESV2ErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accountSuspendedException(let message):
-            return "AccountSuspendedException: \(message ?? "")"
-        case .alreadyExistsException(let message):
-            return "AlreadyExistsException: \(message ?? "")"
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        case .concurrentModificationException(let message):
-            return "ConcurrentModificationException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .invalidNextTokenException(let message):
-            return "InvalidNextTokenException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .mailFromDomainNotVerifiedException(let message):
-            return "MailFromDomainNotVerifiedException: \(message ?? "")"
-        case .messageRejected(let message):
-            return "MessageRejected: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .sendingPausedException(let message):
-            return "SendingPausedException: \(message ?? "")"
-        case .tooManyRequestsException(let message):
-            return "TooManyRequestsException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/SFN/SFN_Error.swift
+++ b/Sources/Soto/Services/SFN/SFN_Error.swift
@@ -17,145 +17,86 @@
 import SotoCore
 
 /// Error enum for SFN
-public enum SFNErrorType: AWSErrorType {
-    case activityDoesNotExist(message: String?)
-    case activityLimitExceeded(message: String?)
-    case activityWorkerLimitExceeded(message: String?)
-    case executionAlreadyExists(message: String?)
-    case executionDoesNotExist(message: String?)
-    case executionLimitExceeded(message: String?)
-    case invalidArn(message: String?)
-    case invalidDefinition(message: String?)
-    case invalidExecutionInput(message: String?)
-    case invalidLoggingConfiguration(message: String?)
-    case invalidName(message: String?)
-    case invalidOutput(message: String?)
-    case invalidToken(message: String?)
-    case invalidTracingConfiguration(message: String?)
-    case missingRequiredParameter(message: String?)
-    case resourceNotFound(message: String?)
-    case stateMachineAlreadyExists(message: String?)
-    case stateMachineDeleting(message: String?)
-    case stateMachineDoesNotExist(message: String?)
-    case stateMachineLimitExceeded(message: String?)
-    case stateMachineTypeNotSupported(message: String?)
-    case taskDoesNotExist(message: String?)
-    case taskTimedOut(message: String?)
-    case tooManyTags(message: String?)
-}
+public struct SFNErrorType: AWSErrorType {
+    enum Code: String {
+        case activityDoesNotExist = "ActivityDoesNotExist"
+        case activityLimitExceeded = "ActivityLimitExceeded"
+        case activityWorkerLimitExceeded = "ActivityWorkerLimitExceeded"
+        case executionAlreadyExists = "ExecutionAlreadyExists"
+        case executionDoesNotExist = "ExecutionDoesNotExist"
+        case executionLimitExceeded = "ExecutionLimitExceeded"
+        case invalidArn = "InvalidArn"
+        case invalidDefinition = "InvalidDefinition"
+        case invalidExecutionInput = "InvalidExecutionInput"
+        case invalidLoggingConfiguration = "InvalidLoggingConfiguration"
+        case invalidName = "InvalidName"
+        case invalidOutput = "InvalidOutput"
+        case invalidToken = "InvalidToken"
+        case invalidTracingConfiguration = "InvalidTracingConfiguration"
+        case missingRequiredParameter = "MissingRequiredParameter"
+        case resourceNotFound = "ResourceNotFound"
+        case stateMachineAlreadyExists = "StateMachineAlreadyExists"
+        case stateMachineDeleting = "StateMachineDeleting"
+        case stateMachineDoesNotExist = "StateMachineDoesNotExist"
+        case stateMachineLimitExceeded = "StateMachineLimitExceeded"
+        case stateMachineTypeNotSupported = "StateMachineTypeNotSupported"
+        case taskDoesNotExist = "TaskDoesNotExist"
+        case taskTimedOut = "TaskTimedOut"
+        case tooManyTags = "TooManyTags"
+    }
 
-extension SFNErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ActivityDoesNotExist":
-            self = .activityDoesNotExist(message: message)
-        case "ActivityLimitExceeded":
-            self = .activityLimitExceeded(message: message)
-        case "ActivityWorkerLimitExceeded":
-            self = .activityWorkerLimitExceeded(message: message)
-        case "ExecutionAlreadyExists":
-            self = .executionAlreadyExists(message: message)
-        case "ExecutionDoesNotExist":
-            self = .executionDoesNotExist(message: message)
-        case "ExecutionLimitExceeded":
-            self = .executionLimitExceeded(message: message)
-        case "InvalidArn":
-            self = .invalidArn(message: message)
-        case "InvalidDefinition":
-            self = .invalidDefinition(message: message)
-        case "InvalidExecutionInput":
-            self = .invalidExecutionInput(message: message)
-        case "InvalidLoggingConfiguration":
-            self = .invalidLoggingConfiguration(message: message)
-        case "InvalidName":
-            self = .invalidName(message: message)
-        case "InvalidOutput":
-            self = .invalidOutput(message: message)
-        case "InvalidToken":
-            self = .invalidToken(message: message)
-        case "InvalidTracingConfiguration":
-            self = .invalidTracingConfiguration(message: message)
-        case "MissingRequiredParameter":
-            self = .missingRequiredParameter(message: message)
-        case "ResourceNotFound":
-            self = .resourceNotFound(message: message)
-        case "StateMachineAlreadyExists":
-            self = .stateMachineAlreadyExists(message: message)
-        case "StateMachineDeleting":
-            self = .stateMachineDeleting(message: message)
-        case "StateMachineDoesNotExist":
-            self = .stateMachineDoesNotExist(message: message)
-        case "StateMachineLimitExceeded":
-            self = .stateMachineLimitExceeded(message: message)
-        case "StateMachineTypeNotSupported":
-            self = .stateMachineTypeNotSupported(message: message)
-        case "TaskDoesNotExist":
-            self = .taskDoesNotExist(message: message)
-        case "TaskTimedOut":
-            self = .taskTimedOut(message: message)
-        case "TooManyTags":
-            self = .tooManyTags(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var activityDoesNotExist: Self { .init(.activityDoesNotExist) }
+    public static var activityLimitExceeded: Self { .init(.activityLimitExceeded) }
+    public static var activityWorkerLimitExceeded: Self { .init(.activityWorkerLimitExceeded) }
+    public static var executionAlreadyExists: Self { .init(.executionAlreadyExists) }
+    public static var executionDoesNotExist: Self { .init(.executionDoesNotExist) }
+    public static var executionLimitExceeded: Self { .init(.executionLimitExceeded) }
+    public static var invalidArn: Self { .init(.invalidArn) }
+    public static var invalidDefinition: Self { .init(.invalidDefinition) }
+    public static var invalidExecutionInput: Self { .init(.invalidExecutionInput) }
+    public static var invalidLoggingConfiguration: Self { .init(.invalidLoggingConfiguration) }
+    public static var invalidName: Self { .init(.invalidName) }
+    public static var invalidOutput: Self { .init(.invalidOutput) }
+    public static var invalidToken: Self { .init(.invalidToken) }
+    public static var invalidTracingConfiguration: Self { .init(.invalidTracingConfiguration) }
+    public static var missingRequiredParameter: Self { .init(.missingRequiredParameter) }
+    public static var resourceNotFound: Self { .init(.resourceNotFound) }
+    public static var stateMachineAlreadyExists: Self { .init(.stateMachineAlreadyExists) }
+    public static var stateMachineDeleting: Self { .init(.stateMachineDeleting) }
+    public static var stateMachineDoesNotExist: Self { .init(.stateMachineDoesNotExist) }
+    public static var stateMachineLimitExceeded: Self { .init(.stateMachineLimitExceeded) }
+    public static var stateMachineTypeNotSupported: Self { .init(.stateMachineTypeNotSupported) }
+    public static var taskDoesNotExist: Self { .init(.taskDoesNotExist) }
+    public static var taskTimedOut: Self { .init(.taskTimedOut) }
+    public static var tooManyTags: Self { .init(.tooManyTags) }
+}
+
+extension SFNErrorType: Equatable {
+    public static func == (lhs: SFNErrorType, rhs: SFNErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension SFNErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .activityDoesNotExist(let message):
-            return "ActivityDoesNotExist: \(message ?? "")"
-        case .activityLimitExceeded(let message):
-            return "ActivityLimitExceeded: \(message ?? "")"
-        case .activityWorkerLimitExceeded(let message):
-            return "ActivityWorkerLimitExceeded: \(message ?? "")"
-        case .executionAlreadyExists(let message):
-            return "ExecutionAlreadyExists: \(message ?? "")"
-        case .executionDoesNotExist(let message):
-            return "ExecutionDoesNotExist: \(message ?? "")"
-        case .executionLimitExceeded(let message):
-            return "ExecutionLimitExceeded: \(message ?? "")"
-        case .invalidArn(let message):
-            return "InvalidArn: \(message ?? "")"
-        case .invalidDefinition(let message):
-            return "InvalidDefinition: \(message ?? "")"
-        case .invalidExecutionInput(let message):
-            return "InvalidExecutionInput: \(message ?? "")"
-        case .invalidLoggingConfiguration(let message):
-            return "InvalidLoggingConfiguration: \(message ?? "")"
-        case .invalidName(let message):
-            return "InvalidName: \(message ?? "")"
-        case .invalidOutput(let message):
-            return "InvalidOutput: \(message ?? "")"
-        case .invalidToken(let message):
-            return "InvalidToken: \(message ?? "")"
-        case .invalidTracingConfiguration(let message):
-            return "InvalidTracingConfiguration: \(message ?? "")"
-        case .missingRequiredParameter(let message):
-            return "MissingRequiredParameter: \(message ?? "")"
-        case .resourceNotFound(let message):
-            return "ResourceNotFound: \(message ?? "")"
-        case .stateMachineAlreadyExists(let message):
-            return "StateMachineAlreadyExists: \(message ?? "")"
-        case .stateMachineDeleting(let message):
-            return "StateMachineDeleting: \(message ?? "")"
-        case .stateMachineDoesNotExist(let message):
-            return "StateMachineDoesNotExist: \(message ?? "")"
-        case .stateMachineLimitExceeded(let message):
-            return "StateMachineLimitExceeded: \(message ?? "")"
-        case .stateMachineTypeNotSupported(let message):
-            return "StateMachineTypeNotSupported: \(message ?? "")"
-        case .taskDoesNotExist(let message):
-            return "TaskDoesNotExist: \(message ?? "")"
-        case .taskTimedOut(let message):
-            return "TaskTimedOut: \(message ?? "")"
-        case .tooManyTags(let message):
-            return "TooManyTags: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/SMS/SMS_Error.swift
+++ b/Sources/Soto/Services/SMS/SMS_Error.swift
@@ -17,85 +17,62 @@
 import SotoCore
 
 /// Error enum for SMS
-public enum SMSErrorType: AWSErrorType {
-    case dryRunOperationException(message: String?)
-    case internalError(message: String?)
-    case invalidParameterException(message: String?)
-    case missingRequiredParameterException(message: String?)
-    case noConnectorsAvailableException(message: String?)
-    case operationNotPermittedException(message: String?)
-    case replicationJobAlreadyExistsException(message: String?)
-    case replicationJobNotFoundException(message: String?)
-    case replicationRunLimitExceededException(message: String?)
-    case serverCannotBeReplicatedException(message: String?)
-    case temporarilyUnavailableException(message: String?)
-    case unauthorizedOperationException(message: String?)
-}
+public struct SMSErrorType: AWSErrorType {
+    enum Code: String {
+        case dryRunOperationException = "DryRunOperationException"
+        case internalError = "InternalError"
+        case invalidParameterException = "InvalidParameterException"
+        case missingRequiredParameterException = "MissingRequiredParameterException"
+        case noConnectorsAvailableException = "NoConnectorsAvailableException"
+        case operationNotPermittedException = "OperationNotPermittedException"
+        case replicationJobAlreadyExistsException = "ReplicationJobAlreadyExistsException"
+        case replicationJobNotFoundException = "ReplicationJobNotFoundException"
+        case replicationRunLimitExceededException = "ReplicationRunLimitExceededException"
+        case serverCannotBeReplicatedException = "ServerCannotBeReplicatedException"
+        case temporarilyUnavailableException = "TemporarilyUnavailableException"
+        case unauthorizedOperationException = "UnauthorizedOperationException"
+    }
 
-extension SMSErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "DryRunOperationException":
-            self = .dryRunOperationException(message: message)
-        case "InternalError":
-            self = .internalError(message: message)
-        case "InvalidParameterException":
-            self = .invalidParameterException(message: message)
-        case "MissingRequiredParameterException":
-            self = .missingRequiredParameterException(message: message)
-        case "NoConnectorsAvailableException":
-            self = .noConnectorsAvailableException(message: message)
-        case "OperationNotPermittedException":
-            self = .operationNotPermittedException(message: message)
-        case "ReplicationJobAlreadyExistsException":
-            self = .replicationJobAlreadyExistsException(message: message)
-        case "ReplicationJobNotFoundException":
-            self = .replicationJobNotFoundException(message: message)
-        case "ReplicationRunLimitExceededException":
-            self = .replicationRunLimitExceededException(message: message)
-        case "ServerCannotBeReplicatedException":
-            self = .serverCannotBeReplicatedException(message: message)
-        case "TemporarilyUnavailableException":
-            self = .temporarilyUnavailableException(message: message)
-        case "UnauthorizedOperationException":
-            self = .unauthorizedOperationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var dryRunOperationException: Self { .init(.dryRunOperationException) }
+    public static var internalError: Self { .init(.internalError) }
+    public static var invalidParameterException: Self { .init(.invalidParameterException) }
+    public static var missingRequiredParameterException: Self { .init(.missingRequiredParameterException) }
+    public static var noConnectorsAvailableException: Self { .init(.noConnectorsAvailableException) }
+    public static var operationNotPermittedException: Self { .init(.operationNotPermittedException) }
+    public static var replicationJobAlreadyExistsException: Self { .init(.replicationJobAlreadyExistsException) }
+    public static var replicationJobNotFoundException: Self { .init(.replicationJobNotFoundException) }
+    public static var replicationRunLimitExceededException: Self { .init(.replicationRunLimitExceededException) }
+    public static var serverCannotBeReplicatedException: Self { .init(.serverCannotBeReplicatedException) }
+    public static var temporarilyUnavailableException: Self { .init(.temporarilyUnavailableException) }
+    public static var unauthorizedOperationException: Self { .init(.unauthorizedOperationException) }
+}
+
+extension SMSErrorType: Equatable {
+    public static func == (lhs: SMSErrorType, rhs: SMSErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension SMSErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .dryRunOperationException(let message):
-            return "DryRunOperationException: \(message ?? "")"
-        case .internalError(let message):
-            return "InternalError: \(message ?? "")"
-        case .invalidParameterException(let message):
-            return "InvalidParameterException: \(message ?? "")"
-        case .missingRequiredParameterException(let message):
-            return "MissingRequiredParameterException: \(message ?? "")"
-        case .noConnectorsAvailableException(let message):
-            return "NoConnectorsAvailableException: \(message ?? "")"
-        case .operationNotPermittedException(let message):
-            return "OperationNotPermittedException: \(message ?? "")"
-        case .replicationJobAlreadyExistsException(let message):
-            return "ReplicationJobAlreadyExistsException: \(message ?? "")"
-        case .replicationJobNotFoundException(let message):
-            return "ReplicationJobNotFoundException: \(message ?? "")"
-        case .replicationRunLimitExceededException(let message):
-            return "ReplicationRunLimitExceededException: \(message ?? "")"
-        case .serverCannotBeReplicatedException(let message):
-            return "ServerCannotBeReplicatedException: \(message ?? "")"
-        case .temporarilyUnavailableException(let message):
-            return "TemporarilyUnavailableException: \(message ?? "")"
-        case .unauthorizedOperationException(let message):
-            return "UnauthorizedOperationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/SNS/SNS_Error.swift
+++ b/Sources/Soto/Services/SNS/SNS_Error.swift
@@ -17,140 +17,84 @@
 import SotoCore
 
 /// Error enum for SNS
-public enum SNSErrorType: AWSErrorType {
-    case authorizationErrorException(message: String?)
-    case concurrentAccessException(message: String?)
-    case endpointDisabledException(message: String?)
-    case filterPolicyLimitExceededException(message: String?)
-    case internalErrorException(message: String?)
-    case invalidParameterException(message: String?)
-    case invalidParameterValueException(message: String?)
-    case invalidSecurityException(message: String?)
-    case kMSAccessDeniedException(message: String?)
-    case kMSDisabledException(message: String?)
-    case kMSInvalidStateException(message: String?)
-    case kMSNotFoundException(message: String?)
-    case kMSOptInRequired(message: String?)
-    case kMSThrottlingException(message: String?)
-    case notFoundException(message: String?)
-    case platformApplicationDisabledException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case staleTagException(message: String?)
-    case subscriptionLimitExceededException(message: String?)
-    case tagLimitExceededException(message: String?)
-    case tagPolicyException(message: String?)
-    case throttledException(message: String?)
-    case topicLimitExceededException(message: String?)
-}
+public struct SNSErrorType: AWSErrorType {
+    enum Code: String {
+        case authorizationErrorException = "AuthorizationError"
+        case concurrentAccessException = "ConcurrentAccess"
+        case endpointDisabledException = "EndpointDisabled"
+        case filterPolicyLimitExceededException = "FilterPolicyLimitExceeded"
+        case internalErrorException = "InternalError"
+        case invalidParameterException = "InvalidParameter"
+        case invalidParameterValueException = "ParameterValueInvalid"
+        case invalidSecurityException = "InvalidSecurity"
+        case kMSAccessDeniedException = "KMSAccessDenied"
+        case kMSDisabledException = "KMSDisabled"
+        case kMSInvalidStateException = "KMSInvalidState"
+        case kMSNotFoundException = "KMSNotFound"
+        case kMSOptInRequired = "KMSOptInRequired"
+        case kMSThrottlingException = "KMSThrottling"
+        case notFoundException = "NotFound"
+        case platformApplicationDisabledException = "PlatformApplicationDisabled"
+        case resourceNotFoundException = "ResourceNotFound"
+        case staleTagException = "StaleTag"
+        case subscriptionLimitExceededException = "SubscriptionLimitExceeded"
+        case tagLimitExceededException = "TagLimitExceeded"
+        case tagPolicyException = "TagPolicy"
+        case throttledException = "Throttled"
+        case topicLimitExceededException = "TopicLimitExceeded"
+    }
 
-extension SNSErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AuthorizationError":
-            self = .authorizationErrorException(message: message)
-        case "ConcurrentAccess":
-            self = .concurrentAccessException(message: message)
-        case "EndpointDisabled":
-            self = .endpointDisabledException(message: message)
-        case "FilterPolicyLimitExceeded":
-            self = .filterPolicyLimitExceededException(message: message)
-        case "InternalError":
-            self = .internalErrorException(message: message)
-        case "InvalidParameter":
-            self = .invalidParameterException(message: message)
-        case "ParameterValueInvalid":
-            self = .invalidParameterValueException(message: message)
-        case "InvalidSecurity":
-            self = .invalidSecurityException(message: message)
-        case "KMSAccessDenied":
-            self = .kMSAccessDeniedException(message: message)
-        case "KMSDisabled":
-            self = .kMSDisabledException(message: message)
-        case "KMSInvalidState":
-            self = .kMSInvalidStateException(message: message)
-        case "KMSNotFound":
-            self = .kMSNotFoundException(message: message)
-        case "KMSOptInRequired":
-            self = .kMSOptInRequired(message: message)
-        case "KMSThrottling":
-            self = .kMSThrottlingException(message: message)
-        case "NotFound":
-            self = .notFoundException(message: message)
-        case "PlatformApplicationDisabled":
-            self = .platformApplicationDisabledException(message: message)
-        case "ResourceNotFound":
-            self = .resourceNotFoundException(message: message)
-        case "StaleTag":
-            self = .staleTagException(message: message)
-        case "SubscriptionLimitExceeded":
-            self = .subscriptionLimitExceededException(message: message)
-        case "TagLimitExceeded":
-            self = .tagLimitExceededException(message: message)
-        case "TagPolicy":
-            self = .tagPolicyException(message: message)
-        case "Throttled":
-            self = .throttledException(message: message)
-        case "TopicLimitExceeded":
-            self = .topicLimitExceededException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var authorizationErrorException: Self { .init(.authorizationErrorException) }
+    public static var concurrentAccessException: Self { .init(.concurrentAccessException) }
+    public static var endpointDisabledException: Self { .init(.endpointDisabledException) }
+    public static var filterPolicyLimitExceededException: Self { .init(.filterPolicyLimitExceededException) }
+    public static var internalErrorException: Self { .init(.internalErrorException) }
+    public static var invalidParameterException: Self { .init(.invalidParameterException) }
+    public static var invalidParameterValueException: Self { .init(.invalidParameterValueException) }
+    public static var invalidSecurityException: Self { .init(.invalidSecurityException) }
+    public static var kMSAccessDeniedException: Self { .init(.kMSAccessDeniedException) }
+    public static var kMSDisabledException: Self { .init(.kMSDisabledException) }
+    public static var kMSInvalidStateException: Self { .init(.kMSInvalidStateException) }
+    public static var kMSNotFoundException: Self { .init(.kMSNotFoundException) }
+    public static var kMSOptInRequired: Self { .init(.kMSOptInRequired) }
+    public static var kMSThrottlingException: Self { .init(.kMSThrottlingException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var platformApplicationDisabledException: Self { .init(.platformApplicationDisabledException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var staleTagException: Self { .init(.staleTagException) }
+    public static var subscriptionLimitExceededException: Self { .init(.subscriptionLimitExceededException) }
+    public static var tagLimitExceededException: Self { .init(.tagLimitExceededException) }
+    public static var tagPolicyException: Self { .init(.tagPolicyException) }
+    public static var throttledException: Self { .init(.throttledException) }
+    public static var topicLimitExceededException: Self { .init(.topicLimitExceededException) }
+}
+
+extension SNSErrorType: Equatable {
+    public static func == (lhs: SNSErrorType, rhs: SNSErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension SNSErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .authorizationErrorException(let message):
-            return "AuthorizationError: \(message ?? "")"
-        case .concurrentAccessException(let message):
-            return "ConcurrentAccess: \(message ?? "")"
-        case .endpointDisabledException(let message):
-            return "EndpointDisabled: \(message ?? "")"
-        case .filterPolicyLimitExceededException(let message):
-            return "FilterPolicyLimitExceeded: \(message ?? "")"
-        case .internalErrorException(let message):
-            return "InternalError: \(message ?? "")"
-        case .invalidParameterException(let message):
-            return "InvalidParameter: \(message ?? "")"
-        case .invalidParameterValueException(let message):
-            return "ParameterValueInvalid: \(message ?? "")"
-        case .invalidSecurityException(let message):
-            return "InvalidSecurity: \(message ?? "")"
-        case .kMSAccessDeniedException(let message):
-            return "KMSAccessDenied: \(message ?? "")"
-        case .kMSDisabledException(let message):
-            return "KMSDisabled: \(message ?? "")"
-        case .kMSInvalidStateException(let message):
-            return "KMSInvalidState: \(message ?? "")"
-        case .kMSNotFoundException(let message):
-            return "KMSNotFound: \(message ?? "")"
-        case .kMSOptInRequired(let message):
-            return "KMSOptInRequired: \(message ?? "")"
-        case .kMSThrottlingException(let message):
-            return "KMSThrottling: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFound: \(message ?? "")"
-        case .platformApplicationDisabledException(let message):
-            return "PlatformApplicationDisabled: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFound: \(message ?? "")"
-        case .staleTagException(let message):
-            return "StaleTag: \(message ?? "")"
-        case .subscriptionLimitExceededException(let message):
-            return "SubscriptionLimitExceeded: \(message ?? "")"
-        case .tagLimitExceededException(let message):
-            return "TagLimitExceeded: \(message ?? "")"
-        case .tagPolicyException(let message):
-            return "TagPolicy: \(message ?? "")"
-        case .throttledException(let message):
-            return "Throttled: \(message ?? "")"
-        case .topicLimitExceededException(let message):
-            return "TopicLimitExceeded: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/SQS/SQS_Error.swift
+++ b/Sources/Soto/Services/SQS/SQS_Error.swift
@@ -17,105 +17,70 @@
 import SotoCore
 
 /// Error enum for SQS
-public enum SQSErrorType: AWSErrorType {
-    case batchEntryIdsNotDistinct(message: String?)
-    case batchRequestTooLong(message: String?)
-    case emptyBatchRequest(message: String?)
-    case invalidAttributeName(message: String?)
-    case invalidBatchEntryId(message: String?)
-    case invalidIdFormat(message: String?)
-    case invalidMessageContents(message: String?)
-    case messageNotInflight(message: String?)
-    case overLimit(message: String?)
-    case purgeQueueInProgress(message: String?)
-    case queueDeletedRecently(message: String?)
-    case queueDoesNotExist(message: String?)
-    case queueNameExists(message: String?)
-    case receiptHandleIsInvalid(message: String?)
-    case tooManyEntriesInBatchRequest(message: String?)
-    case unsupportedOperation(message: String?)
-}
+public struct SQSErrorType: AWSErrorType {
+    enum Code: String {
+        case batchEntryIdsNotDistinct = "AWS.SimpleQueueService.BatchEntryIdsNotDistinct"
+        case batchRequestTooLong = "AWS.SimpleQueueService.BatchRequestTooLong"
+        case emptyBatchRequest = "AWS.SimpleQueueService.EmptyBatchRequest"
+        case invalidAttributeName = "InvalidAttributeName"
+        case invalidBatchEntryId = "AWS.SimpleQueueService.InvalidBatchEntryId"
+        case invalidIdFormat = "InvalidIdFormat"
+        case invalidMessageContents = "InvalidMessageContents"
+        case messageNotInflight = "AWS.SimpleQueueService.MessageNotInflight"
+        case overLimit = "OverLimit"
+        case purgeQueueInProgress = "AWS.SimpleQueueService.PurgeQueueInProgress"
+        case queueDeletedRecently = "AWS.SimpleQueueService.QueueDeletedRecently"
+        case queueDoesNotExist = "AWS.SimpleQueueService.NonExistentQueue"
+        case queueNameExists = "QueueAlreadyExists"
+        case receiptHandleIsInvalid = "ReceiptHandleIsInvalid"
+        case tooManyEntriesInBatchRequest = "AWS.SimpleQueueService.TooManyEntriesInBatchRequest"
+        case unsupportedOperation = "AWS.SimpleQueueService.UnsupportedOperation"
+    }
 
-extension SQSErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AWS.SimpleQueueService.BatchEntryIdsNotDistinct":
-            self = .batchEntryIdsNotDistinct(message: message)
-        case "AWS.SimpleQueueService.BatchRequestTooLong":
-            self = .batchRequestTooLong(message: message)
-        case "AWS.SimpleQueueService.EmptyBatchRequest":
-            self = .emptyBatchRequest(message: message)
-        case "InvalidAttributeName":
-            self = .invalidAttributeName(message: message)
-        case "AWS.SimpleQueueService.InvalidBatchEntryId":
-            self = .invalidBatchEntryId(message: message)
-        case "InvalidIdFormat":
-            self = .invalidIdFormat(message: message)
-        case "InvalidMessageContents":
-            self = .invalidMessageContents(message: message)
-        case "AWS.SimpleQueueService.MessageNotInflight":
-            self = .messageNotInflight(message: message)
-        case "OverLimit":
-            self = .overLimit(message: message)
-        case "AWS.SimpleQueueService.PurgeQueueInProgress":
-            self = .purgeQueueInProgress(message: message)
-        case "AWS.SimpleQueueService.QueueDeletedRecently":
-            self = .queueDeletedRecently(message: message)
-        case "AWS.SimpleQueueService.NonExistentQueue":
-            self = .queueDoesNotExist(message: message)
-        case "QueueAlreadyExists":
-            self = .queueNameExists(message: message)
-        case "ReceiptHandleIsInvalid":
-            self = .receiptHandleIsInvalid(message: message)
-        case "AWS.SimpleQueueService.TooManyEntriesInBatchRequest":
-            self = .tooManyEntriesInBatchRequest(message: message)
-        case "AWS.SimpleQueueService.UnsupportedOperation":
-            self = .unsupportedOperation(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var batchEntryIdsNotDistinct: Self { .init(.batchEntryIdsNotDistinct) }
+    public static var batchRequestTooLong: Self { .init(.batchRequestTooLong) }
+    public static var emptyBatchRequest: Self { .init(.emptyBatchRequest) }
+    public static var invalidAttributeName: Self { .init(.invalidAttributeName) }
+    public static var invalidBatchEntryId: Self { .init(.invalidBatchEntryId) }
+    public static var invalidIdFormat: Self { .init(.invalidIdFormat) }
+    public static var invalidMessageContents: Self { .init(.invalidMessageContents) }
+    public static var messageNotInflight: Self { .init(.messageNotInflight) }
+    public static var overLimit: Self { .init(.overLimit) }
+    public static var purgeQueueInProgress: Self { .init(.purgeQueueInProgress) }
+    public static var queueDeletedRecently: Self { .init(.queueDeletedRecently) }
+    public static var queueDoesNotExist: Self { .init(.queueDoesNotExist) }
+    public static var queueNameExists: Self { .init(.queueNameExists) }
+    public static var receiptHandleIsInvalid: Self { .init(.receiptHandleIsInvalid) }
+    public static var tooManyEntriesInBatchRequest: Self { .init(.tooManyEntriesInBatchRequest) }
+    public static var unsupportedOperation: Self { .init(.unsupportedOperation) }
+}
+
+extension SQSErrorType: Equatable {
+    public static func == (lhs: SQSErrorType, rhs: SQSErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension SQSErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .batchEntryIdsNotDistinct(let message):
-            return "AWS.SimpleQueueService.BatchEntryIdsNotDistinct: \(message ?? "")"
-        case .batchRequestTooLong(let message):
-            return "AWS.SimpleQueueService.BatchRequestTooLong: \(message ?? "")"
-        case .emptyBatchRequest(let message):
-            return "AWS.SimpleQueueService.EmptyBatchRequest: \(message ?? "")"
-        case .invalidAttributeName(let message):
-            return "InvalidAttributeName: \(message ?? "")"
-        case .invalidBatchEntryId(let message):
-            return "AWS.SimpleQueueService.InvalidBatchEntryId: \(message ?? "")"
-        case .invalidIdFormat(let message):
-            return "InvalidIdFormat: \(message ?? "")"
-        case .invalidMessageContents(let message):
-            return "InvalidMessageContents: \(message ?? "")"
-        case .messageNotInflight(let message):
-            return "AWS.SimpleQueueService.MessageNotInflight: \(message ?? "")"
-        case .overLimit(let message):
-            return "OverLimit: \(message ?? "")"
-        case .purgeQueueInProgress(let message):
-            return "AWS.SimpleQueueService.PurgeQueueInProgress: \(message ?? "")"
-        case .queueDeletedRecently(let message):
-            return "AWS.SimpleQueueService.QueueDeletedRecently: \(message ?? "")"
-        case .queueDoesNotExist(let message):
-            return "AWS.SimpleQueueService.NonExistentQueue: \(message ?? "")"
-        case .queueNameExists(let message):
-            return "QueueAlreadyExists: \(message ?? "")"
-        case .receiptHandleIsInvalid(let message):
-            return "ReceiptHandleIsInvalid: \(message ?? "")"
-        case .tooManyEntriesInBatchRequest(let message):
-            return "AWS.SimpleQueueService.TooManyEntriesInBatchRequest: \(message ?? "")"
-        case .unsupportedOperation(let message):
-            return "AWS.SimpleQueueService.UnsupportedOperation: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/SSM/SSM_Error.swift
+++ b/Sources/Soto/Services/SSM/SSM_Error.swift
@@ -17,590 +17,264 @@
 import SotoCore
 
 /// Error enum for SSM
-public enum SSMErrorType: AWSErrorType {
-    case alreadyExistsException(message: String?)
-    case associatedInstances(message: String?)
-    case associationAlreadyExists(message: String?)
-    case associationDoesNotExist(message: String?)
-    case associationExecutionDoesNotExist(message: String?)
-    case associationLimitExceeded(message: String?)
-    case associationVersionLimitExceeded(message: String?)
-    case automationDefinitionNotFoundException(message: String?)
-    case automationDefinitionVersionNotFoundException(message: String?)
-    case automationExecutionLimitExceededException(message: String?)
-    case automationExecutionNotFoundException(message: String?)
-    case automationStepNotFoundException(message: String?)
-    case complianceTypeCountLimitExceededException(message: String?)
-    case customSchemaCountLimitExceededException(message: String?)
-    case documentAlreadyExists(message: String?)
-    case documentLimitExceeded(message: String?)
-    case documentPermissionLimit(message: String?)
-    case documentVersionLimitExceeded(message: String?)
-    case doesNotExistException(message: String?)
-    case duplicateDocumentContent(message: String?)
-    case duplicateDocumentVersionName(message: String?)
-    case duplicateInstanceId(message: String?)
-    case featureNotAvailableException(message: String?)
-    case hierarchyLevelLimitExceededException(message: String?)
-    case hierarchyTypeMismatchException(message: String?)
-    case idempotentParameterMismatch(message: String?)
-    case incompatiblePolicyException(message: String?)
-    case internalServerError(message: String?)
-    case invalidActivation(message: String?)
-    case invalidActivationId(message: String?)
-    case invalidAggregatorException(message: String?)
-    case invalidAllowedPatternException(message: String?)
-    case invalidAssociation(message: String?)
-    case invalidAssociationVersion(message: String?)
-    case invalidAutomationExecutionParametersException(message: String?)
-    case invalidAutomationSignalException(message: String?)
-    case invalidAutomationStatusUpdateException(message: String?)
-    case invalidCommandId(message: String?)
-    case invalidDeleteInventoryParametersException(message: String?)
-    case invalidDeletionIdException(message: String?)
-    case invalidDocument(message: String?)
-    case invalidDocumentContent(message: String?)
-    case invalidDocumentOperation(message: String?)
-    case invalidDocumentSchemaVersion(message: String?)
-    case invalidDocumentType(message: String?)
-    case invalidDocumentVersion(message: String?)
-    case invalidFilter(message: String?)
-    case invalidFilterKey(message: String?)
-    case invalidFilterOption(message: String?)
-    case invalidFilterValue(message: String?)
-    case invalidInstanceId(message: String?)
-    case invalidInstanceInformationFilterValue(message: String?)
-    case invalidInventoryGroupException(message: String?)
-    case invalidInventoryItemContextException(message: String?)
-    case invalidInventoryRequestException(message: String?)
-    case invalidItemContentException(message: String?)
-    case invalidKeyId(message: String?)
-    case invalidNextToken(message: String?)
-    case invalidNotificationConfig(message: String?)
-    case invalidOptionException(message: String?)
-    case invalidOutputFolder(message: String?)
-    case invalidOutputLocation(message: String?)
-    case invalidParameters(message: String?)
-    case invalidPermissionType(message: String?)
-    case invalidPluginName(message: String?)
-    case invalidPolicyAttributeException(message: String?)
-    case invalidPolicyTypeException(message: String?)
-    case invalidResourceId(message: String?)
-    case invalidResourceType(message: String?)
-    case invalidResultAttributeException(message: String?)
-    case invalidRole(message: String?)
-    case invalidSchedule(message: String?)
-    case invalidTarget(message: String?)
-    case invalidTypeNameException(message: String?)
-    case invalidUpdate(message: String?)
-    case invocationDoesNotExist(message: String?)
-    case itemContentMismatchException(message: String?)
-    case itemSizeLimitExceededException(message: String?)
-    case maxDocumentSizeExceeded(message: String?)
-    case opsItemAlreadyExistsException(message: String?)
-    case opsItemInvalidParameterException(message: String?)
-    case opsItemLimitExceededException(message: String?)
-    case opsItemNotFoundException(message: String?)
-    case parameterAlreadyExists(message: String?)
-    case parameterLimitExceeded(message: String?)
-    case parameterMaxVersionLimitExceeded(message: String?)
-    case parameterNotFound(message: String?)
-    case parameterPatternMismatchException(message: String?)
-    case parameterVersionLabelLimitExceeded(message: String?)
-    case parameterVersionNotFound(message: String?)
-    case policiesLimitExceededException(message: String?)
-    case resourceDataSyncAlreadyExistsException(message: String?)
-    case resourceDataSyncConflictException(message: String?)
-    case resourceDataSyncCountExceededException(message: String?)
-    case resourceDataSyncInvalidConfigurationException(message: String?)
-    case resourceDataSyncNotFoundException(message: String?)
-    case resourceInUseException(message: String?)
-    case resourceLimitExceededException(message: String?)
-    case serviceSettingNotFound(message: String?)
-    case statusUnchanged(message: String?)
-    case subTypeCountLimitExceededException(message: String?)
-    case targetInUseException(message: String?)
-    case targetNotConnected(message: String?)
-    case tooManyTagsError(message: String?)
-    case tooManyUpdates(message: String?)
-    case totalSizeLimitExceededException(message: String?)
-    case unsupportedCalendarException(message: String?)
-    case unsupportedFeatureRequiredException(message: String?)
-    case unsupportedInventoryItemContextException(message: String?)
-    case unsupportedInventorySchemaVersionException(message: String?)
-    case unsupportedOperatingSystem(message: String?)
-    case unsupportedParameterType(message: String?)
-    case unsupportedPlatformType(message: String?)
-}
+public struct SSMErrorType: AWSErrorType {
+    enum Code: String {
+        case alreadyExistsException = "AlreadyExistsException"
+        case associatedInstances = "AssociatedInstances"
+        case associationAlreadyExists = "AssociationAlreadyExists"
+        case associationDoesNotExist = "AssociationDoesNotExist"
+        case associationExecutionDoesNotExist = "AssociationExecutionDoesNotExist"
+        case associationLimitExceeded = "AssociationLimitExceeded"
+        case associationVersionLimitExceeded = "AssociationVersionLimitExceeded"
+        case automationDefinitionNotFoundException = "AutomationDefinitionNotFoundException"
+        case automationDefinitionVersionNotFoundException = "AutomationDefinitionVersionNotFoundException"
+        case automationExecutionLimitExceededException = "AutomationExecutionLimitExceededException"
+        case automationExecutionNotFoundException = "AutomationExecutionNotFoundException"
+        case automationStepNotFoundException = "AutomationStepNotFoundException"
+        case complianceTypeCountLimitExceededException = "ComplianceTypeCountLimitExceededException"
+        case customSchemaCountLimitExceededException = "CustomSchemaCountLimitExceededException"
+        case documentAlreadyExists = "DocumentAlreadyExists"
+        case documentLimitExceeded = "DocumentLimitExceeded"
+        case documentPermissionLimit = "DocumentPermissionLimit"
+        case documentVersionLimitExceeded = "DocumentVersionLimitExceeded"
+        case doesNotExistException = "DoesNotExistException"
+        case duplicateDocumentContent = "DuplicateDocumentContent"
+        case duplicateDocumentVersionName = "DuplicateDocumentVersionName"
+        case duplicateInstanceId = "DuplicateInstanceId"
+        case featureNotAvailableException = "FeatureNotAvailableException"
+        case hierarchyLevelLimitExceededException = "HierarchyLevelLimitExceededException"
+        case hierarchyTypeMismatchException = "HierarchyTypeMismatchException"
+        case idempotentParameterMismatch = "IdempotentParameterMismatch"
+        case incompatiblePolicyException = "IncompatiblePolicyException"
+        case internalServerError = "InternalServerError"
+        case invalidActivation = "InvalidActivation"
+        case invalidActivationId = "InvalidActivationId"
+        case invalidAggregatorException = "InvalidAggregatorException"
+        case invalidAllowedPatternException = "InvalidAllowedPatternException"
+        case invalidAssociation = "InvalidAssociation"
+        case invalidAssociationVersion = "InvalidAssociationVersion"
+        case invalidAutomationExecutionParametersException = "InvalidAutomationExecutionParametersException"
+        case invalidAutomationSignalException = "InvalidAutomationSignalException"
+        case invalidAutomationStatusUpdateException = "InvalidAutomationStatusUpdateException"
+        case invalidCommandId = "InvalidCommandId"
+        case invalidDeleteInventoryParametersException = "InvalidDeleteInventoryParametersException"
+        case invalidDeletionIdException = "InvalidDeletionIdException"
+        case invalidDocument = "InvalidDocument"
+        case invalidDocumentContent = "InvalidDocumentContent"
+        case invalidDocumentOperation = "InvalidDocumentOperation"
+        case invalidDocumentSchemaVersion = "InvalidDocumentSchemaVersion"
+        case invalidDocumentType = "InvalidDocumentType"
+        case invalidDocumentVersion = "InvalidDocumentVersion"
+        case invalidFilter = "InvalidFilter"
+        case invalidFilterKey = "InvalidFilterKey"
+        case invalidFilterOption = "InvalidFilterOption"
+        case invalidFilterValue = "InvalidFilterValue"
+        case invalidInstanceId = "InvalidInstanceId"
+        case invalidInstanceInformationFilterValue = "InvalidInstanceInformationFilterValue"
+        case invalidInventoryGroupException = "InvalidInventoryGroupException"
+        case invalidInventoryItemContextException = "InvalidInventoryItemContextException"
+        case invalidInventoryRequestException = "InvalidInventoryRequestException"
+        case invalidItemContentException = "InvalidItemContentException"
+        case invalidKeyId = "InvalidKeyId"
+        case invalidNextToken = "InvalidNextToken"
+        case invalidNotificationConfig = "InvalidNotificationConfig"
+        case invalidOptionException = "InvalidOptionException"
+        case invalidOutputFolder = "InvalidOutputFolder"
+        case invalidOutputLocation = "InvalidOutputLocation"
+        case invalidParameters = "InvalidParameters"
+        case invalidPermissionType = "InvalidPermissionType"
+        case invalidPluginName = "InvalidPluginName"
+        case invalidPolicyAttributeException = "InvalidPolicyAttributeException"
+        case invalidPolicyTypeException = "InvalidPolicyTypeException"
+        case invalidResourceId = "InvalidResourceId"
+        case invalidResourceType = "InvalidResourceType"
+        case invalidResultAttributeException = "InvalidResultAttributeException"
+        case invalidRole = "InvalidRole"
+        case invalidSchedule = "InvalidSchedule"
+        case invalidTarget = "InvalidTarget"
+        case invalidTypeNameException = "InvalidTypeNameException"
+        case invalidUpdate = "InvalidUpdate"
+        case invocationDoesNotExist = "InvocationDoesNotExist"
+        case itemContentMismatchException = "ItemContentMismatchException"
+        case itemSizeLimitExceededException = "ItemSizeLimitExceededException"
+        case maxDocumentSizeExceeded = "MaxDocumentSizeExceeded"
+        case opsItemAlreadyExistsException = "OpsItemAlreadyExistsException"
+        case opsItemInvalidParameterException = "OpsItemInvalidParameterException"
+        case opsItemLimitExceededException = "OpsItemLimitExceededException"
+        case opsItemNotFoundException = "OpsItemNotFoundException"
+        case parameterAlreadyExists = "ParameterAlreadyExists"
+        case parameterLimitExceeded = "ParameterLimitExceeded"
+        case parameterMaxVersionLimitExceeded = "ParameterMaxVersionLimitExceeded"
+        case parameterNotFound = "ParameterNotFound"
+        case parameterPatternMismatchException = "ParameterPatternMismatchException"
+        case parameterVersionLabelLimitExceeded = "ParameterVersionLabelLimitExceeded"
+        case parameterVersionNotFound = "ParameterVersionNotFound"
+        case policiesLimitExceededException = "PoliciesLimitExceededException"
+        case resourceDataSyncAlreadyExistsException = "ResourceDataSyncAlreadyExistsException"
+        case resourceDataSyncConflictException = "ResourceDataSyncConflictException"
+        case resourceDataSyncCountExceededException = "ResourceDataSyncCountExceededException"
+        case resourceDataSyncInvalidConfigurationException = "ResourceDataSyncInvalidConfigurationException"
+        case resourceDataSyncNotFoundException = "ResourceDataSyncNotFoundException"
+        case resourceInUseException = "ResourceInUseException"
+        case resourceLimitExceededException = "ResourceLimitExceededException"
+        case serviceSettingNotFound = "ServiceSettingNotFound"
+        case statusUnchanged = "StatusUnchanged"
+        case subTypeCountLimitExceededException = "SubTypeCountLimitExceededException"
+        case targetInUseException = "TargetInUseException"
+        case targetNotConnected = "TargetNotConnected"
+        case tooManyTagsError = "TooManyTagsError"
+        case tooManyUpdates = "TooManyUpdates"
+        case totalSizeLimitExceededException = "TotalSizeLimitExceededException"
+        case unsupportedCalendarException = "UnsupportedCalendarException"
+        case unsupportedFeatureRequiredException = "UnsupportedFeatureRequiredException"
+        case unsupportedInventoryItemContextException = "UnsupportedInventoryItemContextException"
+        case unsupportedInventorySchemaVersionException = "UnsupportedInventorySchemaVersionException"
+        case unsupportedOperatingSystem = "UnsupportedOperatingSystem"
+        case unsupportedParameterType = "UnsupportedParameterType"
+        case unsupportedPlatformType = "UnsupportedPlatformType"
+    }
 
-extension SSMErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AlreadyExistsException":
-            self = .alreadyExistsException(message: message)
-        case "AssociatedInstances":
-            self = .associatedInstances(message: message)
-        case "AssociationAlreadyExists":
-            self = .associationAlreadyExists(message: message)
-        case "AssociationDoesNotExist":
-            self = .associationDoesNotExist(message: message)
-        case "AssociationExecutionDoesNotExist":
-            self = .associationExecutionDoesNotExist(message: message)
-        case "AssociationLimitExceeded":
-            self = .associationLimitExceeded(message: message)
-        case "AssociationVersionLimitExceeded":
-            self = .associationVersionLimitExceeded(message: message)
-        case "AutomationDefinitionNotFoundException":
-            self = .automationDefinitionNotFoundException(message: message)
-        case "AutomationDefinitionVersionNotFoundException":
-            self = .automationDefinitionVersionNotFoundException(message: message)
-        case "AutomationExecutionLimitExceededException":
-            self = .automationExecutionLimitExceededException(message: message)
-        case "AutomationExecutionNotFoundException":
-            self = .automationExecutionNotFoundException(message: message)
-        case "AutomationStepNotFoundException":
-            self = .automationStepNotFoundException(message: message)
-        case "ComplianceTypeCountLimitExceededException":
-            self = .complianceTypeCountLimitExceededException(message: message)
-        case "CustomSchemaCountLimitExceededException":
-            self = .customSchemaCountLimitExceededException(message: message)
-        case "DocumentAlreadyExists":
-            self = .documentAlreadyExists(message: message)
-        case "DocumentLimitExceeded":
-            self = .documentLimitExceeded(message: message)
-        case "DocumentPermissionLimit":
-            self = .documentPermissionLimit(message: message)
-        case "DocumentVersionLimitExceeded":
-            self = .documentVersionLimitExceeded(message: message)
-        case "DoesNotExistException":
-            self = .doesNotExistException(message: message)
-        case "DuplicateDocumentContent":
-            self = .duplicateDocumentContent(message: message)
-        case "DuplicateDocumentVersionName":
-            self = .duplicateDocumentVersionName(message: message)
-        case "DuplicateInstanceId":
-            self = .duplicateInstanceId(message: message)
-        case "FeatureNotAvailableException":
-            self = .featureNotAvailableException(message: message)
-        case "HierarchyLevelLimitExceededException":
-            self = .hierarchyLevelLimitExceededException(message: message)
-        case "HierarchyTypeMismatchException":
-            self = .hierarchyTypeMismatchException(message: message)
-        case "IdempotentParameterMismatch":
-            self = .idempotentParameterMismatch(message: message)
-        case "IncompatiblePolicyException":
-            self = .incompatiblePolicyException(message: message)
-        case "InternalServerError":
-            self = .internalServerError(message: message)
-        case "InvalidActivation":
-            self = .invalidActivation(message: message)
-        case "InvalidActivationId":
-            self = .invalidActivationId(message: message)
-        case "InvalidAggregatorException":
-            self = .invalidAggregatorException(message: message)
-        case "InvalidAllowedPatternException":
-            self = .invalidAllowedPatternException(message: message)
-        case "InvalidAssociation":
-            self = .invalidAssociation(message: message)
-        case "InvalidAssociationVersion":
-            self = .invalidAssociationVersion(message: message)
-        case "InvalidAutomationExecutionParametersException":
-            self = .invalidAutomationExecutionParametersException(message: message)
-        case "InvalidAutomationSignalException":
-            self = .invalidAutomationSignalException(message: message)
-        case "InvalidAutomationStatusUpdateException":
-            self = .invalidAutomationStatusUpdateException(message: message)
-        case "InvalidCommandId":
-            self = .invalidCommandId(message: message)
-        case "InvalidDeleteInventoryParametersException":
-            self = .invalidDeleteInventoryParametersException(message: message)
-        case "InvalidDeletionIdException":
-            self = .invalidDeletionIdException(message: message)
-        case "InvalidDocument":
-            self = .invalidDocument(message: message)
-        case "InvalidDocumentContent":
-            self = .invalidDocumentContent(message: message)
-        case "InvalidDocumentOperation":
-            self = .invalidDocumentOperation(message: message)
-        case "InvalidDocumentSchemaVersion":
-            self = .invalidDocumentSchemaVersion(message: message)
-        case "InvalidDocumentType":
-            self = .invalidDocumentType(message: message)
-        case "InvalidDocumentVersion":
-            self = .invalidDocumentVersion(message: message)
-        case "InvalidFilter":
-            self = .invalidFilter(message: message)
-        case "InvalidFilterKey":
-            self = .invalidFilterKey(message: message)
-        case "InvalidFilterOption":
-            self = .invalidFilterOption(message: message)
-        case "InvalidFilterValue":
-            self = .invalidFilterValue(message: message)
-        case "InvalidInstanceId":
-            self = .invalidInstanceId(message: message)
-        case "InvalidInstanceInformationFilterValue":
-            self = .invalidInstanceInformationFilterValue(message: message)
-        case "InvalidInventoryGroupException":
-            self = .invalidInventoryGroupException(message: message)
-        case "InvalidInventoryItemContextException":
-            self = .invalidInventoryItemContextException(message: message)
-        case "InvalidInventoryRequestException":
-            self = .invalidInventoryRequestException(message: message)
-        case "InvalidItemContentException":
-            self = .invalidItemContentException(message: message)
-        case "InvalidKeyId":
-            self = .invalidKeyId(message: message)
-        case "InvalidNextToken":
-            self = .invalidNextToken(message: message)
-        case "InvalidNotificationConfig":
-            self = .invalidNotificationConfig(message: message)
-        case "InvalidOptionException":
-            self = .invalidOptionException(message: message)
-        case "InvalidOutputFolder":
-            self = .invalidOutputFolder(message: message)
-        case "InvalidOutputLocation":
-            self = .invalidOutputLocation(message: message)
-        case "InvalidParameters":
-            self = .invalidParameters(message: message)
-        case "InvalidPermissionType":
-            self = .invalidPermissionType(message: message)
-        case "InvalidPluginName":
-            self = .invalidPluginName(message: message)
-        case "InvalidPolicyAttributeException":
-            self = .invalidPolicyAttributeException(message: message)
-        case "InvalidPolicyTypeException":
-            self = .invalidPolicyTypeException(message: message)
-        case "InvalidResourceId":
-            self = .invalidResourceId(message: message)
-        case "InvalidResourceType":
-            self = .invalidResourceType(message: message)
-        case "InvalidResultAttributeException":
-            self = .invalidResultAttributeException(message: message)
-        case "InvalidRole":
-            self = .invalidRole(message: message)
-        case "InvalidSchedule":
-            self = .invalidSchedule(message: message)
-        case "InvalidTarget":
-            self = .invalidTarget(message: message)
-        case "InvalidTypeNameException":
-            self = .invalidTypeNameException(message: message)
-        case "InvalidUpdate":
-            self = .invalidUpdate(message: message)
-        case "InvocationDoesNotExist":
-            self = .invocationDoesNotExist(message: message)
-        case "ItemContentMismatchException":
-            self = .itemContentMismatchException(message: message)
-        case "ItemSizeLimitExceededException":
-            self = .itemSizeLimitExceededException(message: message)
-        case "MaxDocumentSizeExceeded":
-            self = .maxDocumentSizeExceeded(message: message)
-        case "OpsItemAlreadyExistsException":
-            self = .opsItemAlreadyExistsException(message: message)
-        case "OpsItemInvalidParameterException":
-            self = .opsItemInvalidParameterException(message: message)
-        case "OpsItemLimitExceededException":
-            self = .opsItemLimitExceededException(message: message)
-        case "OpsItemNotFoundException":
-            self = .opsItemNotFoundException(message: message)
-        case "ParameterAlreadyExists":
-            self = .parameterAlreadyExists(message: message)
-        case "ParameterLimitExceeded":
-            self = .parameterLimitExceeded(message: message)
-        case "ParameterMaxVersionLimitExceeded":
-            self = .parameterMaxVersionLimitExceeded(message: message)
-        case "ParameterNotFound":
-            self = .parameterNotFound(message: message)
-        case "ParameterPatternMismatchException":
-            self = .parameterPatternMismatchException(message: message)
-        case "ParameterVersionLabelLimitExceeded":
-            self = .parameterVersionLabelLimitExceeded(message: message)
-        case "ParameterVersionNotFound":
-            self = .parameterVersionNotFound(message: message)
-        case "PoliciesLimitExceededException":
-            self = .policiesLimitExceededException(message: message)
-        case "ResourceDataSyncAlreadyExistsException":
-            self = .resourceDataSyncAlreadyExistsException(message: message)
-        case "ResourceDataSyncConflictException":
-            self = .resourceDataSyncConflictException(message: message)
-        case "ResourceDataSyncCountExceededException":
-            self = .resourceDataSyncCountExceededException(message: message)
-        case "ResourceDataSyncInvalidConfigurationException":
-            self = .resourceDataSyncInvalidConfigurationException(message: message)
-        case "ResourceDataSyncNotFoundException":
-            self = .resourceDataSyncNotFoundException(message: message)
-        case "ResourceInUseException":
-            self = .resourceInUseException(message: message)
-        case "ResourceLimitExceededException":
-            self = .resourceLimitExceededException(message: message)
-        case "ServiceSettingNotFound":
-            self = .serviceSettingNotFound(message: message)
-        case "StatusUnchanged":
-            self = .statusUnchanged(message: message)
-        case "SubTypeCountLimitExceededException":
-            self = .subTypeCountLimitExceededException(message: message)
-        case "TargetInUseException":
-            self = .targetInUseException(message: message)
-        case "TargetNotConnected":
-            self = .targetNotConnected(message: message)
-        case "TooManyTagsError":
-            self = .tooManyTagsError(message: message)
-        case "TooManyUpdates":
-            self = .tooManyUpdates(message: message)
-        case "TotalSizeLimitExceededException":
-            self = .totalSizeLimitExceededException(message: message)
-        case "UnsupportedCalendarException":
-            self = .unsupportedCalendarException(message: message)
-        case "UnsupportedFeatureRequiredException":
-            self = .unsupportedFeatureRequiredException(message: message)
-        case "UnsupportedInventoryItemContextException":
-            self = .unsupportedInventoryItemContextException(message: message)
-        case "UnsupportedInventorySchemaVersionException":
-            self = .unsupportedInventorySchemaVersionException(message: message)
-        case "UnsupportedOperatingSystem":
-            self = .unsupportedOperatingSystem(message: message)
-        case "UnsupportedParameterType":
-            self = .unsupportedParameterType(message: message)
-        case "UnsupportedPlatformType":
-            self = .unsupportedPlatformType(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var alreadyExistsException: Self { .init(.alreadyExistsException) }
+    public static var associatedInstances: Self { .init(.associatedInstances) }
+    public static var associationAlreadyExists: Self { .init(.associationAlreadyExists) }
+    public static var associationDoesNotExist: Self { .init(.associationDoesNotExist) }
+    public static var associationExecutionDoesNotExist: Self { .init(.associationExecutionDoesNotExist) }
+    public static var associationLimitExceeded: Self { .init(.associationLimitExceeded) }
+    public static var associationVersionLimitExceeded: Self { .init(.associationVersionLimitExceeded) }
+    public static var automationDefinitionNotFoundException: Self { .init(.automationDefinitionNotFoundException) }
+    public static var automationDefinitionVersionNotFoundException: Self { .init(.automationDefinitionVersionNotFoundException) }
+    public static var automationExecutionLimitExceededException: Self { .init(.automationExecutionLimitExceededException) }
+    public static var automationExecutionNotFoundException: Self { .init(.automationExecutionNotFoundException) }
+    public static var automationStepNotFoundException: Self { .init(.automationStepNotFoundException) }
+    public static var complianceTypeCountLimitExceededException: Self { .init(.complianceTypeCountLimitExceededException) }
+    public static var customSchemaCountLimitExceededException: Self { .init(.customSchemaCountLimitExceededException) }
+    public static var documentAlreadyExists: Self { .init(.documentAlreadyExists) }
+    public static var documentLimitExceeded: Self { .init(.documentLimitExceeded) }
+    public static var documentPermissionLimit: Self { .init(.documentPermissionLimit) }
+    public static var documentVersionLimitExceeded: Self { .init(.documentVersionLimitExceeded) }
+    public static var doesNotExistException: Self { .init(.doesNotExistException) }
+    public static var duplicateDocumentContent: Self { .init(.duplicateDocumentContent) }
+    public static var duplicateDocumentVersionName: Self { .init(.duplicateDocumentVersionName) }
+    public static var duplicateInstanceId: Self { .init(.duplicateInstanceId) }
+    public static var featureNotAvailableException: Self { .init(.featureNotAvailableException) }
+    public static var hierarchyLevelLimitExceededException: Self { .init(.hierarchyLevelLimitExceededException) }
+    public static var hierarchyTypeMismatchException: Self { .init(.hierarchyTypeMismatchException) }
+    public static var idempotentParameterMismatch: Self { .init(.idempotentParameterMismatch) }
+    public static var incompatiblePolicyException: Self { .init(.incompatiblePolicyException) }
+    public static var internalServerError: Self { .init(.internalServerError) }
+    public static var invalidActivation: Self { .init(.invalidActivation) }
+    public static var invalidActivationId: Self { .init(.invalidActivationId) }
+    public static var invalidAggregatorException: Self { .init(.invalidAggregatorException) }
+    public static var invalidAllowedPatternException: Self { .init(.invalidAllowedPatternException) }
+    public static var invalidAssociation: Self { .init(.invalidAssociation) }
+    public static var invalidAssociationVersion: Self { .init(.invalidAssociationVersion) }
+    public static var invalidAutomationExecutionParametersException: Self { .init(.invalidAutomationExecutionParametersException) }
+    public static var invalidAutomationSignalException: Self { .init(.invalidAutomationSignalException) }
+    public static var invalidAutomationStatusUpdateException: Self { .init(.invalidAutomationStatusUpdateException) }
+    public static var invalidCommandId: Self { .init(.invalidCommandId) }
+    public static var invalidDeleteInventoryParametersException: Self { .init(.invalidDeleteInventoryParametersException) }
+    public static var invalidDeletionIdException: Self { .init(.invalidDeletionIdException) }
+    public static var invalidDocument: Self { .init(.invalidDocument) }
+    public static var invalidDocumentContent: Self { .init(.invalidDocumentContent) }
+    public static var invalidDocumentOperation: Self { .init(.invalidDocumentOperation) }
+    public static var invalidDocumentSchemaVersion: Self { .init(.invalidDocumentSchemaVersion) }
+    public static var invalidDocumentType: Self { .init(.invalidDocumentType) }
+    public static var invalidDocumentVersion: Self { .init(.invalidDocumentVersion) }
+    public static var invalidFilter: Self { .init(.invalidFilter) }
+    public static var invalidFilterKey: Self { .init(.invalidFilterKey) }
+    public static var invalidFilterOption: Self { .init(.invalidFilterOption) }
+    public static var invalidFilterValue: Self { .init(.invalidFilterValue) }
+    public static var invalidInstanceId: Self { .init(.invalidInstanceId) }
+    public static var invalidInstanceInformationFilterValue: Self { .init(.invalidInstanceInformationFilterValue) }
+    public static var invalidInventoryGroupException: Self { .init(.invalidInventoryGroupException) }
+    public static var invalidInventoryItemContextException: Self { .init(.invalidInventoryItemContextException) }
+    public static var invalidInventoryRequestException: Self { .init(.invalidInventoryRequestException) }
+    public static var invalidItemContentException: Self { .init(.invalidItemContentException) }
+    public static var invalidKeyId: Self { .init(.invalidKeyId) }
+    public static var invalidNextToken: Self { .init(.invalidNextToken) }
+    public static var invalidNotificationConfig: Self { .init(.invalidNotificationConfig) }
+    public static var invalidOptionException: Self { .init(.invalidOptionException) }
+    public static var invalidOutputFolder: Self { .init(.invalidOutputFolder) }
+    public static var invalidOutputLocation: Self { .init(.invalidOutputLocation) }
+    public static var invalidParameters: Self { .init(.invalidParameters) }
+    public static var invalidPermissionType: Self { .init(.invalidPermissionType) }
+    public static var invalidPluginName: Self { .init(.invalidPluginName) }
+    public static var invalidPolicyAttributeException: Self { .init(.invalidPolicyAttributeException) }
+    public static var invalidPolicyTypeException: Self { .init(.invalidPolicyTypeException) }
+    public static var invalidResourceId: Self { .init(.invalidResourceId) }
+    public static var invalidResourceType: Self { .init(.invalidResourceType) }
+    public static var invalidResultAttributeException: Self { .init(.invalidResultAttributeException) }
+    public static var invalidRole: Self { .init(.invalidRole) }
+    public static var invalidSchedule: Self { .init(.invalidSchedule) }
+    public static var invalidTarget: Self { .init(.invalidTarget) }
+    public static var invalidTypeNameException: Self { .init(.invalidTypeNameException) }
+    public static var invalidUpdate: Self { .init(.invalidUpdate) }
+    public static var invocationDoesNotExist: Self { .init(.invocationDoesNotExist) }
+    public static var itemContentMismatchException: Self { .init(.itemContentMismatchException) }
+    public static var itemSizeLimitExceededException: Self { .init(.itemSizeLimitExceededException) }
+    public static var maxDocumentSizeExceeded: Self { .init(.maxDocumentSizeExceeded) }
+    public static var opsItemAlreadyExistsException: Self { .init(.opsItemAlreadyExistsException) }
+    public static var opsItemInvalidParameterException: Self { .init(.opsItemInvalidParameterException) }
+    public static var opsItemLimitExceededException: Self { .init(.opsItemLimitExceededException) }
+    public static var opsItemNotFoundException: Self { .init(.opsItemNotFoundException) }
+    public static var parameterAlreadyExists: Self { .init(.parameterAlreadyExists) }
+    public static var parameterLimitExceeded: Self { .init(.parameterLimitExceeded) }
+    public static var parameterMaxVersionLimitExceeded: Self { .init(.parameterMaxVersionLimitExceeded) }
+    public static var parameterNotFound: Self { .init(.parameterNotFound) }
+    public static var parameterPatternMismatchException: Self { .init(.parameterPatternMismatchException) }
+    public static var parameterVersionLabelLimitExceeded: Self { .init(.parameterVersionLabelLimitExceeded) }
+    public static var parameterVersionNotFound: Self { .init(.parameterVersionNotFound) }
+    public static var policiesLimitExceededException: Self { .init(.policiesLimitExceededException) }
+    public static var resourceDataSyncAlreadyExistsException: Self { .init(.resourceDataSyncAlreadyExistsException) }
+    public static var resourceDataSyncConflictException: Self { .init(.resourceDataSyncConflictException) }
+    public static var resourceDataSyncCountExceededException: Self { .init(.resourceDataSyncCountExceededException) }
+    public static var resourceDataSyncInvalidConfigurationException: Self { .init(.resourceDataSyncInvalidConfigurationException) }
+    public static var resourceDataSyncNotFoundException: Self { .init(.resourceDataSyncNotFoundException) }
+    public static var resourceInUseException: Self { .init(.resourceInUseException) }
+    public static var resourceLimitExceededException: Self { .init(.resourceLimitExceededException) }
+    public static var serviceSettingNotFound: Self { .init(.serviceSettingNotFound) }
+    public static var statusUnchanged: Self { .init(.statusUnchanged) }
+    public static var subTypeCountLimitExceededException: Self { .init(.subTypeCountLimitExceededException) }
+    public static var targetInUseException: Self { .init(.targetInUseException) }
+    public static var targetNotConnected: Self { .init(.targetNotConnected) }
+    public static var tooManyTagsError: Self { .init(.tooManyTagsError) }
+    public static var tooManyUpdates: Self { .init(.tooManyUpdates) }
+    public static var totalSizeLimitExceededException: Self { .init(.totalSizeLimitExceededException) }
+    public static var unsupportedCalendarException: Self { .init(.unsupportedCalendarException) }
+    public static var unsupportedFeatureRequiredException: Self { .init(.unsupportedFeatureRequiredException) }
+    public static var unsupportedInventoryItemContextException: Self { .init(.unsupportedInventoryItemContextException) }
+    public static var unsupportedInventorySchemaVersionException: Self { .init(.unsupportedInventorySchemaVersionException) }
+    public static var unsupportedOperatingSystem: Self { .init(.unsupportedOperatingSystem) }
+    public static var unsupportedParameterType: Self { .init(.unsupportedParameterType) }
+    public static var unsupportedPlatformType: Self { .init(.unsupportedPlatformType) }
+}
+
+extension SSMErrorType: Equatable {
+    public static func == (lhs: SSMErrorType, rhs: SSMErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension SSMErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .alreadyExistsException(let message):
-            return "AlreadyExistsException: \(message ?? "")"
-        case .associatedInstances(let message):
-            return "AssociatedInstances: \(message ?? "")"
-        case .associationAlreadyExists(let message):
-            return "AssociationAlreadyExists: \(message ?? "")"
-        case .associationDoesNotExist(let message):
-            return "AssociationDoesNotExist: \(message ?? "")"
-        case .associationExecutionDoesNotExist(let message):
-            return "AssociationExecutionDoesNotExist: \(message ?? "")"
-        case .associationLimitExceeded(let message):
-            return "AssociationLimitExceeded: \(message ?? "")"
-        case .associationVersionLimitExceeded(let message):
-            return "AssociationVersionLimitExceeded: \(message ?? "")"
-        case .automationDefinitionNotFoundException(let message):
-            return "AutomationDefinitionNotFoundException: \(message ?? "")"
-        case .automationDefinitionVersionNotFoundException(let message):
-            return "AutomationDefinitionVersionNotFoundException: \(message ?? "")"
-        case .automationExecutionLimitExceededException(let message):
-            return "AutomationExecutionLimitExceededException: \(message ?? "")"
-        case .automationExecutionNotFoundException(let message):
-            return "AutomationExecutionNotFoundException: \(message ?? "")"
-        case .automationStepNotFoundException(let message):
-            return "AutomationStepNotFoundException: \(message ?? "")"
-        case .complianceTypeCountLimitExceededException(let message):
-            return "ComplianceTypeCountLimitExceededException: \(message ?? "")"
-        case .customSchemaCountLimitExceededException(let message):
-            return "CustomSchemaCountLimitExceededException: \(message ?? "")"
-        case .documentAlreadyExists(let message):
-            return "DocumentAlreadyExists: \(message ?? "")"
-        case .documentLimitExceeded(let message):
-            return "DocumentLimitExceeded: \(message ?? "")"
-        case .documentPermissionLimit(let message):
-            return "DocumentPermissionLimit: \(message ?? "")"
-        case .documentVersionLimitExceeded(let message):
-            return "DocumentVersionLimitExceeded: \(message ?? "")"
-        case .doesNotExistException(let message):
-            return "DoesNotExistException: \(message ?? "")"
-        case .duplicateDocumentContent(let message):
-            return "DuplicateDocumentContent: \(message ?? "")"
-        case .duplicateDocumentVersionName(let message):
-            return "DuplicateDocumentVersionName: \(message ?? "")"
-        case .duplicateInstanceId(let message):
-            return "DuplicateInstanceId: \(message ?? "")"
-        case .featureNotAvailableException(let message):
-            return "FeatureNotAvailableException: \(message ?? "")"
-        case .hierarchyLevelLimitExceededException(let message):
-            return "HierarchyLevelLimitExceededException: \(message ?? "")"
-        case .hierarchyTypeMismatchException(let message):
-            return "HierarchyTypeMismatchException: \(message ?? "")"
-        case .idempotentParameterMismatch(let message):
-            return "IdempotentParameterMismatch: \(message ?? "")"
-        case .incompatiblePolicyException(let message):
-            return "IncompatiblePolicyException: \(message ?? "")"
-        case .internalServerError(let message):
-            return "InternalServerError: \(message ?? "")"
-        case .invalidActivation(let message):
-            return "InvalidActivation: \(message ?? "")"
-        case .invalidActivationId(let message):
-            return "InvalidActivationId: \(message ?? "")"
-        case .invalidAggregatorException(let message):
-            return "InvalidAggregatorException: \(message ?? "")"
-        case .invalidAllowedPatternException(let message):
-            return "InvalidAllowedPatternException: \(message ?? "")"
-        case .invalidAssociation(let message):
-            return "InvalidAssociation: \(message ?? "")"
-        case .invalidAssociationVersion(let message):
-            return "InvalidAssociationVersion: \(message ?? "")"
-        case .invalidAutomationExecutionParametersException(let message):
-            return "InvalidAutomationExecutionParametersException: \(message ?? "")"
-        case .invalidAutomationSignalException(let message):
-            return "InvalidAutomationSignalException: \(message ?? "")"
-        case .invalidAutomationStatusUpdateException(let message):
-            return "InvalidAutomationStatusUpdateException: \(message ?? "")"
-        case .invalidCommandId(let message):
-            return "InvalidCommandId: \(message ?? "")"
-        case .invalidDeleteInventoryParametersException(let message):
-            return "InvalidDeleteInventoryParametersException: \(message ?? "")"
-        case .invalidDeletionIdException(let message):
-            return "InvalidDeletionIdException: \(message ?? "")"
-        case .invalidDocument(let message):
-            return "InvalidDocument: \(message ?? "")"
-        case .invalidDocumentContent(let message):
-            return "InvalidDocumentContent: \(message ?? "")"
-        case .invalidDocumentOperation(let message):
-            return "InvalidDocumentOperation: \(message ?? "")"
-        case .invalidDocumentSchemaVersion(let message):
-            return "InvalidDocumentSchemaVersion: \(message ?? "")"
-        case .invalidDocumentType(let message):
-            return "InvalidDocumentType: \(message ?? "")"
-        case .invalidDocumentVersion(let message):
-            return "InvalidDocumentVersion: \(message ?? "")"
-        case .invalidFilter(let message):
-            return "InvalidFilter: \(message ?? "")"
-        case .invalidFilterKey(let message):
-            return "InvalidFilterKey: \(message ?? "")"
-        case .invalidFilterOption(let message):
-            return "InvalidFilterOption: \(message ?? "")"
-        case .invalidFilterValue(let message):
-            return "InvalidFilterValue: \(message ?? "")"
-        case .invalidInstanceId(let message):
-            return "InvalidInstanceId: \(message ?? "")"
-        case .invalidInstanceInformationFilterValue(let message):
-            return "InvalidInstanceInformationFilterValue: \(message ?? "")"
-        case .invalidInventoryGroupException(let message):
-            return "InvalidInventoryGroupException: \(message ?? "")"
-        case .invalidInventoryItemContextException(let message):
-            return "InvalidInventoryItemContextException: \(message ?? "")"
-        case .invalidInventoryRequestException(let message):
-            return "InvalidInventoryRequestException: \(message ?? "")"
-        case .invalidItemContentException(let message):
-            return "InvalidItemContentException: \(message ?? "")"
-        case .invalidKeyId(let message):
-            return "InvalidKeyId: \(message ?? "")"
-        case .invalidNextToken(let message):
-            return "InvalidNextToken: \(message ?? "")"
-        case .invalidNotificationConfig(let message):
-            return "InvalidNotificationConfig: \(message ?? "")"
-        case .invalidOptionException(let message):
-            return "InvalidOptionException: \(message ?? "")"
-        case .invalidOutputFolder(let message):
-            return "InvalidOutputFolder: \(message ?? "")"
-        case .invalidOutputLocation(let message):
-            return "InvalidOutputLocation: \(message ?? "")"
-        case .invalidParameters(let message):
-            return "InvalidParameters: \(message ?? "")"
-        case .invalidPermissionType(let message):
-            return "InvalidPermissionType: \(message ?? "")"
-        case .invalidPluginName(let message):
-            return "InvalidPluginName: \(message ?? "")"
-        case .invalidPolicyAttributeException(let message):
-            return "InvalidPolicyAttributeException: \(message ?? "")"
-        case .invalidPolicyTypeException(let message):
-            return "InvalidPolicyTypeException: \(message ?? "")"
-        case .invalidResourceId(let message):
-            return "InvalidResourceId: \(message ?? "")"
-        case .invalidResourceType(let message):
-            return "InvalidResourceType: \(message ?? "")"
-        case .invalidResultAttributeException(let message):
-            return "InvalidResultAttributeException: \(message ?? "")"
-        case .invalidRole(let message):
-            return "InvalidRole: \(message ?? "")"
-        case .invalidSchedule(let message):
-            return "InvalidSchedule: \(message ?? "")"
-        case .invalidTarget(let message):
-            return "InvalidTarget: \(message ?? "")"
-        case .invalidTypeNameException(let message):
-            return "InvalidTypeNameException: \(message ?? "")"
-        case .invalidUpdate(let message):
-            return "InvalidUpdate: \(message ?? "")"
-        case .invocationDoesNotExist(let message):
-            return "InvocationDoesNotExist: \(message ?? "")"
-        case .itemContentMismatchException(let message):
-            return "ItemContentMismatchException: \(message ?? "")"
-        case .itemSizeLimitExceededException(let message):
-            return "ItemSizeLimitExceededException: \(message ?? "")"
-        case .maxDocumentSizeExceeded(let message):
-            return "MaxDocumentSizeExceeded: \(message ?? "")"
-        case .opsItemAlreadyExistsException(let message):
-            return "OpsItemAlreadyExistsException: \(message ?? "")"
-        case .opsItemInvalidParameterException(let message):
-            return "OpsItemInvalidParameterException: \(message ?? "")"
-        case .opsItemLimitExceededException(let message):
-            return "OpsItemLimitExceededException: \(message ?? "")"
-        case .opsItemNotFoundException(let message):
-            return "OpsItemNotFoundException: \(message ?? "")"
-        case .parameterAlreadyExists(let message):
-            return "ParameterAlreadyExists: \(message ?? "")"
-        case .parameterLimitExceeded(let message):
-            return "ParameterLimitExceeded: \(message ?? "")"
-        case .parameterMaxVersionLimitExceeded(let message):
-            return "ParameterMaxVersionLimitExceeded: \(message ?? "")"
-        case .parameterNotFound(let message):
-            return "ParameterNotFound: \(message ?? "")"
-        case .parameterPatternMismatchException(let message):
-            return "ParameterPatternMismatchException: \(message ?? "")"
-        case .parameterVersionLabelLimitExceeded(let message):
-            return "ParameterVersionLabelLimitExceeded: \(message ?? "")"
-        case .parameterVersionNotFound(let message):
-            return "ParameterVersionNotFound: \(message ?? "")"
-        case .policiesLimitExceededException(let message):
-            return "PoliciesLimitExceededException: \(message ?? "")"
-        case .resourceDataSyncAlreadyExistsException(let message):
-            return "ResourceDataSyncAlreadyExistsException: \(message ?? "")"
-        case .resourceDataSyncConflictException(let message):
-            return "ResourceDataSyncConflictException: \(message ?? "")"
-        case .resourceDataSyncCountExceededException(let message):
-            return "ResourceDataSyncCountExceededException: \(message ?? "")"
-        case .resourceDataSyncInvalidConfigurationException(let message):
-            return "ResourceDataSyncInvalidConfigurationException: \(message ?? "")"
-        case .resourceDataSyncNotFoundException(let message):
-            return "ResourceDataSyncNotFoundException: \(message ?? "")"
-        case .resourceInUseException(let message):
-            return "ResourceInUseException: \(message ?? "")"
-        case .resourceLimitExceededException(let message):
-            return "ResourceLimitExceededException: \(message ?? "")"
-        case .serviceSettingNotFound(let message):
-            return "ServiceSettingNotFound: \(message ?? "")"
-        case .statusUnchanged(let message):
-            return "StatusUnchanged: \(message ?? "")"
-        case .subTypeCountLimitExceededException(let message):
-            return "SubTypeCountLimitExceededException: \(message ?? "")"
-        case .targetInUseException(let message):
-            return "TargetInUseException: \(message ?? "")"
-        case .targetNotConnected(let message):
-            return "TargetNotConnected: \(message ?? "")"
-        case .tooManyTagsError(let message):
-            return "TooManyTagsError: \(message ?? "")"
-        case .tooManyUpdates(let message):
-            return "TooManyUpdates: \(message ?? "")"
-        case .totalSizeLimitExceededException(let message):
-            return "TotalSizeLimitExceededException: \(message ?? "")"
-        case .unsupportedCalendarException(let message):
-            return "UnsupportedCalendarException: \(message ?? "")"
-        case .unsupportedFeatureRequiredException(let message):
-            return "UnsupportedFeatureRequiredException: \(message ?? "")"
-        case .unsupportedInventoryItemContextException(let message):
-            return "UnsupportedInventoryItemContextException: \(message ?? "")"
-        case .unsupportedInventorySchemaVersionException(let message):
-            return "UnsupportedInventorySchemaVersionException: \(message ?? "")"
-        case .unsupportedOperatingSystem(let message):
-            return "UnsupportedOperatingSystem: \(message ?? "")"
-        case .unsupportedParameterType(let message):
-            return "UnsupportedParameterType: \(message ?? "")"
-        case .unsupportedPlatformType(let message):
-            return "UnsupportedPlatformType: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/SSO/SSO_Error.swift
+++ b/Sources/Soto/Services/SSO/SSO_Error.swift
@@ -17,45 +17,46 @@
 import SotoCore
 
 /// Error enum for SSO
-public enum SSOErrorType: AWSErrorType {
-    case invalidRequestException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case tooManyRequestsException(message: String?)
-    case unauthorizedException(message: String?)
-}
+public struct SSOErrorType: AWSErrorType {
+    enum Code: String {
+        case invalidRequestException = "InvalidRequestException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case tooManyRequestsException = "TooManyRequestsException"
+        case unauthorizedException = "UnauthorizedException"
+    }
 
-extension SSOErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "TooManyRequestsException":
-            self = .tooManyRequestsException(message: message)
-        case "UnauthorizedException":
-            self = .unauthorizedException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var tooManyRequestsException: Self { .init(.tooManyRequestsException) }
+    public static var unauthorizedException: Self { .init(.unauthorizedException) }
+}
+
+extension SSOErrorType: Equatable {
+    public static func == (lhs: SSOErrorType, rhs: SSOErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension SSOErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .tooManyRequestsException(let message):
-            return "TooManyRequestsException: \(message ?? "")"
-        case .unauthorizedException(let message):
-            return "UnauthorizedException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/SSOAdmin/SSOAdmin_Error.swift
+++ b/Sources/Soto/Services/SSOAdmin/SSOAdmin_Error.swift
@@ -17,60 +17,52 @@
 import SotoCore
 
 /// Error enum for SSOAdmin
-public enum SSOAdminErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case conflictException(message: String?)
-    case internalServerException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceQuotaExceededException(message: String?)
-    case throttlingException(message: String?)
-    case validationException(message: String?)
-}
+public struct SSOAdminErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case conflictException = "ConflictException"
+        case internalServerException = "InternalServerException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceQuotaExceededException = "ServiceQuotaExceededException"
+        case throttlingException = "ThrottlingException"
+        case validationException = "ValidationException"
+    }
 
-extension SSOAdminErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceQuotaExceededException":
-            self = .serviceQuotaExceededException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceQuotaExceededException: Self { .init(.serviceQuotaExceededException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension SSOAdminErrorType: Equatable {
+    public static func == (lhs: SSOAdminErrorType, rhs: SSOAdminErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension SSOAdminErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceQuotaExceededException(let message):
-            return "ServiceQuotaExceededException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/SSOOIDC/SSOOIDC_Error.swift
+++ b/Sources/Soto/Services/SSOOIDC/SSOOIDC_Error.swift
@@ -17,85 +17,62 @@
 import SotoCore
 
 /// Error enum for SSOOIDC
-public enum SSOOIDCErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case authorizationPendingException(message: String?)
-    case expiredTokenException(message: String?)
-    case internalServerException(message: String?)
-    case invalidClientException(message: String?)
-    case invalidClientMetadataException(message: String?)
-    case invalidGrantException(message: String?)
-    case invalidRequestException(message: String?)
-    case invalidScopeException(message: String?)
-    case slowDownException(message: String?)
-    case unauthorizedClientException(message: String?)
-    case unsupportedGrantTypeException(message: String?)
-}
+public struct SSOOIDCErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case authorizationPendingException = "AuthorizationPendingException"
+        case expiredTokenException = "ExpiredTokenException"
+        case internalServerException = "InternalServerException"
+        case invalidClientException = "InvalidClientException"
+        case invalidClientMetadataException = "InvalidClientMetadataException"
+        case invalidGrantException = "InvalidGrantException"
+        case invalidRequestException = "InvalidRequestException"
+        case invalidScopeException = "InvalidScopeException"
+        case slowDownException = "SlowDownException"
+        case unauthorizedClientException = "UnauthorizedClientException"
+        case unsupportedGrantTypeException = "UnsupportedGrantTypeException"
+    }
 
-extension SSOOIDCErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "AuthorizationPendingException":
-            self = .authorizationPendingException(message: message)
-        case "ExpiredTokenException":
-            self = .expiredTokenException(message: message)
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "InvalidClientException":
-            self = .invalidClientException(message: message)
-        case "InvalidClientMetadataException":
-            self = .invalidClientMetadataException(message: message)
-        case "InvalidGrantException":
-            self = .invalidGrantException(message: message)
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        case "InvalidScopeException":
-            self = .invalidScopeException(message: message)
-        case "SlowDownException":
-            self = .slowDownException(message: message)
-        case "UnauthorizedClientException":
-            self = .unauthorizedClientException(message: message)
-        case "UnsupportedGrantTypeException":
-            self = .unsupportedGrantTypeException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var authorizationPendingException: Self { .init(.authorizationPendingException) }
+    public static var expiredTokenException: Self { .init(.expiredTokenException) }
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var invalidClientException: Self { .init(.invalidClientException) }
+    public static var invalidClientMetadataException: Self { .init(.invalidClientMetadataException) }
+    public static var invalidGrantException: Self { .init(.invalidGrantException) }
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+    public static var invalidScopeException: Self { .init(.invalidScopeException) }
+    public static var slowDownException: Self { .init(.slowDownException) }
+    public static var unauthorizedClientException: Self { .init(.unauthorizedClientException) }
+    public static var unsupportedGrantTypeException: Self { .init(.unsupportedGrantTypeException) }
+}
+
+extension SSOOIDCErrorType: Equatable {
+    public static func == (lhs: SSOOIDCErrorType, rhs: SSOOIDCErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension SSOOIDCErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .authorizationPendingException(let message):
-            return "AuthorizationPendingException: \(message ?? "")"
-        case .expiredTokenException(let message):
-            return "ExpiredTokenException: \(message ?? "")"
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .invalidClientException(let message):
-            return "InvalidClientException: \(message ?? "")"
-        case .invalidClientMetadataException(let message):
-            return "InvalidClientMetadataException: \(message ?? "")"
-        case .invalidGrantException(let message):
-            return "InvalidGrantException: \(message ?? "")"
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        case .invalidScopeException(let message):
-            return "InvalidScopeException: \(message ?? "")"
-        case .slowDownException(let message):
-            return "SlowDownException: \(message ?? "")"
-        case .unauthorizedClientException(let message):
-            return "UnauthorizedClientException: \(message ?? "")"
-        case .unsupportedGrantTypeException(let message):
-            return "UnsupportedGrantTypeException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/STS/STS_Error.swift
+++ b/Sources/Soto/Services/STS/STS_Error.swift
@@ -17,65 +17,54 @@
 import SotoCore
 
 /// Error enum for STS
-public enum STSErrorType: AWSErrorType {
-    case expiredTokenException(message: String?)
-    case iDPCommunicationErrorException(message: String?)
-    case iDPRejectedClaimException(message: String?)
-    case invalidAuthorizationMessageException(message: String?)
-    case invalidIdentityTokenException(message: String?)
-    case malformedPolicyDocumentException(message: String?)
-    case packedPolicyTooLargeException(message: String?)
-    case regionDisabledException(message: String?)
-}
+public struct STSErrorType: AWSErrorType {
+    enum Code: String {
+        case expiredTokenException = "ExpiredTokenException"
+        case iDPCommunicationErrorException = "IDPCommunicationError"
+        case iDPRejectedClaimException = "IDPRejectedClaim"
+        case invalidAuthorizationMessageException = "InvalidAuthorizationMessageException"
+        case invalidIdentityTokenException = "InvalidIdentityToken"
+        case malformedPolicyDocumentException = "MalformedPolicyDocument"
+        case packedPolicyTooLargeException = "PackedPolicyTooLarge"
+        case regionDisabledException = "RegionDisabledException"
+    }
 
-extension STSErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ExpiredTokenException":
-            self = .expiredTokenException(message: message)
-        case "IDPCommunicationError":
-            self = .iDPCommunicationErrorException(message: message)
-        case "IDPRejectedClaim":
-            self = .iDPRejectedClaimException(message: message)
-        case "InvalidAuthorizationMessageException":
-            self = .invalidAuthorizationMessageException(message: message)
-        case "InvalidIdentityToken":
-            self = .invalidIdentityTokenException(message: message)
-        case "MalformedPolicyDocument":
-            self = .malformedPolicyDocumentException(message: message)
-        case "PackedPolicyTooLarge":
-            self = .packedPolicyTooLargeException(message: message)
-        case "RegionDisabledException":
-            self = .regionDisabledException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var expiredTokenException: Self { .init(.expiredTokenException) }
+    public static var iDPCommunicationErrorException: Self { .init(.iDPCommunicationErrorException) }
+    public static var iDPRejectedClaimException: Self { .init(.iDPRejectedClaimException) }
+    public static var invalidAuthorizationMessageException: Self { .init(.invalidAuthorizationMessageException) }
+    public static var invalidIdentityTokenException: Self { .init(.invalidIdentityTokenException) }
+    public static var malformedPolicyDocumentException: Self { .init(.malformedPolicyDocumentException) }
+    public static var packedPolicyTooLargeException: Self { .init(.packedPolicyTooLargeException) }
+    public static var regionDisabledException: Self { .init(.regionDisabledException) }
+}
+
+extension STSErrorType: Equatable {
+    public static func == (lhs: STSErrorType, rhs: STSErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension STSErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .expiredTokenException(let message):
-            return "ExpiredTokenException: \(message ?? "")"
-        case .iDPCommunicationErrorException(let message):
-            return "IDPCommunicationError: \(message ?? "")"
-        case .iDPRejectedClaimException(let message):
-            return "IDPRejectedClaim: \(message ?? "")"
-        case .invalidAuthorizationMessageException(let message):
-            return "InvalidAuthorizationMessageException: \(message ?? "")"
-        case .invalidIdentityTokenException(let message):
-            return "InvalidIdentityToken: \(message ?? "")"
-        case .malformedPolicyDocumentException(let message):
-            return "MalformedPolicyDocument: \(message ?? "")"
-        case .packedPolicyTooLargeException(let message):
-            return "PackedPolicyTooLarge: \(message ?? "")"
-        case .regionDisabledException(let message):
-            return "RegionDisabledException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/SWF/SWF_Error.swift
+++ b/Sources/Soto/Services/SWF/SWF_Error.swift
@@ -17,75 +17,58 @@
 import SotoCore
 
 /// Error enum for SWF
-public enum SWFErrorType: AWSErrorType {
-    case defaultUndefinedFault(message: String?)
-    case domainAlreadyExistsFault(message: String?)
-    case domainDeprecatedFault(message: String?)
-    case limitExceededFault(message: String?)
-    case operationNotPermittedFault(message: String?)
-    case tooManyTagsFault(message: String?)
-    case typeAlreadyExistsFault(message: String?)
-    case typeDeprecatedFault(message: String?)
-    case unknownResourceFault(message: String?)
-    case workflowExecutionAlreadyStartedFault(message: String?)
-}
+public struct SWFErrorType: AWSErrorType {
+    enum Code: String {
+        case defaultUndefinedFault = "DefaultUndefinedFault"
+        case domainAlreadyExistsFault = "DomainAlreadyExistsFault"
+        case domainDeprecatedFault = "DomainDeprecatedFault"
+        case limitExceededFault = "LimitExceededFault"
+        case operationNotPermittedFault = "OperationNotPermittedFault"
+        case tooManyTagsFault = "TooManyTagsFault"
+        case typeAlreadyExistsFault = "TypeAlreadyExistsFault"
+        case typeDeprecatedFault = "TypeDeprecatedFault"
+        case unknownResourceFault = "UnknownResourceFault"
+        case workflowExecutionAlreadyStartedFault = "WorkflowExecutionAlreadyStartedFault"
+    }
 
-extension SWFErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "DefaultUndefinedFault":
-            self = .defaultUndefinedFault(message: message)
-        case "DomainAlreadyExistsFault":
-            self = .domainAlreadyExistsFault(message: message)
-        case "DomainDeprecatedFault":
-            self = .domainDeprecatedFault(message: message)
-        case "LimitExceededFault":
-            self = .limitExceededFault(message: message)
-        case "OperationNotPermittedFault":
-            self = .operationNotPermittedFault(message: message)
-        case "TooManyTagsFault":
-            self = .tooManyTagsFault(message: message)
-        case "TypeAlreadyExistsFault":
-            self = .typeAlreadyExistsFault(message: message)
-        case "TypeDeprecatedFault":
-            self = .typeDeprecatedFault(message: message)
-        case "UnknownResourceFault":
-            self = .unknownResourceFault(message: message)
-        case "WorkflowExecutionAlreadyStartedFault":
-            self = .workflowExecutionAlreadyStartedFault(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var defaultUndefinedFault: Self { .init(.defaultUndefinedFault) }
+    public static var domainAlreadyExistsFault: Self { .init(.domainAlreadyExistsFault) }
+    public static var domainDeprecatedFault: Self { .init(.domainDeprecatedFault) }
+    public static var limitExceededFault: Self { .init(.limitExceededFault) }
+    public static var operationNotPermittedFault: Self { .init(.operationNotPermittedFault) }
+    public static var tooManyTagsFault: Self { .init(.tooManyTagsFault) }
+    public static var typeAlreadyExistsFault: Self { .init(.typeAlreadyExistsFault) }
+    public static var typeDeprecatedFault: Self { .init(.typeDeprecatedFault) }
+    public static var unknownResourceFault: Self { .init(.unknownResourceFault) }
+    public static var workflowExecutionAlreadyStartedFault: Self { .init(.workflowExecutionAlreadyStartedFault) }
+}
+
+extension SWFErrorType: Equatable {
+    public static func == (lhs: SWFErrorType, rhs: SWFErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension SWFErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .defaultUndefinedFault(let message):
-            return "DefaultUndefinedFault: \(message ?? "")"
-        case .domainAlreadyExistsFault(let message):
-            return "DomainAlreadyExistsFault: \(message ?? "")"
-        case .domainDeprecatedFault(let message):
-            return "DomainDeprecatedFault: \(message ?? "")"
-        case .limitExceededFault(let message):
-            return "LimitExceededFault: \(message ?? "")"
-        case .operationNotPermittedFault(let message):
-            return "OperationNotPermittedFault: \(message ?? "")"
-        case .tooManyTagsFault(let message):
-            return "TooManyTagsFault: \(message ?? "")"
-        case .typeAlreadyExistsFault(let message):
-            return "TypeAlreadyExistsFault: \(message ?? "")"
-        case .typeDeprecatedFault(let message):
-            return "TypeDeprecatedFault: \(message ?? "")"
-        case .unknownResourceFault(let message):
-            return "UnknownResourceFault: \(message ?? "")"
-        case .workflowExecutionAlreadyStartedFault(let message):
-            return "WorkflowExecutionAlreadyStartedFault: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/SageMaker/SageMaker_Error.swift
+++ b/Sources/Soto/Services/SageMaker/SageMaker_Error.swift
@@ -17,45 +17,46 @@
 import SotoCore
 
 /// Error enum for SageMaker
-public enum SageMakerErrorType: AWSErrorType {
-    case conflictException(message: String?)
-    case resourceInUse(message: String?)
-    case resourceLimitExceeded(message: String?)
-    case resourceNotFound(message: String?)
-}
+public struct SageMakerErrorType: AWSErrorType {
+    enum Code: String {
+        case conflictException = "ConflictException"
+        case resourceInUse = "ResourceInUse"
+        case resourceLimitExceeded = "ResourceLimitExceeded"
+        case resourceNotFound = "ResourceNotFound"
+    }
 
-extension SageMakerErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "ResourceInUse":
-            self = .resourceInUse(message: message)
-        case "ResourceLimitExceeded":
-            self = .resourceLimitExceeded(message: message)
-        case "ResourceNotFound":
-            self = .resourceNotFound(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var resourceInUse: Self { .init(.resourceInUse) }
+    public static var resourceLimitExceeded: Self { .init(.resourceLimitExceeded) }
+    public static var resourceNotFound: Self { .init(.resourceNotFound) }
+}
+
+extension SageMakerErrorType: Equatable {
+    public static func == (lhs: SageMakerErrorType, rhs: SageMakerErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension SageMakerErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .resourceInUse(let message):
-            return "ResourceInUse: \(message ?? "")"
-        case .resourceLimitExceeded(let message):
-            return "ResourceLimitExceeded: \(message ?? "")"
-        case .resourceNotFound(let message):
-            return "ResourceNotFound: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/SageMakerRuntime/SageMakerRuntime_Error.swift
+++ b/Sources/Soto/Services/SageMakerRuntime/SageMakerRuntime_Error.swift
@@ -17,45 +17,46 @@
 import SotoCore
 
 /// Error enum for SageMakerRuntime
-public enum SageMakerRuntimeErrorType: AWSErrorType {
-    case internalFailure(message: String?)
-    case modelError(message: String?)
-    case serviceUnavailable(message: String?)
-    case validationError(message: String?)
-}
+public struct SageMakerRuntimeErrorType: AWSErrorType {
+    enum Code: String {
+        case internalFailure = "InternalFailure"
+        case modelError = "ModelError"
+        case serviceUnavailable = "ServiceUnavailable"
+        case validationError = "ValidationError"
+    }
 
-extension SageMakerRuntimeErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "InternalFailure":
-            self = .internalFailure(message: message)
-        case "ModelError":
-            self = .modelError(message: message)
-        case "ServiceUnavailable":
-            self = .serviceUnavailable(message: message)
-        case "ValidationError":
-            self = .validationError(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var internalFailure: Self { .init(.internalFailure) }
+    public static var modelError: Self { .init(.modelError) }
+    public static var serviceUnavailable: Self { .init(.serviceUnavailable) }
+    public static var validationError: Self { .init(.validationError) }
+}
+
+extension SageMakerRuntimeErrorType: Equatable {
+    public static func == (lhs: SageMakerRuntimeErrorType, rhs: SageMakerRuntimeErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension SageMakerRuntimeErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .internalFailure(let message):
-            return "InternalFailure: \(message ?? "")"
-        case .modelError(let message):
-            return "ModelError: \(message ?? "")"
-        case .serviceUnavailable(let message):
-            return "ServiceUnavailable: \(message ?? "")"
-        case .validationError(let message):
-            return "ValidationError: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/SavingsPlans/SavingsPlans_Error.swift
+++ b/Sources/Soto/Services/SavingsPlans/SavingsPlans_Error.swift
@@ -17,45 +17,46 @@
 import SotoCore
 
 /// Error enum for SavingsPlans
-public enum SavingsPlansErrorType: AWSErrorType {
-    case internalServerException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceQuotaExceededException(message: String?)
-    case validationException(message: String?)
-}
+public struct SavingsPlansErrorType: AWSErrorType {
+    enum Code: String {
+        case internalServerException = "InternalServerException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceQuotaExceededException = "ServiceQuotaExceededException"
+        case validationException = "ValidationException"
+    }
 
-extension SavingsPlansErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceQuotaExceededException":
-            self = .serviceQuotaExceededException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceQuotaExceededException: Self { .init(.serviceQuotaExceededException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension SavingsPlansErrorType: Equatable {
+    public static func == (lhs: SavingsPlansErrorType, rhs: SavingsPlansErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension SavingsPlansErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceQuotaExceededException(let message):
-            return "ServiceQuotaExceededException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Schemas/Schemas_Error.swift
+++ b/Sources/Soto/Services/Schemas/Schemas_Error.swift
@@ -17,75 +17,58 @@
 import SotoCore
 
 /// Error enum for Schemas
-public enum SchemasErrorType: AWSErrorType {
-    case badRequestException(message: String?)
-    case conflictException(message: String?)
-    case forbiddenException(message: String?)
-    case goneException(message: String?)
-    case internalServerErrorException(message: String?)
-    case notFoundException(message: String?)
-    case preconditionFailedException(message: String?)
-    case serviceUnavailableException(message: String?)
-    case tooManyRequestsException(message: String?)
-    case unauthorizedException(message: String?)
-}
+public struct SchemasErrorType: AWSErrorType {
+    enum Code: String {
+        case badRequestException = "BadRequestException"
+        case conflictException = "ConflictException"
+        case forbiddenException = "ForbiddenException"
+        case goneException = "GoneException"
+        case internalServerErrorException = "InternalServerErrorException"
+        case notFoundException = "NotFoundException"
+        case preconditionFailedException = "PreconditionFailedException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+        case tooManyRequestsException = "TooManyRequestsException"
+        case unauthorizedException = "UnauthorizedException"
+    }
 
-extension SchemasErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "ForbiddenException":
-            self = .forbiddenException(message: message)
-        case "GoneException":
-            self = .goneException(message: message)
-        case "InternalServerErrorException":
-            self = .internalServerErrorException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "PreconditionFailedException":
-            self = .preconditionFailedException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        case "TooManyRequestsException":
-            self = .tooManyRequestsException(message: message)
-        case "UnauthorizedException":
-            self = .unauthorizedException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var badRequestException: Self { .init(.badRequestException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var forbiddenException: Self { .init(.forbiddenException) }
+    public static var goneException: Self { .init(.goneException) }
+    public static var internalServerErrorException: Self { .init(.internalServerErrorException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var preconditionFailedException: Self { .init(.preconditionFailedException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+    public static var tooManyRequestsException: Self { .init(.tooManyRequestsException) }
+    public static var unauthorizedException: Self { .init(.unauthorizedException) }
+}
+
+extension SchemasErrorType: Equatable {
+    public static func == (lhs: SchemasErrorType, rhs: SchemasErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension SchemasErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .forbiddenException(let message):
-            return "ForbiddenException: \(message ?? "")"
-        case .goneException(let message):
-            return "GoneException: \(message ?? "")"
-        case .internalServerErrorException(let message):
-            return "InternalServerErrorException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .preconditionFailedException(let message):
-            return "PreconditionFailedException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        case .tooManyRequestsException(let message):
-            return "TooManyRequestsException: \(message ?? "")"
-        case .unauthorizedException(let message):
-            return "UnauthorizedException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/SecretsManager/SecretsManager_Error.swift
+++ b/Sources/Soto/Services/SecretsManager/SecretsManager_Error.swift
@@ -17,85 +17,62 @@
 import SotoCore
 
 /// Error enum for SecretsManager
-public enum SecretsManagerErrorType: AWSErrorType {
-    case decryptionFailure(message: String?)
-    case encryptionFailure(message: String?)
-    case internalServiceError(message: String?)
-    case invalidNextTokenException(message: String?)
-    case invalidParameterException(message: String?)
-    case invalidRequestException(message: String?)
-    case limitExceededException(message: String?)
-    case malformedPolicyDocumentException(message: String?)
-    case preconditionNotMetException(message: String?)
-    case publicPolicyException(message: String?)
-    case resourceExistsException(message: String?)
-    case resourceNotFoundException(message: String?)
-}
+public struct SecretsManagerErrorType: AWSErrorType {
+    enum Code: String {
+        case decryptionFailure = "DecryptionFailure"
+        case encryptionFailure = "EncryptionFailure"
+        case internalServiceError = "InternalServiceError"
+        case invalidNextTokenException = "InvalidNextTokenException"
+        case invalidParameterException = "InvalidParameterException"
+        case invalidRequestException = "InvalidRequestException"
+        case limitExceededException = "LimitExceededException"
+        case malformedPolicyDocumentException = "MalformedPolicyDocumentException"
+        case preconditionNotMetException = "PreconditionNotMetException"
+        case publicPolicyException = "PublicPolicyException"
+        case resourceExistsException = "ResourceExistsException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+    }
 
-extension SecretsManagerErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "DecryptionFailure":
-            self = .decryptionFailure(message: message)
-        case "EncryptionFailure":
-            self = .encryptionFailure(message: message)
-        case "InternalServiceError":
-            self = .internalServiceError(message: message)
-        case "InvalidNextTokenException":
-            self = .invalidNextTokenException(message: message)
-        case "InvalidParameterException":
-            self = .invalidParameterException(message: message)
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "MalformedPolicyDocumentException":
-            self = .malformedPolicyDocumentException(message: message)
-        case "PreconditionNotMetException":
-            self = .preconditionNotMetException(message: message)
-        case "PublicPolicyException":
-            self = .publicPolicyException(message: message)
-        case "ResourceExistsException":
-            self = .resourceExistsException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var decryptionFailure: Self { .init(.decryptionFailure) }
+    public static var encryptionFailure: Self { .init(.encryptionFailure) }
+    public static var internalServiceError: Self { .init(.internalServiceError) }
+    public static var invalidNextTokenException: Self { .init(.invalidNextTokenException) }
+    public static var invalidParameterException: Self { .init(.invalidParameterException) }
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var malformedPolicyDocumentException: Self { .init(.malformedPolicyDocumentException) }
+    public static var preconditionNotMetException: Self { .init(.preconditionNotMetException) }
+    public static var publicPolicyException: Self { .init(.publicPolicyException) }
+    public static var resourceExistsException: Self { .init(.resourceExistsException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+}
+
+extension SecretsManagerErrorType: Equatable {
+    public static func == (lhs: SecretsManagerErrorType, rhs: SecretsManagerErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension SecretsManagerErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .decryptionFailure(let message):
-            return "DecryptionFailure: \(message ?? "")"
-        case .encryptionFailure(let message):
-            return "EncryptionFailure: \(message ?? "")"
-        case .internalServiceError(let message):
-            return "InternalServiceError: \(message ?? "")"
-        case .invalidNextTokenException(let message):
-            return "InvalidNextTokenException: \(message ?? "")"
-        case .invalidParameterException(let message):
-            return "InvalidParameterException: \(message ?? "")"
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .malformedPolicyDocumentException(let message):
-            return "MalformedPolicyDocumentException: \(message ?? "")"
-        case .preconditionNotMetException(let message):
-            return "PreconditionNotMetException: \(message ?? "")"
-        case .publicPolicyException(let message):
-            return "PublicPolicyException: \(message ?? "")"
-        case .resourceExistsException(let message):
-            return "ResourceExistsException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/SecurityHub/SecurityHub_Error.swift
+++ b/Sources/Soto/Services/SecurityHub/SecurityHub_Error.swift
@@ -17,60 +17,52 @@
 import SotoCore
 
 /// Error enum for SecurityHub
-public enum SecurityHubErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case internalException(message: String?)
-    case invalidAccessException(message: String?)
-    case invalidInputException(message: String?)
-    case limitExceededException(message: String?)
-    case resourceConflictException(message: String?)
-    case resourceNotFoundException(message: String?)
-}
+public struct SecurityHubErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case internalException = "InternalException"
+        case invalidAccessException = "InvalidAccessException"
+        case invalidInputException = "InvalidInputException"
+        case limitExceededException = "LimitExceededException"
+        case resourceConflictException = "ResourceConflictException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+    }
 
-extension SecurityHubErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "InternalException":
-            self = .internalException(message: message)
-        case "InvalidAccessException":
-            self = .invalidAccessException(message: message)
-        case "InvalidInputException":
-            self = .invalidInputException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ResourceConflictException":
-            self = .resourceConflictException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var internalException: Self { .init(.internalException) }
+    public static var invalidAccessException: Self { .init(.invalidAccessException) }
+    public static var invalidInputException: Self { .init(.invalidInputException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var resourceConflictException: Self { .init(.resourceConflictException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+}
+
+extension SecurityHubErrorType: Equatable {
+    public static func == (lhs: SecurityHubErrorType, rhs: SecurityHubErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension SecurityHubErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .internalException(let message):
-            return "InternalException: \(message ?? "")"
-        case .invalidAccessException(let message):
-            return "InvalidAccessException: \(message ?? "")"
-        case .invalidInputException(let message):
-            return "InvalidInputException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .resourceConflictException(let message):
-            return "ResourceConflictException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/ServerlessApplicationRepository/ServerlessApplicationRepository_Error.swift
+++ b/Sources/Soto/Services/ServerlessApplicationRepository/ServerlessApplicationRepository_Error.swift
@@ -17,55 +17,50 @@
 import SotoCore
 
 /// Error enum for ServerlessApplicationRepository
-public enum ServerlessApplicationRepositoryErrorType: AWSErrorType {
-    case badRequestException(message: String?)
-    case conflictException(message: String?)
-    case forbiddenException(message: String?)
-    case internalServerErrorException(message: String?)
-    case notFoundException(message: String?)
-    case tooManyRequestsException(message: String?)
-}
+public struct ServerlessApplicationRepositoryErrorType: AWSErrorType {
+    enum Code: String {
+        case badRequestException = "BadRequestException"
+        case conflictException = "ConflictException"
+        case forbiddenException = "ForbiddenException"
+        case internalServerErrorException = "InternalServerErrorException"
+        case notFoundException = "NotFoundException"
+        case tooManyRequestsException = "TooManyRequestsException"
+    }
 
-extension ServerlessApplicationRepositoryErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "ForbiddenException":
-            self = .forbiddenException(message: message)
-        case "InternalServerErrorException":
-            self = .internalServerErrorException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "TooManyRequestsException":
-            self = .tooManyRequestsException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var badRequestException: Self { .init(.badRequestException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var forbiddenException: Self { .init(.forbiddenException) }
+    public static var internalServerErrorException: Self { .init(.internalServerErrorException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var tooManyRequestsException: Self { .init(.tooManyRequestsException) }
+}
+
+extension ServerlessApplicationRepositoryErrorType: Equatable {
+    public static func == (lhs: ServerlessApplicationRepositoryErrorType, rhs: ServerlessApplicationRepositoryErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ServerlessApplicationRepositoryErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .forbiddenException(let message):
-            return "ForbiddenException: \(message ?? "")"
-        case .internalServerErrorException(let message):
-            return "InternalServerErrorException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .tooManyRequestsException(let message):
-            return "TooManyRequestsException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/ServiceCatalog/ServiceCatalog_Error.swift
+++ b/Sources/Soto/Services/ServiceCatalog/ServiceCatalog_Error.swift
@@ -17,65 +17,54 @@
 import SotoCore
 
 /// Error enum for ServiceCatalog
-public enum ServiceCatalogErrorType: AWSErrorType {
-    case duplicateResourceException(message: String?)
-    case invalidParametersException(message: String?)
-    case invalidStateException(message: String?)
-    case limitExceededException(message: String?)
-    case operationNotSupportedException(message: String?)
-    case resourceInUseException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case tagOptionNotMigratedException(message: String?)
-}
+public struct ServiceCatalogErrorType: AWSErrorType {
+    enum Code: String {
+        case duplicateResourceException = "DuplicateResourceException"
+        case invalidParametersException = "InvalidParametersException"
+        case invalidStateException = "InvalidStateException"
+        case limitExceededException = "LimitExceededException"
+        case operationNotSupportedException = "OperationNotSupportedException"
+        case resourceInUseException = "ResourceInUseException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case tagOptionNotMigratedException = "TagOptionNotMigratedException"
+    }
 
-extension ServiceCatalogErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "DuplicateResourceException":
-            self = .duplicateResourceException(message: message)
-        case "InvalidParametersException":
-            self = .invalidParametersException(message: message)
-        case "InvalidStateException":
-            self = .invalidStateException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "OperationNotSupportedException":
-            self = .operationNotSupportedException(message: message)
-        case "ResourceInUseException":
-            self = .resourceInUseException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "TagOptionNotMigratedException":
-            self = .tagOptionNotMigratedException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var duplicateResourceException: Self { .init(.duplicateResourceException) }
+    public static var invalidParametersException: Self { .init(.invalidParametersException) }
+    public static var invalidStateException: Self { .init(.invalidStateException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var operationNotSupportedException: Self { .init(.operationNotSupportedException) }
+    public static var resourceInUseException: Self { .init(.resourceInUseException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var tagOptionNotMigratedException: Self { .init(.tagOptionNotMigratedException) }
+}
+
+extension ServiceCatalogErrorType: Equatable {
+    public static func == (lhs: ServiceCatalogErrorType, rhs: ServiceCatalogErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ServiceCatalogErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .duplicateResourceException(let message):
-            return "DuplicateResourceException: \(message ?? "")"
-        case .invalidParametersException(let message):
-            return "InvalidParametersException: \(message ?? "")"
-        case .invalidStateException(let message):
-            return "InvalidStateException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .operationNotSupportedException(let message):
-            return "OperationNotSupportedException: \(message ?? "")"
-        case .resourceInUseException(let message):
-            return "ResourceInUseException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .tagOptionNotMigratedException(let message):
-            return "TagOptionNotMigratedException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/ServiceDiscovery/ServiceDiscovery_Error.swift
+++ b/Sources/Soto/Services/ServiceDiscovery/ServiceDiscovery_Error.swift
@@ -17,95 +17,66 @@
 import SotoCore
 
 /// Error enum for ServiceDiscovery
-public enum ServiceDiscoveryErrorType: AWSErrorType {
-    case customHealthNotFound(message: String?)
-    case duplicateRequest(message: String?)
-    case instanceNotFound(message: String?)
-    case invalidInput(message: String?)
-    case namespaceAlreadyExists(message: String?)
-    case namespaceNotFound(message: String?)
-    case operationNotFound(message: String?)
-    case requestLimitExceeded(message: String?)
-    case resourceInUse(message: String?)
-    case resourceLimitExceeded(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceAlreadyExists(message: String?)
-    case serviceNotFound(message: String?)
-    case tooManyTagsException(message: String?)
-}
+public struct ServiceDiscoveryErrorType: AWSErrorType {
+    enum Code: String {
+        case customHealthNotFound = "CustomHealthNotFound"
+        case duplicateRequest = "DuplicateRequest"
+        case instanceNotFound = "InstanceNotFound"
+        case invalidInput = "InvalidInput"
+        case namespaceAlreadyExists = "NamespaceAlreadyExists"
+        case namespaceNotFound = "NamespaceNotFound"
+        case operationNotFound = "OperationNotFound"
+        case requestLimitExceeded = "RequestLimitExceeded"
+        case resourceInUse = "ResourceInUse"
+        case resourceLimitExceeded = "ResourceLimitExceeded"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceAlreadyExists = "ServiceAlreadyExists"
+        case serviceNotFound = "ServiceNotFound"
+        case tooManyTagsException = "TooManyTagsException"
+    }
 
-extension ServiceDiscoveryErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "CustomHealthNotFound":
-            self = .customHealthNotFound(message: message)
-        case "DuplicateRequest":
-            self = .duplicateRequest(message: message)
-        case "InstanceNotFound":
-            self = .instanceNotFound(message: message)
-        case "InvalidInput":
-            self = .invalidInput(message: message)
-        case "NamespaceAlreadyExists":
-            self = .namespaceAlreadyExists(message: message)
-        case "NamespaceNotFound":
-            self = .namespaceNotFound(message: message)
-        case "OperationNotFound":
-            self = .operationNotFound(message: message)
-        case "RequestLimitExceeded":
-            self = .requestLimitExceeded(message: message)
-        case "ResourceInUse":
-            self = .resourceInUse(message: message)
-        case "ResourceLimitExceeded":
-            self = .resourceLimitExceeded(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceAlreadyExists":
-            self = .serviceAlreadyExists(message: message)
-        case "ServiceNotFound":
-            self = .serviceNotFound(message: message)
-        case "TooManyTagsException":
-            self = .tooManyTagsException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var customHealthNotFound: Self { .init(.customHealthNotFound) }
+    public static var duplicateRequest: Self { .init(.duplicateRequest) }
+    public static var instanceNotFound: Self { .init(.instanceNotFound) }
+    public static var invalidInput: Self { .init(.invalidInput) }
+    public static var namespaceAlreadyExists: Self { .init(.namespaceAlreadyExists) }
+    public static var namespaceNotFound: Self { .init(.namespaceNotFound) }
+    public static var operationNotFound: Self { .init(.operationNotFound) }
+    public static var requestLimitExceeded: Self { .init(.requestLimitExceeded) }
+    public static var resourceInUse: Self { .init(.resourceInUse) }
+    public static var resourceLimitExceeded: Self { .init(.resourceLimitExceeded) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceAlreadyExists: Self { .init(.serviceAlreadyExists) }
+    public static var serviceNotFound: Self { .init(.serviceNotFound) }
+    public static var tooManyTagsException: Self { .init(.tooManyTagsException) }
+}
+
+extension ServiceDiscoveryErrorType: Equatable {
+    public static func == (lhs: ServiceDiscoveryErrorType, rhs: ServiceDiscoveryErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ServiceDiscoveryErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .customHealthNotFound(let message):
-            return "CustomHealthNotFound: \(message ?? "")"
-        case .duplicateRequest(let message):
-            return "DuplicateRequest: \(message ?? "")"
-        case .instanceNotFound(let message):
-            return "InstanceNotFound: \(message ?? "")"
-        case .invalidInput(let message):
-            return "InvalidInput: \(message ?? "")"
-        case .namespaceAlreadyExists(let message):
-            return "NamespaceAlreadyExists: \(message ?? "")"
-        case .namespaceNotFound(let message):
-            return "NamespaceNotFound: \(message ?? "")"
-        case .operationNotFound(let message):
-            return "OperationNotFound: \(message ?? "")"
-        case .requestLimitExceeded(let message):
-            return "RequestLimitExceeded: \(message ?? "")"
-        case .resourceInUse(let message):
-            return "ResourceInUse: \(message ?? "")"
-        case .resourceLimitExceeded(let message):
-            return "ResourceLimitExceeded: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceAlreadyExists(let message):
-            return "ServiceAlreadyExists: \(message ?? "")"
-        case .serviceNotFound(let message):
-            return "ServiceNotFound: \(message ?? "")"
-        case .tooManyTagsException(let message):
-            return "TooManyTagsException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/ServiceQuotas/ServiceQuotas_Error.swift
+++ b/Sources/Soto/Services/ServiceQuotas/ServiceQuotas_Error.swift
@@ -17,100 +17,68 @@
 import SotoCore
 
 /// Error enum for ServiceQuotas
-public enum ServiceQuotasErrorType: AWSErrorType {
-    case aWSServiceAccessNotEnabledException(message: String?)
-    case accessDeniedException(message: String?)
-    case dependencyAccessDeniedException(message: String?)
-    case illegalArgumentException(message: String?)
-    case invalidPaginationTokenException(message: String?)
-    case invalidResourceStateException(message: String?)
-    case noAvailableOrganizationException(message: String?)
-    case noSuchResourceException(message: String?)
-    case organizationNotInAllFeaturesModeException(message: String?)
-    case quotaExceededException(message: String?)
-    case resourceAlreadyExistsException(message: String?)
-    case serviceException(message: String?)
-    case serviceQuotaTemplateNotInUseException(message: String?)
-    case templatesNotAvailableInRegionException(message: String?)
-    case tooManyRequestsException(message: String?)
-}
+public struct ServiceQuotasErrorType: AWSErrorType {
+    enum Code: String {
+        case aWSServiceAccessNotEnabledException = "AWSServiceAccessNotEnabledException"
+        case accessDeniedException = "AccessDeniedException"
+        case dependencyAccessDeniedException = "DependencyAccessDeniedException"
+        case illegalArgumentException = "IllegalArgumentException"
+        case invalidPaginationTokenException = "InvalidPaginationTokenException"
+        case invalidResourceStateException = "InvalidResourceStateException"
+        case noAvailableOrganizationException = "NoAvailableOrganizationException"
+        case noSuchResourceException = "NoSuchResourceException"
+        case organizationNotInAllFeaturesModeException = "OrganizationNotInAllFeaturesModeException"
+        case quotaExceededException = "QuotaExceededException"
+        case resourceAlreadyExistsException = "ResourceAlreadyExistsException"
+        case serviceException = "ServiceException"
+        case serviceQuotaTemplateNotInUseException = "ServiceQuotaTemplateNotInUseException"
+        case templatesNotAvailableInRegionException = "TemplatesNotAvailableInRegionException"
+        case tooManyRequestsException = "TooManyRequestsException"
+    }
 
-extension ServiceQuotasErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AWSServiceAccessNotEnabledException":
-            self = .aWSServiceAccessNotEnabledException(message: message)
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "DependencyAccessDeniedException":
-            self = .dependencyAccessDeniedException(message: message)
-        case "IllegalArgumentException":
-            self = .illegalArgumentException(message: message)
-        case "InvalidPaginationTokenException":
-            self = .invalidPaginationTokenException(message: message)
-        case "InvalidResourceStateException":
-            self = .invalidResourceStateException(message: message)
-        case "NoAvailableOrganizationException":
-            self = .noAvailableOrganizationException(message: message)
-        case "NoSuchResourceException":
-            self = .noSuchResourceException(message: message)
-        case "OrganizationNotInAllFeaturesModeException":
-            self = .organizationNotInAllFeaturesModeException(message: message)
-        case "QuotaExceededException":
-            self = .quotaExceededException(message: message)
-        case "ResourceAlreadyExistsException":
-            self = .resourceAlreadyExistsException(message: message)
-        case "ServiceException":
-            self = .serviceException(message: message)
-        case "ServiceQuotaTemplateNotInUseException":
-            self = .serviceQuotaTemplateNotInUseException(message: message)
-        case "TemplatesNotAvailableInRegionException":
-            self = .templatesNotAvailableInRegionException(message: message)
-        case "TooManyRequestsException":
-            self = .tooManyRequestsException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var aWSServiceAccessNotEnabledException: Self { .init(.aWSServiceAccessNotEnabledException) }
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var dependencyAccessDeniedException: Self { .init(.dependencyAccessDeniedException) }
+    public static var illegalArgumentException: Self { .init(.illegalArgumentException) }
+    public static var invalidPaginationTokenException: Self { .init(.invalidPaginationTokenException) }
+    public static var invalidResourceStateException: Self { .init(.invalidResourceStateException) }
+    public static var noAvailableOrganizationException: Self { .init(.noAvailableOrganizationException) }
+    public static var noSuchResourceException: Self { .init(.noSuchResourceException) }
+    public static var organizationNotInAllFeaturesModeException: Self { .init(.organizationNotInAllFeaturesModeException) }
+    public static var quotaExceededException: Self { .init(.quotaExceededException) }
+    public static var resourceAlreadyExistsException: Self { .init(.resourceAlreadyExistsException) }
+    public static var serviceException: Self { .init(.serviceException) }
+    public static var serviceQuotaTemplateNotInUseException: Self { .init(.serviceQuotaTemplateNotInUseException) }
+    public static var templatesNotAvailableInRegionException: Self { .init(.templatesNotAvailableInRegionException) }
+    public static var tooManyRequestsException: Self { .init(.tooManyRequestsException) }
+}
+
+extension ServiceQuotasErrorType: Equatable {
+    public static func == (lhs: ServiceQuotasErrorType, rhs: ServiceQuotasErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ServiceQuotasErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .aWSServiceAccessNotEnabledException(let message):
-            return "AWSServiceAccessNotEnabledException: \(message ?? "")"
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .dependencyAccessDeniedException(let message):
-            return "DependencyAccessDeniedException: \(message ?? "")"
-        case .illegalArgumentException(let message):
-            return "IllegalArgumentException: \(message ?? "")"
-        case .invalidPaginationTokenException(let message):
-            return "InvalidPaginationTokenException: \(message ?? "")"
-        case .invalidResourceStateException(let message):
-            return "InvalidResourceStateException: \(message ?? "")"
-        case .noAvailableOrganizationException(let message):
-            return "NoAvailableOrganizationException: \(message ?? "")"
-        case .noSuchResourceException(let message):
-            return "NoSuchResourceException: \(message ?? "")"
-        case .organizationNotInAllFeaturesModeException(let message):
-            return "OrganizationNotInAllFeaturesModeException: \(message ?? "")"
-        case .quotaExceededException(let message):
-            return "QuotaExceededException: \(message ?? "")"
-        case .resourceAlreadyExistsException(let message):
-            return "ResourceAlreadyExistsException: \(message ?? "")"
-        case .serviceException(let message):
-            return "ServiceException: \(message ?? "")"
-        case .serviceQuotaTemplateNotInUseException(let message):
-            return "ServiceQuotaTemplateNotInUseException: \(message ?? "")"
-        case .templatesNotAvailableInRegionException(let message):
-            return "TemplatesNotAvailableInRegionException: \(message ?? "")"
-        case .tooManyRequestsException(let message):
-            return "TooManyRequestsException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Shield/Shield_Error.swift
+++ b/Sources/Soto/Services/Shield/Shield_Error.swift
@@ -17,90 +17,64 @@
 import SotoCore
 
 /// Error enum for Shield
-public enum ShieldErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case accessDeniedForDependencyException(message: String?)
-    case internalErrorException(message: String?)
-    case invalidOperationException(message: String?)
-    case invalidPaginationTokenException(message: String?)
-    case invalidParameterException(message: String?)
-    case invalidResourceException(message: String?)
-    case limitsExceededException(message: String?)
-    case lockedSubscriptionException(message: String?)
-    case noAssociatedRoleException(message: String?)
-    case optimisticLockException(message: String?)
-    case resourceAlreadyExistsException(message: String?)
-    case resourceNotFoundException(message: String?)
-}
+public struct ShieldErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case accessDeniedForDependencyException = "AccessDeniedForDependencyException"
+        case internalErrorException = "InternalErrorException"
+        case invalidOperationException = "InvalidOperationException"
+        case invalidPaginationTokenException = "InvalidPaginationTokenException"
+        case invalidParameterException = "InvalidParameterException"
+        case invalidResourceException = "InvalidResourceException"
+        case limitsExceededException = "LimitsExceededException"
+        case lockedSubscriptionException = "LockedSubscriptionException"
+        case noAssociatedRoleException = "NoAssociatedRoleException"
+        case optimisticLockException = "OptimisticLockException"
+        case resourceAlreadyExistsException = "ResourceAlreadyExistsException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+    }
 
-extension ShieldErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "AccessDeniedForDependencyException":
-            self = .accessDeniedForDependencyException(message: message)
-        case "InternalErrorException":
-            self = .internalErrorException(message: message)
-        case "InvalidOperationException":
-            self = .invalidOperationException(message: message)
-        case "InvalidPaginationTokenException":
-            self = .invalidPaginationTokenException(message: message)
-        case "InvalidParameterException":
-            self = .invalidParameterException(message: message)
-        case "InvalidResourceException":
-            self = .invalidResourceException(message: message)
-        case "LimitsExceededException":
-            self = .limitsExceededException(message: message)
-        case "LockedSubscriptionException":
-            self = .lockedSubscriptionException(message: message)
-        case "NoAssociatedRoleException":
-            self = .noAssociatedRoleException(message: message)
-        case "OptimisticLockException":
-            self = .optimisticLockException(message: message)
-        case "ResourceAlreadyExistsException":
-            self = .resourceAlreadyExistsException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var accessDeniedForDependencyException: Self { .init(.accessDeniedForDependencyException) }
+    public static var internalErrorException: Self { .init(.internalErrorException) }
+    public static var invalidOperationException: Self { .init(.invalidOperationException) }
+    public static var invalidPaginationTokenException: Self { .init(.invalidPaginationTokenException) }
+    public static var invalidParameterException: Self { .init(.invalidParameterException) }
+    public static var invalidResourceException: Self { .init(.invalidResourceException) }
+    public static var limitsExceededException: Self { .init(.limitsExceededException) }
+    public static var lockedSubscriptionException: Self { .init(.lockedSubscriptionException) }
+    public static var noAssociatedRoleException: Self { .init(.noAssociatedRoleException) }
+    public static var optimisticLockException: Self { .init(.optimisticLockException) }
+    public static var resourceAlreadyExistsException: Self { .init(.resourceAlreadyExistsException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+}
+
+extension ShieldErrorType: Equatable {
+    public static func == (lhs: ShieldErrorType, rhs: ShieldErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension ShieldErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .accessDeniedForDependencyException(let message):
-            return "AccessDeniedForDependencyException: \(message ?? "")"
-        case .internalErrorException(let message):
-            return "InternalErrorException: \(message ?? "")"
-        case .invalidOperationException(let message):
-            return "InvalidOperationException: \(message ?? "")"
-        case .invalidPaginationTokenException(let message):
-            return "InvalidPaginationTokenException: \(message ?? "")"
-        case .invalidParameterException(let message):
-            return "InvalidParameterException: \(message ?? "")"
-        case .invalidResourceException(let message):
-            return "InvalidResourceException: \(message ?? "")"
-        case .limitsExceededException(let message):
-            return "LimitsExceededException: \(message ?? "")"
-        case .lockedSubscriptionException(let message):
-            return "LockedSubscriptionException: \(message ?? "")"
-        case .noAssociatedRoleException(let message):
-            return "NoAssociatedRoleException: \(message ?? "")"
-        case .optimisticLockException(let message):
-            return "OptimisticLockException: \(message ?? "")"
-        case .resourceAlreadyExistsException(let message):
-            return "ResourceAlreadyExistsException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Signer/Signer_Error.swift
+++ b/Sources/Soto/Services/Signer/Signer_Error.swift
@@ -17,60 +17,52 @@
 import SotoCore
 
 /// Error enum for Signer
-public enum SignerErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case badRequestException(message: String?)
-    case internalServiceErrorException(message: String?)
-    case notFoundException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case throttlingException(message: String?)
-    case validationException(message: String?)
-}
+public struct SignerErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case badRequestException = "BadRequestException"
+        case internalServiceErrorException = "InternalServiceErrorException"
+        case notFoundException = "NotFoundException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case throttlingException = "ThrottlingException"
+        case validationException = "ValidationException"
+    }
 
-extension SignerErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        case "InternalServiceErrorException":
-            self = .internalServiceErrorException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var badRequestException: Self { .init(.badRequestException) }
+    public static var internalServiceErrorException: Self { .init(.internalServiceErrorException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension SignerErrorType: Equatable {
+    public static func == (lhs: SignerErrorType, rhs: SignerErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension SignerErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        case .internalServiceErrorException(let message):
-            return "InternalServiceErrorException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/SimpleDB/SimpleDB_Error.swift
+++ b/Sources/Soto/Services/SimpleDB/SimpleDB_Error.swift
@@ -17,110 +17,72 @@
 import SotoCore
 
 /// Error enum for SimpleDB
-public enum SimpleDBErrorType: AWSErrorType {
-    case attributeDoesNotExist(message: String?)
-    case duplicateItemName(message: String?)
-    case invalidNextToken(message: String?)
-    case invalidNumberPredicates(message: String?)
-    case invalidNumberValueTests(message: String?)
-    case invalidParameterValue(message: String?)
-    case invalidQueryExpression(message: String?)
-    case missingParameter(message: String?)
-    case noSuchDomain(message: String?)
-    case numberDomainAttributesExceeded(message: String?)
-    case numberDomainBytesExceeded(message: String?)
-    case numberDomainsExceeded(message: String?)
-    case numberItemAttributesExceeded(message: String?)
-    case numberSubmittedAttributesExceeded(message: String?)
-    case numberSubmittedItemsExceeded(message: String?)
-    case requestTimeout(message: String?)
-    case tooManyRequestedAttributes(message: String?)
-}
+public struct SimpleDBErrorType: AWSErrorType {
+    enum Code: String {
+        case attributeDoesNotExist = "AttributeDoesNotExist"
+        case duplicateItemName = "DuplicateItemName"
+        case invalidNextToken = "InvalidNextToken"
+        case invalidNumberPredicates = "InvalidNumberPredicates"
+        case invalidNumberValueTests = "InvalidNumberValueTests"
+        case invalidParameterValue = "InvalidParameterValue"
+        case invalidQueryExpression = "InvalidQueryExpression"
+        case missingParameter = "MissingParameter"
+        case noSuchDomain = "NoSuchDomain"
+        case numberDomainAttributesExceeded = "NumberDomainAttributesExceeded"
+        case numberDomainBytesExceeded = "NumberDomainBytesExceeded"
+        case numberDomainsExceeded = "NumberDomainsExceeded"
+        case numberItemAttributesExceeded = "NumberItemAttributesExceeded"
+        case numberSubmittedAttributesExceeded = "NumberSubmittedAttributesExceeded"
+        case numberSubmittedItemsExceeded = "NumberSubmittedItemsExceeded"
+        case requestTimeout = "RequestTimeout"
+        case tooManyRequestedAttributes = "TooManyRequestedAttributes"
+    }
 
-extension SimpleDBErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AttributeDoesNotExist":
-            self = .attributeDoesNotExist(message: message)
-        case "DuplicateItemName":
-            self = .duplicateItemName(message: message)
-        case "InvalidNextToken":
-            self = .invalidNextToken(message: message)
-        case "InvalidNumberPredicates":
-            self = .invalidNumberPredicates(message: message)
-        case "InvalidNumberValueTests":
-            self = .invalidNumberValueTests(message: message)
-        case "InvalidParameterValue":
-            self = .invalidParameterValue(message: message)
-        case "InvalidQueryExpression":
-            self = .invalidQueryExpression(message: message)
-        case "MissingParameter":
-            self = .missingParameter(message: message)
-        case "NoSuchDomain":
-            self = .noSuchDomain(message: message)
-        case "NumberDomainAttributesExceeded":
-            self = .numberDomainAttributesExceeded(message: message)
-        case "NumberDomainBytesExceeded":
-            self = .numberDomainBytesExceeded(message: message)
-        case "NumberDomainsExceeded":
-            self = .numberDomainsExceeded(message: message)
-        case "NumberItemAttributesExceeded":
-            self = .numberItemAttributesExceeded(message: message)
-        case "NumberSubmittedAttributesExceeded":
-            self = .numberSubmittedAttributesExceeded(message: message)
-        case "NumberSubmittedItemsExceeded":
-            self = .numberSubmittedItemsExceeded(message: message)
-        case "RequestTimeout":
-            self = .requestTimeout(message: message)
-        case "TooManyRequestedAttributes":
-            self = .tooManyRequestedAttributes(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var attributeDoesNotExist: Self { .init(.attributeDoesNotExist) }
+    public static var duplicateItemName: Self { .init(.duplicateItemName) }
+    public static var invalidNextToken: Self { .init(.invalidNextToken) }
+    public static var invalidNumberPredicates: Self { .init(.invalidNumberPredicates) }
+    public static var invalidNumberValueTests: Self { .init(.invalidNumberValueTests) }
+    public static var invalidParameterValue: Self { .init(.invalidParameterValue) }
+    public static var invalidQueryExpression: Self { .init(.invalidQueryExpression) }
+    public static var missingParameter: Self { .init(.missingParameter) }
+    public static var noSuchDomain: Self { .init(.noSuchDomain) }
+    public static var numberDomainAttributesExceeded: Self { .init(.numberDomainAttributesExceeded) }
+    public static var numberDomainBytesExceeded: Self { .init(.numberDomainBytesExceeded) }
+    public static var numberDomainsExceeded: Self { .init(.numberDomainsExceeded) }
+    public static var numberItemAttributesExceeded: Self { .init(.numberItemAttributesExceeded) }
+    public static var numberSubmittedAttributesExceeded: Self { .init(.numberSubmittedAttributesExceeded) }
+    public static var numberSubmittedItemsExceeded: Self { .init(.numberSubmittedItemsExceeded) }
+    public static var requestTimeout: Self { .init(.requestTimeout) }
+    public static var tooManyRequestedAttributes: Self { .init(.tooManyRequestedAttributes) }
+}
+
+extension SimpleDBErrorType: Equatable {
+    public static func == (lhs: SimpleDBErrorType, rhs: SimpleDBErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension SimpleDBErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .attributeDoesNotExist(let message):
-            return "AttributeDoesNotExist: \(message ?? "")"
-        case .duplicateItemName(let message):
-            return "DuplicateItemName: \(message ?? "")"
-        case .invalidNextToken(let message):
-            return "InvalidNextToken: \(message ?? "")"
-        case .invalidNumberPredicates(let message):
-            return "InvalidNumberPredicates: \(message ?? "")"
-        case .invalidNumberValueTests(let message):
-            return "InvalidNumberValueTests: \(message ?? "")"
-        case .invalidParameterValue(let message):
-            return "InvalidParameterValue: \(message ?? "")"
-        case .invalidQueryExpression(let message):
-            return "InvalidQueryExpression: \(message ?? "")"
-        case .missingParameter(let message):
-            return "MissingParameter: \(message ?? "")"
-        case .noSuchDomain(let message):
-            return "NoSuchDomain: \(message ?? "")"
-        case .numberDomainAttributesExceeded(let message):
-            return "NumberDomainAttributesExceeded: \(message ?? "")"
-        case .numberDomainBytesExceeded(let message):
-            return "NumberDomainBytesExceeded: \(message ?? "")"
-        case .numberDomainsExceeded(let message):
-            return "NumberDomainsExceeded: \(message ?? "")"
-        case .numberItemAttributesExceeded(let message):
-            return "NumberItemAttributesExceeded: \(message ?? "")"
-        case .numberSubmittedAttributesExceeded(let message):
-            return "NumberSubmittedAttributesExceeded: \(message ?? "")"
-        case .numberSubmittedItemsExceeded(let message):
-            return "NumberSubmittedItemsExceeded: \(message ?? "")"
-        case .requestTimeout(let message):
-            return "RequestTimeout: \(message ?? "")"
-        case .tooManyRequestedAttributes(let message):
-            return "TooManyRequestedAttributes: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Snowball/Snowball_Error.swift
+++ b/Sources/Soto/Services/Snowball/Snowball_Error.swift
@@ -17,70 +17,56 @@
 import SotoCore
 
 /// Error enum for Snowball
-public enum SnowballErrorType: AWSErrorType {
-    case clusterLimitExceededException(message: String?)
-    case ec2RequestFailedException(message: String?)
-    case invalidAddressException(message: String?)
-    case invalidInputCombinationException(message: String?)
-    case invalidJobStateException(message: String?)
-    case invalidNextTokenException(message: String?)
-    case invalidResourceException(message: String?)
-    case kMSRequestFailedException(message: String?)
-    case unsupportedAddressException(message: String?)
-}
+public struct SnowballErrorType: AWSErrorType {
+    enum Code: String {
+        case clusterLimitExceededException = "ClusterLimitExceededException"
+        case ec2RequestFailedException = "Ec2RequestFailedException"
+        case invalidAddressException = "InvalidAddressException"
+        case invalidInputCombinationException = "InvalidInputCombinationException"
+        case invalidJobStateException = "InvalidJobStateException"
+        case invalidNextTokenException = "InvalidNextTokenException"
+        case invalidResourceException = "InvalidResourceException"
+        case kMSRequestFailedException = "KMSRequestFailedException"
+        case unsupportedAddressException = "UnsupportedAddressException"
+    }
 
-extension SnowballErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ClusterLimitExceededException":
-            self = .clusterLimitExceededException(message: message)
-        case "Ec2RequestFailedException":
-            self = .ec2RequestFailedException(message: message)
-        case "InvalidAddressException":
-            self = .invalidAddressException(message: message)
-        case "InvalidInputCombinationException":
-            self = .invalidInputCombinationException(message: message)
-        case "InvalidJobStateException":
-            self = .invalidJobStateException(message: message)
-        case "InvalidNextTokenException":
-            self = .invalidNextTokenException(message: message)
-        case "InvalidResourceException":
-            self = .invalidResourceException(message: message)
-        case "KMSRequestFailedException":
-            self = .kMSRequestFailedException(message: message)
-        case "UnsupportedAddressException":
-            self = .unsupportedAddressException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var clusterLimitExceededException: Self { .init(.clusterLimitExceededException) }
+    public static var ec2RequestFailedException: Self { .init(.ec2RequestFailedException) }
+    public static var invalidAddressException: Self { .init(.invalidAddressException) }
+    public static var invalidInputCombinationException: Self { .init(.invalidInputCombinationException) }
+    public static var invalidJobStateException: Self { .init(.invalidJobStateException) }
+    public static var invalidNextTokenException: Self { .init(.invalidNextTokenException) }
+    public static var invalidResourceException: Self { .init(.invalidResourceException) }
+    public static var kMSRequestFailedException: Self { .init(.kMSRequestFailedException) }
+    public static var unsupportedAddressException: Self { .init(.unsupportedAddressException) }
+}
+
+extension SnowballErrorType: Equatable {
+    public static func == (lhs: SnowballErrorType, rhs: SnowballErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension SnowballErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .clusterLimitExceededException(let message):
-            return "ClusterLimitExceededException: \(message ?? "")"
-        case .ec2RequestFailedException(let message):
-            return "Ec2RequestFailedException: \(message ?? "")"
-        case .invalidAddressException(let message):
-            return "InvalidAddressException: \(message ?? "")"
-        case .invalidInputCombinationException(let message):
-            return "InvalidInputCombinationException: \(message ?? "")"
-        case .invalidJobStateException(let message):
-            return "InvalidJobStateException: \(message ?? "")"
-        case .invalidNextTokenException(let message):
-            return "InvalidNextTokenException: \(message ?? "")"
-        case .invalidResourceException(let message):
-            return "InvalidResourceException: \(message ?? "")"
-        case .kMSRequestFailedException(let message):
-            return "KMSRequestFailedException: \(message ?? "")"
-        case .unsupportedAddressException(let message):
-            return "UnsupportedAddressException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/StorageGateway/StorageGateway_Error.swift
+++ b/Sources/Soto/Services/StorageGateway/StorageGateway_Error.swift
@@ -17,40 +17,44 @@
 import SotoCore
 
 /// Error enum for StorageGateway
-public enum StorageGatewayErrorType: AWSErrorType {
-    case internalServerError(message: String?)
-    case invalidGatewayRequestException(message: String?)
-    case serviceUnavailableError(message: String?)
-}
+public struct StorageGatewayErrorType: AWSErrorType {
+    enum Code: String {
+        case internalServerError = "InternalServerError"
+        case invalidGatewayRequestException = "InvalidGatewayRequestException"
+        case serviceUnavailableError = "ServiceUnavailableError"
+    }
 
-extension StorageGatewayErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "InternalServerError":
-            self = .internalServerError(message: message)
-        case "InvalidGatewayRequestException":
-            self = .invalidGatewayRequestException(message: message)
-        case "ServiceUnavailableError":
-            self = .serviceUnavailableError(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var internalServerError: Self { .init(.internalServerError) }
+    public static var invalidGatewayRequestException: Self { .init(.invalidGatewayRequestException) }
+    public static var serviceUnavailableError: Self { .init(.serviceUnavailableError) }
+}
+
+extension StorageGatewayErrorType: Equatable {
+    public static func == (lhs: StorageGatewayErrorType, rhs: StorageGatewayErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension StorageGatewayErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .internalServerError(let message):
-            return "InternalServerError: \(message ?? "")"
-        case .invalidGatewayRequestException(let message):
-            return "InvalidGatewayRequestException: \(message ?? "")"
-        case .serviceUnavailableError(let message):
-            return "ServiceUnavailableError: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Support/Support_Error.swift
+++ b/Sources/Soto/Services/Support/Support_Error.swift
@@ -17,70 +17,56 @@
 import SotoCore
 
 /// Error enum for Support
-public enum SupportErrorType: AWSErrorType {
-    case attachmentIdNotFound(message: String?)
-    case attachmentLimitExceeded(message: String?)
-    case attachmentSetExpired(message: String?)
-    case attachmentSetIdNotFound(message: String?)
-    case attachmentSetSizeLimitExceeded(message: String?)
-    case caseCreationLimitExceeded(message: String?)
-    case caseIdNotFound(message: String?)
-    case describeAttachmentLimitExceeded(message: String?)
-    case internalServerError(message: String?)
-}
+public struct SupportErrorType: AWSErrorType {
+    enum Code: String {
+        case attachmentIdNotFound = "AttachmentIdNotFound"
+        case attachmentLimitExceeded = "AttachmentLimitExceeded"
+        case attachmentSetExpired = "AttachmentSetExpired"
+        case attachmentSetIdNotFound = "AttachmentSetIdNotFound"
+        case attachmentSetSizeLimitExceeded = "AttachmentSetSizeLimitExceeded"
+        case caseCreationLimitExceeded = "CaseCreationLimitExceeded"
+        case caseIdNotFound = "CaseIdNotFound"
+        case describeAttachmentLimitExceeded = "DescribeAttachmentLimitExceeded"
+        case internalServerError = "InternalServerError"
+    }
 
-extension SupportErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AttachmentIdNotFound":
-            self = .attachmentIdNotFound(message: message)
-        case "AttachmentLimitExceeded":
-            self = .attachmentLimitExceeded(message: message)
-        case "AttachmentSetExpired":
-            self = .attachmentSetExpired(message: message)
-        case "AttachmentSetIdNotFound":
-            self = .attachmentSetIdNotFound(message: message)
-        case "AttachmentSetSizeLimitExceeded":
-            self = .attachmentSetSizeLimitExceeded(message: message)
-        case "CaseCreationLimitExceeded":
-            self = .caseCreationLimitExceeded(message: message)
-        case "CaseIdNotFound":
-            self = .caseIdNotFound(message: message)
-        case "DescribeAttachmentLimitExceeded":
-            self = .describeAttachmentLimitExceeded(message: message)
-        case "InternalServerError":
-            self = .internalServerError(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var attachmentIdNotFound: Self { .init(.attachmentIdNotFound) }
+    public static var attachmentLimitExceeded: Self { .init(.attachmentLimitExceeded) }
+    public static var attachmentSetExpired: Self { .init(.attachmentSetExpired) }
+    public static var attachmentSetIdNotFound: Self { .init(.attachmentSetIdNotFound) }
+    public static var attachmentSetSizeLimitExceeded: Self { .init(.attachmentSetSizeLimitExceeded) }
+    public static var caseCreationLimitExceeded: Self { .init(.caseCreationLimitExceeded) }
+    public static var caseIdNotFound: Self { .init(.caseIdNotFound) }
+    public static var describeAttachmentLimitExceeded: Self { .init(.describeAttachmentLimitExceeded) }
+    public static var internalServerError: Self { .init(.internalServerError) }
+}
+
+extension SupportErrorType: Equatable {
+    public static func == (lhs: SupportErrorType, rhs: SupportErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension SupportErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .attachmentIdNotFound(let message):
-            return "AttachmentIdNotFound: \(message ?? "")"
-        case .attachmentLimitExceeded(let message):
-            return "AttachmentLimitExceeded: \(message ?? "")"
-        case .attachmentSetExpired(let message):
-            return "AttachmentSetExpired: \(message ?? "")"
-        case .attachmentSetIdNotFound(let message):
-            return "AttachmentSetIdNotFound: \(message ?? "")"
-        case .attachmentSetSizeLimitExceeded(let message):
-            return "AttachmentSetSizeLimitExceeded: \(message ?? "")"
-        case .caseCreationLimitExceeded(let message):
-            return "CaseCreationLimitExceeded: \(message ?? "")"
-        case .caseIdNotFound(let message):
-            return "CaseIdNotFound: \(message ?? "")"
-        case .describeAttachmentLimitExceeded(let message):
-            return "DescribeAttachmentLimitExceeded: \(message ?? "")"
-        case .internalServerError(let message):
-            return "InternalServerError: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Synthetics/Synthetics_Error.swift
+++ b/Sources/Soto/Services/Synthetics/Synthetics_Error.swift
@@ -17,45 +17,46 @@
 import SotoCore
 
 /// Error enum for Synthetics
-public enum SyntheticsErrorType: AWSErrorType {
-    case conflictException(message: String?)
-    case internalServerException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case validationException(message: String?)
-}
+public struct SyntheticsErrorType: AWSErrorType {
+    enum Code: String {
+        case conflictException = "ConflictException"
+        case internalServerException = "InternalServerException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case validationException = "ValidationException"
+    }
 
-extension SyntheticsErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension SyntheticsErrorType: Equatable {
+    public static func == (lhs: SyntheticsErrorType, rhs: SyntheticsErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension SyntheticsErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Textract/Textract_Error.swift
+++ b/Sources/Soto/Services/Textract/Textract_Error.swift
@@ -17,90 +17,64 @@
 import SotoCore
 
 /// Error enum for Textract
-public enum TextractErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case badDocumentException(message: String?)
-    case documentTooLargeException(message: String?)
-    case humanLoopQuotaExceededException(message: String?)
-    case idempotentParameterMismatchException(message: String?)
-    case internalServerError(message: String?)
-    case invalidJobIdException(message: String?)
-    case invalidParameterException(message: String?)
-    case invalidS3ObjectException(message: String?)
-    case limitExceededException(message: String?)
-    case provisionedThroughputExceededException(message: String?)
-    case throttlingException(message: String?)
-    case unsupportedDocumentException(message: String?)
-}
+public struct TextractErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case badDocumentException = "BadDocumentException"
+        case documentTooLargeException = "DocumentTooLargeException"
+        case humanLoopQuotaExceededException = "HumanLoopQuotaExceededException"
+        case idempotentParameterMismatchException = "IdempotentParameterMismatchException"
+        case internalServerError = "InternalServerError"
+        case invalidJobIdException = "InvalidJobIdException"
+        case invalidParameterException = "InvalidParameterException"
+        case invalidS3ObjectException = "InvalidS3ObjectException"
+        case limitExceededException = "LimitExceededException"
+        case provisionedThroughputExceededException = "ProvisionedThroughputExceededException"
+        case throttlingException = "ThrottlingException"
+        case unsupportedDocumentException = "UnsupportedDocumentException"
+    }
 
-extension TextractErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "BadDocumentException":
-            self = .badDocumentException(message: message)
-        case "DocumentTooLargeException":
-            self = .documentTooLargeException(message: message)
-        case "HumanLoopQuotaExceededException":
-            self = .humanLoopQuotaExceededException(message: message)
-        case "IdempotentParameterMismatchException":
-            self = .idempotentParameterMismatchException(message: message)
-        case "InternalServerError":
-            self = .internalServerError(message: message)
-        case "InvalidJobIdException":
-            self = .invalidJobIdException(message: message)
-        case "InvalidParameterException":
-            self = .invalidParameterException(message: message)
-        case "InvalidS3ObjectException":
-            self = .invalidS3ObjectException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ProvisionedThroughputExceededException":
-            self = .provisionedThroughputExceededException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        case "UnsupportedDocumentException":
-            self = .unsupportedDocumentException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var badDocumentException: Self { .init(.badDocumentException) }
+    public static var documentTooLargeException: Self { .init(.documentTooLargeException) }
+    public static var humanLoopQuotaExceededException: Self { .init(.humanLoopQuotaExceededException) }
+    public static var idempotentParameterMismatchException: Self { .init(.idempotentParameterMismatchException) }
+    public static var internalServerError: Self { .init(.internalServerError) }
+    public static var invalidJobIdException: Self { .init(.invalidJobIdException) }
+    public static var invalidParameterException: Self { .init(.invalidParameterException) }
+    public static var invalidS3ObjectException: Self { .init(.invalidS3ObjectException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var provisionedThroughputExceededException: Self { .init(.provisionedThroughputExceededException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+    public static var unsupportedDocumentException: Self { .init(.unsupportedDocumentException) }
+}
+
+extension TextractErrorType: Equatable {
+    public static func == (lhs: TextractErrorType, rhs: TextractErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension TextractErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .badDocumentException(let message):
-            return "BadDocumentException: \(message ?? "")"
-        case .documentTooLargeException(let message):
-            return "DocumentTooLargeException: \(message ?? "")"
-        case .humanLoopQuotaExceededException(let message):
-            return "HumanLoopQuotaExceededException: \(message ?? "")"
-        case .idempotentParameterMismatchException(let message):
-            return "IdempotentParameterMismatchException: \(message ?? "")"
-        case .internalServerError(let message):
-            return "InternalServerError: \(message ?? "")"
-        case .invalidJobIdException(let message):
-            return "InvalidJobIdException: \(message ?? "")"
-        case .invalidParameterException(let message):
-            return "InvalidParameterException: \(message ?? "")"
-        case .invalidS3ObjectException(let message):
-            return "InvalidS3ObjectException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .provisionedThroughputExceededException(let message):
-            return "ProvisionedThroughputExceededException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        case .unsupportedDocumentException(let message):
-            return "UnsupportedDocumentException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/TimestreamQuery/TimestreamQuery_Error.swift
+++ b/Sources/Soto/Services/TimestreamQuery/TimestreamQuery_Error.swift
@@ -17,60 +17,52 @@
 import SotoCore
 
 /// Error enum for TimestreamQuery
-public enum TimestreamQueryErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case conflictException(message: String?)
-    case internalServerException(message: String?)
-    case invalidEndpointException(message: String?)
-    case queryExecutionException(message: String?)
-    case throttlingException(message: String?)
-    case validationException(message: String?)
-}
+public struct TimestreamQueryErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case conflictException = "ConflictException"
+        case internalServerException = "InternalServerException"
+        case invalidEndpointException = "InvalidEndpointException"
+        case queryExecutionException = "QueryExecutionException"
+        case throttlingException = "ThrottlingException"
+        case validationException = "ValidationException"
+    }
 
-extension TimestreamQueryErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "InvalidEndpointException":
-            self = .invalidEndpointException(message: message)
-        case "QueryExecutionException":
-            self = .queryExecutionException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var invalidEndpointException: Self { .init(.invalidEndpointException) }
+    public static var queryExecutionException: Self { .init(.queryExecutionException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension TimestreamQueryErrorType: Equatable {
+    public static func == (lhs: TimestreamQueryErrorType, rhs: TimestreamQueryErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension TimestreamQueryErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .invalidEndpointException(let message):
-            return "InvalidEndpointException: \(message ?? "")"
-        case .queryExecutionException(let message):
-            return "QueryExecutionException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/TimestreamWrite/TimestreamWrite_Error.swift
+++ b/Sources/Soto/Services/TimestreamWrite/TimestreamWrite_Error.swift
@@ -17,70 +17,56 @@
 import SotoCore
 
 /// Error enum for TimestreamWrite
-public enum TimestreamWriteErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case conflictException(message: String?)
-    case internalServerException(message: String?)
-    case invalidEndpointException(message: String?)
-    case rejectedRecordsException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceQuotaExceededException(message: String?)
-    case throttlingException(message: String?)
-    case validationException(message: String?)
-}
+public struct TimestreamWriteErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case conflictException = "ConflictException"
+        case internalServerException = "InternalServerException"
+        case invalidEndpointException = "InvalidEndpointException"
+        case rejectedRecordsException = "RejectedRecordsException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceQuotaExceededException = "ServiceQuotaExceededException"
+        case throttlingException = "ThrottlingException"
+        case validationException = "ValidationException"
+    }
 
-extension TimestreamWriteErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "InvalidEndpointException":
-            self = .invalidEndpointException(message: message)
-        case "RejectedRecordsException":
-            self = .rejectedRecordsException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceQuotaExceededException":
-            self = .serviceQuotaExceededException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        case "ValidationException":
-            self = .validationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var invalidEndpointException: Self { .init(.invalidEndpointException) }
+    public static var rejectedRecordsException: Self { .init(.rejectedRecordsException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceQuotaExceededException: Self { .init(.serviceQuotaExceededException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+    public static var validationException: Self { .init(.validationException) }
+}
+
+extension TimestreamWriteErrorType: Equatable {
+    public static func == (lhs: TimestreamWriteErrorType, rhs: TimestreamWriteErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension TimestreamWriteErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .invalidEndpointException(let message):
-            return "InvalidEndpointException: \(message ?? "")"
-        case .rejectedRecordsException(let message):
-            return "RejectedRecordsException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceQuotaExceededException(let message):
-            return "ServiceQuotaExceededException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        case .validationException(let message):
-            return "ValidationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/TranscribeService/TranscribeService_Error.swift
+++ b/Sources/Soto/Services/TranscribeService/TranscribeService_Error.swift
@@ -17,50 +17,48 @@
 import SotoCore
 
 /// Error enum for TranscribeService
-public enum TranscribeServiceErrorType: AWSErrorType {
-    case badRequestException(message: String?)
-    case conflictException(message: String?)
-    case internalFailureException(message: String?)
-    case limitExceededException(message: String?)
-    case notFoundException(message: String?)
-}
+public struct TranscribeServiceErrorType: AWSErrorType {
+    enum Code: String {
+        case badRequestException = "BadRequestException"
+        case conflictException = "ConflictException"
+        case internalFailureException = "InternalFailureException"
+        case limitExceededException = "LimitExceededException"
+        case notFoundException = "NotFoundException"
+    }
 
-extension TranscribeServiceErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "InternalFailureException":
-            self = .internalFailureException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "NotFoundException":
-            self = .notFoundException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var badRequestException: Self { .init(.badRequestException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var internalFailureException: Self { .init(.internalFailureException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var notFoundException: Self { .init(.notFoundException) }
+}
+
+extension TranscribeServiceErrorType: Equatable {
+    public static func == (lhs: TranscribeServiceErrorType, rhs: TranscribeServiceErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension TranscribeServiceErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .internalFailureException(let message):
-            return "InternalFailureException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/TranscribeStreamingService/TranscribeStreamingService_Error.swift
+++ b/Sources/Soto/Services/TranscribeStreamingService/TranscribeStreamingService_Error.swift
@@ -17,50 +17,48 @@
 import SotoCore
 
 /// Error enum for TranscribeStreamingService
-public enum TranscribeStreamingServiceErrorType: AWSErrorType {
-    case badRequestException(message: String?)
-    case conflictException(message: String?)
-    case internalFailureException(message: String?)
-    case limitExceededException(message: String?)
-    case serviceUnavailableException(message: String?)
-}
+public struct TranscribeStreamingServiceErrorType: AWSErrorType {
+    enum Code: String {
+        case badRequestException = "BadRequestException"
+        case conflictException = "ConflictException"
+        case internalFailureException = "InternalFailureException"
+        case limitExceededException = "LimitExceededException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+    }
 
-extension TranscribeStreamingServiceErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "BadRequestException":
-            self = .badRequestException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "InternalFailureException":
-            self = .internalFailureException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var badRequestException: Self { .init(.badRequestException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var internalFailureException: Self { .init(.internalFailureException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+}
+
+extension TranscribeStreamingServiceErrorType: Equatable {
+    public static func == (lhs: TranscribeStreamingServiceErrorType, rhs: TranscribeStreamingServiceErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension TranscribeStreamingServiceErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .badRequestException(let message):
-            return "BadRequestException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .internalFailureException(let message):
-            return "InternalFailureException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Transfer/Transfer_Error.swift
+++ b/Sources/Soto/Services/Transfer/Transfer_Error.swift
@@ -17,70 +17,56 @@
 import SotoCore
 
 /// Error enum for Transfer
-public enum TransferErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case conflictException(message: String?)
-    case internalServiceError(message: String?)
-    case invalidNextTokenException(message: String?)
-    case invalidRequestException(message: String?)
-    case resourceExistsException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceUnavailableException(message: String?)
-    case throttlingException(message: String?)
-}
+public struct TransferErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case conflictException = "ConflictException"
+        case internalServiceError = "InternalServiceError"
+        case invalidNextTokenException = "InvalidNextTokenException"
+        case invalidRequestException = "InvalidRequestException"
+        case resourceExistsException = "ResourceExistsException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+        case throttlingException = "ThrottlingException"
+    }
 
-extension TransferErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "ConflictException":
-            self = .conflictException(message: message)
-        case "InternalServiceError":
-            self = .internalServiceError(message: message)
-        case "InvalidNextTokenException":
-            self = .invalidNextTokenException(message: message)
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        case "ResourceExistsException":
-            self = .resourceExistsException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        case "ThrottlingException":
-            self = .throttlingException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var conflictException: Self { .init(.conflictException) }
+    public static var internalServiceError: Self { .init(.internalServiceError) }
+    public static var invalidNextTokenException: Self { .init(.invalidNextTokenException) }
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+    public static var resourceExistsException: Self { .init(.resourceExistsException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+    public static var throttlingException: Self { .init(.throttlingException) }
+}
+
+extension TransferErrorType: Equatable {
+    public static func == (lhs: TransferErrorType, rhs: TransferErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension TransferErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .conflictException(let message):
-            return "ConflictException: \(message ?? "")"
-        case .internalServiceError(let message):
-            return "InternalServiceError: \(message ?? "")"
-        case .invalidNextTokenException(let message):
-            return "InvalidNextTokenException: \(message ?? "")"
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        case .resourceExistsException(let message):
-            return "ResourceExistsException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        case .throttlingException(let message):
-            return "ThrottlingException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/Translate/Translate_Error.swift
+++ b/Sources/Soto/Services/Translate/Translate_Error.swift
@@ -17,80 +17,60 @@
 import SotoCore
 
 /// Error enum for Translate
-public enum TranslateErrorType: AWSErrorType {
-    case detectedLanguageLowConfidenceException(message: String?)
-    case internalServerException(message: String?)
-    case invalidFilterException(message: String?)
-    case invalidParameterValueException(message: String?)
-    case invalidRequestException(message: String?)
-    case limitExceededException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case serviceUnavailableException(message: String?)
-    case textSizeLimitExceededException(message: String?)
-    case tooManyRequestsException(message: String?)
-    case unsupportedLanguagePairException(message: String?)
-}
+public struct TranslateErrorType: AWSErrorType {
+    enum Code: String {
+        case detectedLanguageLowConfidenceException = "DetectedLanguageLowConfidenceException"
+        case internalServerException = "InternalServerException"
+        case invalidFilterException = "InvalidFilterException"
+        case invalidParameterValueException = "InvalidParameterValueException"
+        case invalidRequestException = "InvalidRequestException"
+        case limitExceededException = "LimitExceededException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+        case textSizeLimitExceededException = "TextSizeLimitExceededException"
+        case tooManyRequestsException = "TooManyRequestsException"
+        case unsupportedLanguagePairException = "UnsupportedLanguagePairException"
+    }
 
-extension TranslateErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "DetectedLanguageLowConfidenceException":
-            self = .detectedLanguageLowConfidenceException(message: message)
-        case "InternalServerException":
-            self = .internalServerException(message: message)
-        case "InvalidFilterException":
-            self = .invalidFilterException(message: message)
-        case "InvalidParameterValueException":
-            self = .invalidParameterValueException(message: message)
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        case "TextSizeLimitExceededException":
-            self = .textSizeLimitExceededException(message: message)
-        case "TooManyRequestsException":
-            self = .tooManyRequestsException(message: message)
-        case "UnsupportedLanguagePairException":
-            self = .unsupportedLanguagePairException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var detectedLanguageLowConfidenceException: Self { .init(.detectedLanguageLowConfidenceException) }
+    public static var internalServerException: Self { .init(.internalServerException) }
+    public static var invalidFilterException: Self { .init(.invalidFilterException) }
+    public static var invalidParameterValueException: Self { .init(.invalidParameterValueException) }
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+    public static var textSizeLimitExceededException: Self { .init(.textSizeLimitExceededException) }
+    public static var tooManyRequestsException: Self { .init(.tooManyRequestsException) }
+    public static var unsupportedLanguagePairException: Self { .init(.unsupportedLanguagePairException) }
+}
+
+extension TranslateErrorType: Equatable {
+    public static func == (lhs: TranslateErrorType, rhs: TranslateErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension TranslateErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .detectedLanguageLowConfidenceException(let message):
-            return "DetectedLanguageLowConfidenceException: \(message ?? "")"
-        case .internalServerException(let message):
-            return "InternalServerException: \(message ?? "")"
-        case .invalidFilterException(let message):
-            return "InvalidFilterException: \(message ?? "")"
-        case .invalidParameterValueException(let message):
-            return "InvalidParameterValueException: \(message ?? "")"
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        case .textSizeLimitExceededException(let message):
-            return "TextSizeLimitExceededException: \(message ?? "")"
-        case .tooManyRequestsException(let message):
-            return "TooManyRequestsException: \(message ?? "")"
-        case .unsupportedLanguagePairException(let message):
-            return "UnsupportedLanguagePairException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/WAF/WAF_Error.swift
+++ b/Sources/Soto/Services/WAF/WAF_Error.swift
@@ -17,120 +17,76 @@
 import SotoCore
 
 /// Error enum for WAF
-public enum WAFErrorType: AWSErrorType {
-    case wAFBadRequestException(message: String?)
-    case wAFDisallowedNameException(message: String?)
-    case wAFEntityMigrationException(message: String?)
-    case wAFInternalErrorException(message: String?)
-    case wAFInvalidAccountException(message: String?)
-    case wAFInvalidOperationException(message: String?)
-    case wAFInvalidParameterException(message: String?)
-    case wAFInvalidPermissionPolicyException(message: String?)
-    case wAFInvalidRegexPatternException(message: String?)
-    case wAFLimitsExceededException(message: String?)
-    case wAFNonEmptyEntityException(message: String?)
-    case wAFNonexistentContainerException(message: String?)
-    case wAFNonexistentItemException(message: String?)
-    case wAFReferencedItemException(message: String?)
-    case wAFServiceLinkedRoleErrorException(message: String?)
-    case wAFStaleDataException(message: String?)
-    case wAFSubscriptionNotFoundException(message: String?)
-    case wAFTagOperationException(message: String?)
-    case wAFTagOperationInternalErrorException(message: String?)
-}
+public struct WAFErrorType: AWSErrorType {
+    enum Code: String {
+        case wAFBadRequestException = "WAFBadRequestException"
+        case wAFDisallowedNameException = "WAFDisallowedNameException"
+        case wAFEntityMigrationException = "WAFEntityMigrationException"
+        case wAFInternalErrorException = "WAFInternalErrorException"
+        case wAFInvalidAccountException = "WAFInvalidAccountException"
+        case wAFInvalidOperationException = "WAFInvalidOperationException"
+        case wAFInvalidParameterException = "WAFInvalidParameterException"
+        case wAFInvalidPermissionPolicyException = "WAFInvalidPermissionPolicyException"
+        case wAFInvalidRegexPatternException = "WAFInvalidRegexPatternException"
+        case wAFLimitsExceededException = "WAFLimitsExceededException"
+        case wAFNonEmptyEntityException = "WAFNonEmptyEntityException"
+        case wAFNonexistentContainerException = "WAFNonexistentContainerException"
+        case wAFNonexistentItemException = "WAFNonexistentItemException"
+        case wAFReferencedItemException = "WAFReferencedItemException"
+        case wAFServiceLinkedRoleErrorException = "WAFServiceLinkedRoleErrorException"
+        case wAFStaleDataException = "WAFStaleDataException"
+        case wAFSubscriptionNotFoundException = "WAFSubscriptionNotFoundException"
+        case wAFTagOperationException = "WAFTagOperationException"
+        case wAFTagOperationInternalErrorException = "WAFTagOperationInternalErrorException"
+    }
 
-extension WAFErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "WAFBadRequestException":
-            self = .wAFBadRequestException(message: message)
-        case "WAFDisallowedNameException":
-            self = .wAFDisallowedNameException(message: message)
-        case "WAFEntityMigrationException":
-            self = .wAFEntityMigrationException(message: message)
-        case "WAFInternalErrorException":
-            self = .wAFInternalErrorException(message: message)
-        case "WAFInvalidAccountException":
-            self = .wAFInvalidAccountException(message: message)
-        case "WAFInvalidOperationException":
-            self = .wAFInvalidOperationException(message: message)
-        case "WAFInvalidParameterException":
-            self = .wAFInvalidParameterException(message: message)
-        case "WAFInvalidPermissionPolicyException":
-            self = .wAFInvalidPermissionPolicyException(message: message)
-        case "WAFInvalidRegexPatternException":
-            self = .wAFInvalidRegexPatternException(message: message)
-        case "WAFLimitsExceededException":
-            self = .wAFLimitsExceededException(message: message)
-        case "WAFNonEmptyEntityException":
-            self = .wAFNonEmptyEntityException(message: message)
-        case "WAFNonexistentContainerException":
-            self = .wAFNonexistentContainerException(message: message)
-        case "WAFNonexistentItemException":
-            self = .wAFNonexistentItemException(message: message)
-        case "WAFReferencedItemException":
-            self = .wAFReferencedItemException(message: message)
-        case "WAFServiceLinkedRoleErrorException":
-            self = .wAFServiceLinkedRoleErrorException(message: message)
-        case "WAFStaleDataException":
-            self = .wAFStaleDataException(message: message)
-        case "WAFSubscriptionNotFoundException":
-            self = .wAFSubscriptionNotFoundException(message: message)
-        case "WAFTagOperationException":
-            self = .wAFTagOperationException(message: message)
-        case "WAFTagOperationInternalErrorException":
-            self = .wAFTagOperationInternalErrorException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var wAFBadRequestException: Self { .init(.wAFBadRequestException) }
+    public static var wAFDisallowedNameException: Self { .init(.wAFDisallowedNameException) }
+    public static var wAFEntityMigrationException: Self { .init(.wAFEntityMigrationException) }
+    public static var wAFInternalErrorException: Self { .init(.wAFInternalErrorException) }
+    public static var wAFInvalidAccountException: Self { .init(.wAFInvalidAccountException) }
+    public static var wAFInvalidOperationException: Self { .init(.wAFInvalidOperationException) }
+    public static var wAFInvalidParameterException: Self { .init(.wAFInvalidParameterException) }
+    public static var wAFInvalidPermissionPolicyException: Self { .init(.wAFInvalidPermissionPolicyException) }
+    public static var wAFInvalidRegexPatternException: Self { .init(.wAFInvalidRegexPatternException) }
+    public static var wAFLimitsExceededException: Self { .init(.wAFLimitsExceededException) }
+    public static var wAFNonEmptyEntityException: Self { .init(.wAFNonEmptyEntityException) }
+    public static var wAFNonexistentContainerException: Self { .init(.wAFNonexistentContainerException) }
+    public static var wAFNonexistentItemException: Self { .init(.wAFNonexistentItemException) }
+    public static var wAFReferencedItemException: Self { .init(.wAFReferencedItemException) }
+    public static var wAFServiceLinkedRoleErrorException: Self { .init(.wAFServiceLinkedRoleErrorException) }
+    public static var wAFStaleDataException: Self { .init(.wAFStaleDataException) }
+    public static var wAFSubscriptionNotFoundException: Self { .init(.wAFSubscriptionNotFoundException) }
+    public static var wAFTagOperationException: Self { .init(.wAFTagOperationException) }
+    public static var wAFTagOperationInternalErrorException: Self { .init(.wAFTagOperationInternalErrorException) }
+}
+
+extension WAFErrorType: Equatable {
+    public static func == (lhs: WAFErrorType, rhs: WAFErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension WAFErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .wAFBadRequestException(let message):
-            return "WAFBadRequestException: \(message ?? "")"
-        case .wAFDisallowedNameException(let message):
-            return "WAFDisallowedNameException: \(message ?? "")"
-        case .wAFEntityMigrationException(let message):
-            return "WAFEntityMigrationException: \(message ?? "")"
-        case .wAFInternalErrorException(let message):
-            return "WAFInternalErrorException: \(message ?? "")"
-        case .wAFInvalidAccountException(let message):
-            return "WAFInvalidAccountException: \(message ?? "")"
-        case .wAFInvalidOperationException(let message):
-            return "WAFInvalidOperationException: \(message ?? "")"
-        case .wAFInvalidParameterException(let message):
-            return "WAFInvalidParameterException: \(message ?? "")"
-        case .wAFInvalidPermissionPolicyException(let message):
-            return "WAFInvalidPermissionPolicyException: \(message ?? "")"
-        case .wAFInvalidRegexPatternException(let message):
-            return "WAFInvalidRegexPatternException: \(message ?? "")"
-        case .wAFLimitsExceededException(let message):
-            return "WAFLimitsExceededException: \(message ?? "")"
-        case .wAFNonEmptyEntityException(let message):
-            return "WAFNonEmptyEntityException: \(message ?? "")"
-        case .wAFNonexistentContainerException(let message):
-            return "WAFNonexistentContainerException: \(message ?? "")"
-        case .wAFNonexistentItemException(let message):
-            return "WAFNonexistentItemException: \(message ?? "")"
-        case .wAFReferencedItemException(let message):
-            return "WAFReferencedItemException: \(message ?? "")"
-        case .wAFServiceLinkedRoleErrorException(let message):
-            return "WAFServiceLinkedRoleErrorException: \(message ?? "")"
-        case .wAFStaleDataException(let message):
-            return "WAFStaleDataException: \(message ?? "")"
-        case .wAFSubscriptionNotFoundException(let message):
-            return "WAFSubscriptionNotFoundException: \(message ?? "")"
-        case .wAFTagOperationException(let message):
-            return "WAFTagOperationException: \(message ?? "")"
-        case .wAFTagOperationInternalErrorException(let message):
-            return "WAFTagOperationInternalErrorException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/WAFRegional/WAFRegional_Error.swift
+++ b/Sources/Soto/Services/WAFRegional/WAFRegional_Error.swift
@@ -17,125 +17,78 @@
 import SotoCore
 
 /// Error enum for WAFRegional
-public enum WAFRegionalErrorType: AWSErrorType {
-    case wAFBadRequestException(message: String?)
-    case wAFDisallowedNameException(message: String?)
-    case wAFEntityMigrationException(message: String?)
-    case wAFInternalErrorException(message: String?)
-    case wAFInvalidAccountException(message: String?)
-    case wAFInvalidOperationException(message: String?)
-    case wAFInvalidParameterException(message: String?)
-    case wAFInvalidPermissionPolicyException(message: String?)
-    case wAFInvalidRegexPatternException(message: String?)
-    case wAFLimitsExceededException(message: String?)
-    case wAFNonEmptyEntityException(message: String?)
-    case wAFNonexistentContainerException(message: String?)
-    case wAFNonexistentItemException(message: String?)
-    case wAFReferencedItemException(message: String?)
-    case wAFServiceLinkedRoleErrorException(message: String?)
-    case wAFStaleDataException(message: String?)
-    case wAFSubscriptionNotFoundException(message: String?)
-    case wAFTagOperationException(message: String?)
-    case wAFTagOperationInternalErrorException(message: String?)
-    case wAFUnavailableEntityException(message: String?)
-}
+public struct WAFRegionalErrorType: AWSErrorType {
+    enum Code: String {
+        case wAFBadRequestException = "WAFBadRequestException"
+        case wAFDisallowedNameException = "WAFDisallowedNameException"
+        case wAFEntityMigrationException = "WAFEntityMigrationException"
+        case wAFInternalErrorException = "WAFInternalErrorException"
+        case wAFInvalidAccountException = "WAFInvalidAccountException"
+        case wAFInvalidOperationException = "WAFInvalidOperationException"
+        case wAFInvalidParameterException = "WAFInvalidParameterException"
+        case wAFInvalidPermissionPolicyException = "WAFInvalidPermissionPolicyException"
+        case wAFInvalidRegexPatternException = "WAFInvalidRegexPatternException"
+        case wAFLimitsExceededException = "WAFLimitsExceededException"
+        case wAFNonEmptyEntityException = "WAFNonEmptyEntityException"
+        case wAFNonexistentContainerException = "WAFNonexistentContainerException"
+        case wAFNonexistentItemException = "WAFNonexistentItemException"
+        case wAFReferencedItemException = "WAFReferencedItemException"
+        case wAFServiceLinkedRoleErrorException = "WAFServiceLinkedRoleErrorException"
+        case wAFStaleDataException = "WAFStaleDataException"
+        case wAFSubscriptionNotFoundException = "WAFSubscriptionNotFoundException"
+        case wAFTagOperationException = "WAFTagOperationException"
+        case wAFTagOperationInternalErrorException = "WAFTagOperationInternalErrorException"
+        case wAFUnavailableEntityException = "WAFUnavailableEntityException"
+    }
 
-extension WAFRegionalErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "WAFBadRequestException":
-            self = .wAFBadRequestException(message: message)
-        case "WAFDisallowedNameException":
-            self = .wAFDisallowedNameException(message: message)
-        case "WAFEntityMigrationException":
-            self = .wAFEntityMigrationException(message: message)
-        case "WAFInternalErrorException":
-            self = .wAFInternalErrorException(message: message)
-        case "WAFInvalidAccountException":
-            self = .wAFInvalidAccountException(message: message)
-        case "WAFInvalidOperationException":
-            self = .wAFInvalidOperationException(message: message)
-        case "WAFInvalidParameterException":
-            self = .wAFInvalidParameterException(message: message)
-        case "WAFInvalidPermissionPolicyException":
-            self = .wAFInvalidPermissionPolicyException(message: message)
-        case "WAFInvalidRegexPatternException":
-            self = .wAFInvalidRegexPatternException(message: message)
-        case "WAFLimitsExceededException":
-            self = .wAFLimitsExceededException(message: message)
-        case "WAFNonEmptyEntityException":
-            self = .wAFNonEmptyEntityException(message: message)
-        case "WAFNonexistentContainerException":
-            self = .wAFNonexistentContainerException(message: message)
-        case "WAFNonexistentItemException":
-            self = .wAFNonexistentItemException(message: message)
-        case "WAFReferencedItemException":
-            self = .wAFReferencedItemException(message: message)
-        case "WAFServiceLinkedRoleErrorException":
-            self = .wAFServiceLinkedRoleErrorException(message: message)
-        case "WAFStaleDataException":
-            self = .wAFStaleDataException(message: message)
-        case "WAFSubscriptionNotFoundException":
-            self = .wAFSubscriptionNotFoundException(message: message)
-        case "WAFTagOperationException":
-            self = .wAFTagOperationException(message: message)
-        case "WAFTagOperationInternalErrorException":
-            self = .wAFTagOperationInternalErrorException(message: message)
-        case "WAFUnavailableEntityException":
-            self = .wAFUnavailableEntityException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var wAFBadRequestException: Self { .init(.wAFBadRequestException) }
+    public static var wAFDisallowedNameException: Self { .init(.wAFDisallowedNameException) }
+    public static var wAFEntityMigrationException: Self { .init(.wAFEntityMigrationException) }
+    public static var wAFInternalErrorException: Self { .init(.wAFInternalErrorException) }
+    public static var wAFInvalidAccountException: Self { .init(.wAFInvalidAccountException) }
+    public static var wAFInvalidOperationException: Self { .init(.wAFInvalidOperationException) }
+    public static var wAFInvalidParameterException: Self { .init(.wAFInvalidParameterException) }
+    public static var wAFInvalidPermissionPolicyException: Self { .init(.wAFInvalidPermissionPolicyException) }
+    public static var wAFInvalidRegexPatternException: Self { .init(.wAFInvalidRegexPatternException) }
+    public static var wAFLimitsExceededException: Self { .init(.wAFLimitsExceededException) }
+    public static var wAFNonEmptyEntityException: Self { .init(.wAFNonEmptyEntityException) }
+    public static var wAFNonexistentContainerException: Self { .init(.wAFNonexistentContainerException) }
+    public static var wAFNonexistentItemException: Self { .init(.wAFNonexistentItemException) }
+    public static var wAFReferencedItemException: Self { .init(.wAFReferencedItemException) }
+    public static var wAFServiceLinkedRoleErrorException: Self { .init(.wAFServiceLinkedRoleErrorException) }
+    public static var wAFStaleDataException: Self { .init(.wAFStaleDataException) }
+    public static var wAFSubscriptionNotFoundException: Self { .init(.wAFSubscriptionNotFoundException) }
+    public static var wAFTagOperationException: Self { .init(.wAFTagOperationException) }
+    public static var wAFTagOperationInternalErrorException: Self { .init(.wAFTagOperationInternalErrorException) }
+    public static var wAFUnavailableEntityException: Self { .init(.wAFUnavailableEntityException) }
+}
+
+extension WAFRegionalErrorType: Equatable {
+    public static func == (lhs: WAFRegionalErrorType, rhs: WAFRegionalErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension WAFRegionalErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .wAFBadRequestException(let message):
-            return "WAFBadRequestException: \(message ?? "")"
-        case .wAFDisallowedNameException(let message):
-            return "WAFDisallowedNameException: \(message ?? "")"
-        case .wAFEntityMigrationException(let message):
-            return "WAFEntityMigrationException: \(message ?? "")"
-        case .wAFInternalErrorException(let message):
-            return "WAFInternalErrorException: \(message ?? "")"
-        case .wAFInvalidAccountException(let message):
-            return "WAFInvalidAccountException: \(message ?? "")"
-        case .wAFInvalidOperationException(let message):
-            return "WAFInvalidOperationException: \(message ?? "")"
-        case .wAFInvalidParameterException(let message):
-            return "WAFInvalidParameterException: \(message ?? "")"
-        case .wAFInvalidPermissionPolicyException(let message):
-            return "WAFInvalidPermissionPolicyException: \(message ?? "")"
-        case .wAFInvalidRegexPatternException(let message):
-            return "WAFInvalidRegexPatternException: \(message ?? "")"
-        case .wAFLimitsExceededException(let message):
-            return "WAFLimitsExceededException: \(message ?? "")"
-        case .wAFNonEmptyEntityException(let message):
-            return "WAFNonEmptyEntityException: \(message ?? "")"
-        case .wAFNonexistentContainerException(let message):
-            return "WAFNonexistentContainerException: \(message ?? "")"
-        case .wAFNonexistentItemException(let message):
-            return "WAFNonexistentItemException: \(message ?? "")"
-        case .wAFReferencedItemException(let message):
-            return "WAFReferencedItemException: \(message ?? "")"
-        case .wAFServiceLinkedRoleErrorException(let message):
-            return "WAFServiceLinkedRoleErrorException: \(message ?? "")"
-        case .wAFStaleDataException(let message):
-            return "WAFStaleDataException: \(message ?? "")"
-        case .wAFSubscriptionNotFoundException(let message):
-            return "WAFSubscriptionNotFoundException: \(message ?? "")"
-        case .wAFTagOperationException(let message):
-            return "WAFTagOperationException: \(message ?? "")"
-        case .wAFTagOperationInternalErrorException(let message):
-            return "WAFTagOperationInternalErrorException: \(message ?? "")"
-        case .wAFUnavailableEntityException(let message):
-            return "WAFUnavailableEntityException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/WAFV2/WAFV2_Error.swift
+++ b/Sources/Soto/Services/WAFV2/WAFV2_Error.swift
@@ -17,100 +17,68 @@
 import SotoCore
 
 /// Error enum for WAFV2
-public enum WAFV2ErrorType: AWSErrorType {
-    case wAFAssociatedItemException(message: String?)
-    case wAFDuplicateItemException(message: String?)
-    case wAFInternalErrorException(message: String?)
-    case wAFInvalidOperationException(message: String?)
-    case wAFInvalidParameterException(message: String?)
-    case wAFInvalidPermissionPolicyException(message: String?)
-    case wAFInvalidResourceException(message: String?)
-    case wAFLimitsExceededException(message: String?)
-    case wAFNonexistentItemException(message: String?)
-    case wAFOptimisticLockException(message: String?)
-    case wAFServiceLinkedRoleErrorException(message: String?)
-    case wAFSubscriptionNotFoundException(message: String?)
-    case wAFTagOperationException(message: String?)
-    case wAFTagOperationInternalErrorException(message: String?)
-    case wAFUnavailableEntityException(message: String?)
-}
+public struct WAFV2ErrorType: AWSErrorType {
+    enum Code: String {
+        case wAFAssociatedItemException = "WAFAssociatedItemException"
+        case wAFDuplicateItemException = "WAFDuplicateItemException"
+        case wAFInternalErrorException = "WAFInternalErrorException"
+        case wAFInvalidOperationException = "WAFInvalidOperationException"
+        case wAFInvalidParameterException = "WAFInvalidParameterException"
+        case wAFInvalidPermissionPolicyException = "WAFInvalidPermissionPolicyException"
+        case wAFInvalidResourceException = "WAFInvalidResourceException"
+        case wAFLimitsExceededException = "WAFLimitsExceededException"
+        case wAFNonexistentItemException = "WAFNonexistentItemException"
+        case wAFOptimisticLockException = "WAFOptimisticLockException"
+        case wAFServiceLinkedRoleErrorException = "WAFServiceLinkedRoleErrorException"
+        case wAFSubscriptionNotFoundException = "WAFSubscriptionNotFoundException"
+        case wAFTagOperationException = "WAFTagOperationException"
+        case wAFTagOperationInternalErrorException = "WAFTagOperationInternalErrorException"
+        case wAFUnavailableEntityException = "WAFUnavailableEntityException"
+    }
 
-extension WAFV2ErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "WAFAssociatedItemException":
-            self = .wAFAssociatedItemException(message: message)
-        case "WAFDuplicateItemException":
-            self = .wAFDuplicateItemException(message: message)
-        case "WAFInternalErrorException":
-            self = .wAFInternalErrorException(message: message)
-        case "WAFInvalidOperationException":
-            self = .wAFInvalidOperationException(message: message)
-        case "WAFInvalidParameterException":
-            self = .wAFInvalidParameterException(message: message)
-        case "WAFInvalidPermissionPolicyException":
-            self = .wAFInvalidPermissionPolicyException(message: message)
-        case "WAFInvalidResourceException":
-            self = .wAFInvalidResourceException(message: message)
-        case "WAFLimitsExceededException":
-            self = .wAFLimitsExceededException(message: message)
-        case "WAFNonexistentItemException":
-            self = .wAFNonexistentItemException(message: message)
-        case "WAFOptimisticLockException":
-            self = .wAFOptimisticLockException(message: message)
-        case "WAFServiceLinkedRoleErrorException":
-            self = .wAFServiceLinkedRoleErrorException(message: message)
-        case "WAFSubscriptionNotFoundException":
-            self = .wAFSubscriptionNotFoundException(message: message)
-        case "WAFTagOperationException":
-            self = .wAFTagOperationException(message: message)
-        case "WAFTagOperationInternalErrorException":
-            self = .wAFTagOperationInternalErrorException(message: message)
-        case "WAFUnavailableEntityException":
-            self = .wAFUnavailableEntityException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var wAFAssociatedItemException: Self { .init(.wAFAssociatedItemException) }
+    public static var wAFDuplicateItemException: Self { .init(.wAFDuplicateItemException) }
+    public static var wAFInternalErrorException: Self { .init(.wAFInternalErrorException) }
+    public static var wAFInvalidOperationException: Self { .init(.wAFInvalidOperationException) }
+    public static var wAFInvalidParameterException: Self { .init(.wAFInvalidParameterException) }
+    public static var wAFInvalidPermissionPolicyException: Self { .init(.wAFInvalidPermissionPolicyException) }
+    public static var wAFInvalidResourceException: Self { .init(.wAFInvalidResourceException) }
+    public static var wAFLimitsExceededException: Self { .init(.wAFLimitsExceededException) }
+    public static var wAFNonexistentItemException: Self { .init(.wAFNonexistentItemException) }
+    public static var wAFOptimisticLockException: Self { .init(.wAFOptimisticLockException) }
+    public static var wAFServiceLinkedRoleErrorException: Self { .init(.wAFServiceLinkedRoleErrorException) }
+    public static var wAFSubscriptionNotFoundException: Self { .init(.wAFSubscriptionNotFoundException) }
+    public static var wAFTagOperationException: Self { .init(.wAFTagOperationException) }
+    public static var wAFTagOperationInternalErrorException: Self { .init(.wAFTagOperationInternalErrorException) }
+    public static var wAFUnavailableEntityException: Self { .init(.wAFUnavailableEntityException) }
+}
+
+extension WAFV2ErrorType: Equatable {
+    public static func == (lhs: WAFV2ErrorType, rhs: WAFV2ErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension WAFV2ErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .wAFAssociatedItemException(let message):
-            return "WAFAssociatedItemException: \(message ?? "")"
-        case .wAFDuplicateItemException(let message):
-            return "WAFDuplicateItemException: \(message ?? "")"
-        case .wAFInternalErrorException(let message):
-            return "WAFInternalErrorException: \(message ?? "")"
-        case .wAFInvalidOperationException(let message):
-            return "WAFInvalidOperationException: \(message ?? "")"
-        case .wAFInvalidParameterException(let message):
-            return "WAFInvalidParameterException: \(message ?? "")"
-        case .wAFInvalidPermissionPolicyException(let message):
-            return "WAFInvalidPermissionPolicyException: \(message ?? "")"
-        case .wAFInvalidResourceException(let message):
-            return "WAFInvalidResourceException: \(message ?? "")"
-        case .wAFLimitsExceededException(let message):
-            return "WAFLimitsExceededException: \(message ?? "")"
-        case .wAFNonexistentItemException(let message):
-            return "WAFNonexistentItemException: \(message ?? "")"
-        case .wAFOptimisticLockException(let message):
-            return "WAFOptimisticLockException: \(message ?? "")"
-        case .wAFServiceLinkedRoleErrorException(let message):
-            return "WAFServiceLinkedRoleErrorException: \(message ?? "")"
-        case .wAFSubscriptionNotFoundException(let message):
-            return "WAFSubscriptionNotFoundException: \(message ?? "")"
-        case .wAFTagOperationException(let message):
-            return "WAFTagOperationException: \(message ?? "")"
-        case .wAFTagOperationInternalErrorException(let message):
-            return "WAFTagOperationInternalErrorException: \(message ?? "")"
-        case .wAFUnavailableEntityException(let message):
-            return "WAFUnavailableEntityException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/WorkDocs/WorkDocs_Error.swift
+++ b/Sources/Soto/Services/WorkDocs/WorkDocs_Error.swift
@@ -17,150 +17,88 @@
 import SotoCore
 
 /// Error enum for WorkDocs
-public enum WorkDocsErrorType: AWSErrorType {
-    case concurrentModificationException(message: String?)
-    case conflictingOperationException(message: String?)
-    case customMetadataLimitExceededException(message: String?)
-    case deactivatingLastSystemUserException(message: String?)
-    case documentLockedForCommentsException(message: String?)
-    case draftUploadOutOfSyncException(message: String?)
-    case entityAlreadyExistsException(message: String?)
-    case entityNotExistsException(message: String?)
-    case failedDependencyException(message: String?)
-    case illegalUserStateException(message: String?)
-    case invalidArgumentException(message: String?)
-    case invalidCommentOperationException(message: String?)
-    case invalidOperationException(message: String?)
-    case invalidPasswordException(message: String?)
-    case limitExceededException(message: String?)
-    case prohibitedStateException(message: String?)
-    case requestedEntityTooLargeException(message: String?)
-    case resourceAlreadyCheckedOutException(message: String?)
-    case serviceUnavailableException(message: String?)
-    case storageLimitExceededException(message: String?)
-    case storageLimitWillExceedException(message: String?)
-    case tooManyLabelsException(message: String?)
-    case tooManySubscriptionsException(message: String?)
-    case unauthorizedOperationException(message: String?)
-    case unauthorizedResourceAccessException(message: String?)
-}
+public struct WorkDocsErrorType: AWSErrorType {
+    enum Code: String {
+        case concurrentModificationException = "ConcurrentModificationException"
+        case conflictingOperationException = "ConflictingOperationException"
+        case customMetadataLimitExceededException = "CustomMetadataLimitExceededException"
+        case deactivatingLastSystemUserException = "DeactivatingLastSystemUserException"
+        case documentLockedForCommentsException = "DocumentLockedForCommentsException"
+        case draftUploadOutOfSyncException = "DraftUploadOutOfSyncException"
+        case entityAlreadyExistsException = "EntityAlreadyExistsException"
+        case entityNotExistsException = "EntityNotExistsException"
+        case failedDependencyException = "FailedDependencyException"
+        case illegalUserStateException = "IllegalUserStateException"
+        case invalidArgumentException = "InvalidArgumentException"
+        case invalidCommentOperationException = "InvalidCommentOperationException"
+        case invalidOperationException = "InvalidOperationException"
+        case invalidPasswordException = "InvalidPasswordException"
+        case limitExceededException = "LimitExceededException"
+        case prohibitedStateException = "ProhibitedStateException"
+        case requestedEntityTooLargeException = "RequestedEntityTooLargeException"
+        case resourceAlreadyCheckedOutException = "ResourceAlreadyCheckedOutException"
+        case serviceUnavailableException = "ServiceUnavailableException"
+        case storageLimitExceededException = "StorageLimitExceededException"
+        case storageLimitWillExceedException = "StorageLimitWillExceedException"
+        case tooManyLabelsException = "TooManyLabelsException"
+        case tooManySubscriptionsException = "TooManySubscriptionsException"
+        case unauthorizedOperationException = "UnauthorizedOperationException"
+        case unauthorizedResourceAccessException = "UnauthorizedResourceAccessException"
+    }
 
-extension WorkDocsErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ConcurrentModificationException":
-            self = .concurrentModificationException(message: message)
-        case "ConflictingOperationException":
-            self = .conflictingOperationException(message: message)
-        case "CustomMetadataLimitExceededException":
-            self = .customMetadataLimitExceededException(message: message)
-        case "DeactivatingLastSystemUserException":
-            self = .deactivatingLastSystemUserException(message: message)
-        case "DocumentLockedForCommentsException":
-            self = .documentLockedForCommentsException(message: message)
-        case "DraftUploadOutOfSyncException":
-            self = .draftUploadOutOfSyncException(message: message)
-        case "EntityAlreadyExistsException":
-            self = .entityAlreadyExistsException(message: message)
-        case "EntityNotExistsException":
-            self = .entityNotExistsException(message: message)
-        case "FailedDependencyException":
-            self = .failedDependencyException(message: message)
-        case "IllegalUserStateException":
-            self = .illegalUserStateException(message: message)
-        case "InvalidArgumentException":
-            self = .invalidArgumentException(message: message)
-        case "InvalidCommentOperationException":
-            self = .invalidCommentOperationException(message: message)
-        case "InvalidOperationException":
-            self = .invalidOperationException(message: message)
-        case "InvalidPasswordException":
-            self = .invalidPasswordException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "ProhibitedStateException":
-            self = .prohibitedStateException(message: message)
-        case "RequestedEntityTooLargeException":
-            self = .requestedEntityTooLargeException(message: message)
-        case "ResourceAlreadyCheckedOutException":
-            self = .resourceAlreadyCheckedOutException(message: message)
-        case "ServiceUnavailableException":
-            self = .serviceUnavailableException(message: message)
-        case "StorageLimitExceededException":
-            self = .storageLimitExceededException(message: message)
-        case "StorageLimitWillExceedException":
-            self = .storageLimitWillExceedException(message: message)
-        case "TooManyLabelsException":
-            self = .tooManyLabelsException(message: message)
-        case "TooManySubscriptionsException":
-            self = .tooManySubscriptionsException(message: message)
-        case "UnauthorizedOperationException":
-            self = .unauthorizedOperationException(message: message)
-        case "UnauthorizedResourceAccessException":
-            self = .unauthorizedResourceAccessException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var concurrentModificationException: Self { .init(.concurrentModificationException) }
+    public static var conflictingOperationException: Self { .init(.conflictingOperationException) }
+    public static var customMetadataLimitExceededException: Self { .init(.customMetadataLimitExceededException) }
+    public static var deactivatingLastSystemUserException: Self { .init(.deactivatingLastSystemUserException) }
+    public static var documentLockedForCommentsException: Self { .init(.documentLockedForCommentsException) }
+    public static var draftUploadOutOfSyncException: Self { .init(.draftUploadOutOfSyncException) }
+    public static var entityAlreadyExistsException: Self { .init(.entityAlreadyExistsException) }
+    public static var entityNotExistsException: Self { .init(.entityNotExistsException) }
+    public static var failedDependencyException: Self { .init(.failedDependencyException) }
+    public static var illegalUserStateException: Self { .init(.illegalUserStateException) }
+    public static var invalidArgumentException: Self { .init(.invalidArgumentException) }
+    public static var invalidCommentOperationException: Self { .init(.invalidCommentOperationException) }
+    public static var invalidOperationException: Self { .init(.invalidOperationException) }
+    public static var invalidPasswordException: Self { .init(.invalidPasswordException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var prohibitedStateException: Self { .init(.prohibitedStateException) }
+    public static var requestedEntityTooLargeException: Self { .init(.requestedEntityTooLargeException) }
+    public static var resourceAlreadyCheckedOutException: Self { .init(.resourceAlreadyCheckedOutException) }
+    public static var serviceUnavailableException: Self { .init(.serviceUnavailableException) }
+    public static var storageLimitExceededException: Self { .init(.storageLimitExceededException) }
+    public static var storageLimitWillExceedException: Self { .init(.storageLimitWillExceedException) }
+    public static var tooManyLabelsException: Self { .init(.tooManyLabelsException) }
+    public static var tooManySubscriptionsException: Self { .init(.tooManySubscriptionsException) }
+    public static var unauthorizedOperationException: Self { .init(.unauthorizedOperationException) }
+    public static var unauthorizedResourceAccessException: Self { .init(.unauthorizedResourceAccessException) }
+}
+
+extension WorkDocsErrorType: Equatable {
+    public static func == (lhs: WorkDocsErrorType, rhs: WorkDocsErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension WorkDocsErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .concurrentModificationException(let message):
-            return "ConcurrentModificationException: \(message ?? "")"
-        case .conflictingOperationException(let message):
-            return "ConflictingOperationException: \(message ?? "")"
-        case .customMetadataLimitExceededException(let message):
-            return "CustomMetadataLimitExceededException: \(message ?? "")"
-        case .deactivatingLastSystemUserException(let message):
-            return "DeactivatingLastSystemUserException: \(message ?? "")"
-        case .documentLockedForCommentsException(let message):
-            return "DocumentLockedForCommentsException: \(message ?? "")"
-        case .draftUploadOutOfSyncException(let message):
-            return "DraftUploadOutOfSyncException: \(message ?? "")"
-        case .entityAlreadyExistsException(let message):
-            return "EntityAlreadyExistsException: \(message ?? "")"
-        case .entityNotExistsException(let message):
-            return "EntityNotExistsException: \(message ?? "")"
-        case .failedDependencyException(let message):
-            return "FailedDependencyException: \(message ?? "")"
-        case .illegalUserStateException(let message):
-            return "IllegalUserStateException: \(message ?? "")"
-        case .invalidArgumentException(let message):
-            return "InvalidArgumentException: \(message ?? "")"
-        case .invalidCommentOperationException(let message):
-            return "InvalidCommentOperationException: \(message ?? "")"
-        case .invalidOperationException(let message):
-            return "InvalidOperationException: \(message ?? "")"
-        case .invalidPasswordException(let message):
-            return "InvalidPasswordException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .prohibitedStateException(let message):
-            return "ProhibitedStateException: \(message ?? "")"
-        case .requestedEntityTooLargeException(let message):
-            return "RequestedEntityTooLargeException: \(message ?? "")"
-        case .resourceAlreadyCheckedOutException(let message):
-            return "ResourceAlreadyCheckedOutException: \(message ?? "")"
-        case .serviceUnavailableException(let message):
-            return "ServiceUnavailableException: \(message ?? "")"
-        case .storageLimitExceededException(let message):
-            return "StorageLimitExceededException: \(message ?? "")"
-        case .storageLimitWillExceedException(let message):
-            return "StorageLimitWillExceedException: \(message ?? "")"
-        case .tooManyLabelsException(let message):
-            return "TooManyLabelsException: \(message ?? "")"
-        case .tooManySubscriptionsException(let message):
-            return "TooManySubscriptionsException: \(message ?? "")"
-        case .unauthorizedOperationException(let message):
-            return "UnauthorizedOperationException: \(message ?? "")"
-        case .unauthorizedResourceAccessException(let message):
-            return "UnauthorizedResourceAccessException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/WorkLink/WorkLink_Error.swift
+++ b/Sources/Soto/Services/WorkLink/WorkLink_Error.swift
@@ -17,55 +17,50 @@
 import SotoCore
 
 /// Error enum for WorkLink
-public enum WorkLinkErrorType: AWSErrorType {
-    case internalServerErrorException(message: String?)
-    case invalidRequestException(message: String?)
-    case resourceAlreadyExistsException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case tooManyRequestsException(message: String?)
-    case unauthorizedException(message: String?)
-}
+public struct WorkLinkErrorType: AWSErrorType {
+    enum Code: String {
+        case internalServerErrorException = "InternalServerErrorException"
+        case invalidRequestException = "InvalidRequestException"
+        case resourceAlreadyExistsException = "ResourceAlreadyExistsException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case tooManyRequestsException = "TooManyRequestsException"
+        case unauthorizedException = "UnauthorizedException"
+    }
 
-extension WorkLinkErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "InternalServerErrorException":
-            self = .internalServerErrorException(message: message)
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        case "ResourceAlreadyExistsException":
-            self = .resourceAlreadyExistsException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "TooManyRequestsException":
-            self = .tooManyRequestsException(message: message)
-        case "UnauthorizedException":
-            self = .unauthorizedException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var internalServerErrorException: Self { .init(.internalServerErrorException) }
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+    public static var resourceAlreadyExistsException: Self { .init(.resourceAlreadyExistsException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var tooManyRequestsException: Self { .init(.tooManyRequestsException) }
+    public static var unauthorizedException: Self { .init(.unauthorizedException) }
+}
+
+extension WorkLinkErrorType: Equatable {
+    public static func == (lhs: WorkLinkErrorType, rhs: WorkLinkErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension WorkLinkErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .internalServerErrorException(let message):
-            return "InternalServerErrorException: \(message ?? "")"
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        case .resourceAlreadyExistsException(let message):
-            return "ResourceAlreadyExistsException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .tooManyRequestsException(let message):
-            return "TooManyRequestsException: \(message ?? "")"
-        case .unauthorizedException(let message):
-            return "UnauthorizedException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/WorkMail/WorkMail_Error.swift
+++ b/Sources/Soto/Services/WorkMail/WorkMail_Error.swift
@@ -17,120 +17,76 @@
 import SotoCore
 
 /// Error enum for WorkMail
-public enum WorkMailErrorType: AWSErrorType {
-    case directoryServiceAuthenticationFailedException(message: String?)
-    case directoryUnavailableException(message: String?)
-    case emailAddressInUseException(message: String?)
-    case entityAlreadyRegisteredException(message: String?)
-    case entityNotFoundException(message: String?)
-    case entityStateException(message: String?)
-    case invalidConfigurationException(message: String?)
-    case invalidParameterException(message: String?)
-    case invalidPasswordException(message: String?)
-    case limitExceededException(message: String?)
-    case mailDomainNotFoundException(message: String?)
-    case mailDomainStateException(message: String?)
-    case nameAvailabilityException(message: String?)
-    case organizationNotFoundException(message: String?)
-    case organizationStateException(message: String?)
-    case reservedNameException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case tooManyTagsException(message: String?)
-    case unsupportedOperationException(message: String?)
-}
+public struct WorkMailErrorType: AWSErrorType {
+    enum Code: String {
+        case directoryServiceAuthenticationFailedException = "DirectoryServiceAuthenticationFailedException"
+        case directoryUnavailableException = "DirectoryUnavailableException"
+        case emailAddressInUseException = "EmailAddressInUseException"
+        case entityAlreadyRegisteredException = "EntityAlreadyRegisteredException"
+        case entityNotFoundException = "EntityNotFoundException"
+        case entityStateException = "EntityStateException"
+        case invalidConfigurationException = "InvalidConfigurationException"
+        case invalidParameterException = "InvalidParameterException"
+        case invalidPasswordException = "InvalidPasswordException"
+        case limitExceededException = "LimitExceededException"
+        case mailDomainNotFoundException = "MailDomainNotFoundException"
+        case mailDomainStateException = "MailDomainStateException"
+        case nameAvailabilityException = "NameAvailabilityException"
+        case organizationNotFoundException = "OrganizationNotFoundException"
+        case organizationStateException = "OrganizationStateException"
+        case reservedNameException = "ReservedNameException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case tooManyTagsException = "TooManyTagsException"
+        case unsupportedOperationException = "UnsupportedOperationException"
+    }
 
-extension WorkMailErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "DirectoryServiceAuthenticationFailedException":
-            self = .directoryServiceAuthenticationFailedException(message: message)
-        case "DirectoryUnavailableException":
-            self = .directoryUnavailableException(message: message)
-        case "EmailAddressInUseException":
-            self = .emailAddressInUseException(message: message)
-        case "EntityAlreadyRegisteredException":
-            self = .entityAlreadyRegisteredException(message: message)
-        case "EntityNotFoundException":
-            self = .entityNotFoundException(message: message)
-        case "EntityStateException":
-            self = .entityStateException(message: message)
-        case "InvalidConfigurationException":
-            self = .invalidConfigurationException(message: message)
-        case "InvalidParameterException":
-            self = .invalidParameterException(message: message)
-        case "InvalidPasswordException":
-            self = .invalidPasswordException(message: message)
-        case "LimitExceededException":
-            self = .limitExceededException(message: message)
-        case "MailDomainNotFoundException":
-            self = .mailDomainNotFoundException(message: message)
-        case "MailDomainStateException":
-            self = .mailDomainStateException(message: message)
-        case "NameAvailabilityException":
-            self = .nameAvailabilityException(message: message)
-        case "OrganizationNotFoundException":
-            self = .organizationNotFoundException(message: message)
-        case "OrganizationStateException":
-            self = .organizationStateException(message: message)
-        case "ReservedNameException":
-            self = .reservedNameException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "TooManyTagsException":
-            self = .tooManyTagsException(message: message)
-        case "UnsupportedOperationException":
-            self = .unsupportedOperationException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var directoryServiceAuthenticationFailedException: Self { .init(.directoryServiceAuthenticationFailedException) }
+    public static var directoryUnavailableException: Self { .init(.directoryUnavailableException) }
+    public static var emailAddressInUseException: Self { .init(.emailAddressInUseException) }
+    public static var entityAlreadyRegisteredException: Self { .init(.entityAlreadyRegisteredException) }
+    public static var entityNotFoundException: Self { .init(.entityNotFoundException) }
+    public static var entityStateException: Self { .init(.entityStateException) }
+    public static var invalidConfigurationException: Self { .init(.invalidConfigurationException) }
+    public static var invalidParameterException: Self { .init(.invalidParameterException) }
+    public static var invalidPasswordException: Self { .init(.invalidPasswordException) }
+    public static var limitExceededException: Self { .init(.limitExceededException) }
+    public static var mailDomainNotFoundException: Self { .init(.mailDomainNotFoundException) }
+    public static var mailDomainStateException: Self { .init(.mailDomainStateException) }
+    public static var nameAvailabilityException: Self { .init(.nameAvailabilityException) }
+    public static var organizationNotFoundException: Self { .init(.organizationNotFoundException) }
+    public static var organizationStateException: Self { .init(.organizationStateException) }
+    public static var reservedNameException: Self { .init(.reservedNameException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var tooManyTagsException: Self { .init(.tooManyTagsException) }
+    public static var unsupportedOperationException: Self { .init(.unsupportedOperationException) }
+}
+
+extension WorkMailErrorType: Equatable {
+    public static func == (lhs: WorkMailErrorType, rhs: WorkMailErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension WorkMailErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .directoryServiceAuthenticationFailedException(let message):
-            return "DirectoryServiceAuthenticationFailedException: \(message ?? "")"
-        case .directoryUnavailableException(let message):
-            return "DirectoryUnavailableException: \(message ?? "")"
-        case .emailAddressInUseException(let message):
-            return "EmailAddressInUseException: \(message ?? "")"
-        case .entityAlreadyRegisteredException(let message):
-            return "EntityAlreadyRegisteredException: \(message ?? "")"
-        case .entityNotFoundException(let message):
-            return "EntityNotFoundException: \(message ?? "")"
-        case .entityStateException(let message):
-            return "EntityStateException: \(message ?? "")"
-        case .invalidConfigurationException(let message):
-            return "InvalidConfigurationException: \(message ?? "")"
-        case .invalidParameterException(let message):
-            return "InvalidParameterException: \(message ?? "")"
-        case .invalidPasswordException(let message):
-            return "InvalidPasswordException: \(message ?? "")"
-        case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
-        case .mailDomainNotFoundException(let message):
-            return "MailDomainNotFoundException: \(message ?? "")"
-        case .mailDomainStateException(let message):
-            return "MailDomainStateException: \(message ?? "")"
-        case .nameAvailabilityException(let message):
-            return "NameAvailabilityException: \(message ?? "")"
-        case .organizationNotFoundException(let message):
-            return "OrganizationNotFoundException: \(message ?? "")"
-        case .organizationStateException(let message):
-            return "OrganizationStateException: \(message ?? "")"
-        case .reservedNameException(let message):
-            return "ReservedNameException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .tooManyTagsException(let message):
-            return "TooManyTagsException: \(message ?? "")"
-        case .unsupportedOperationException(let message):
-            return "UnsupportedOperationException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/WorkMailMessageFlow/WorkMailMessageFlow_Error.swift
+++ b/Sources/Soto/Services/WorkMailMessageFlow/WorkMailMessageFlow_Error.swift
@@ -17,30 +17,40 @@
 import SotoCore
 
 /// Error enum for WorkMailMessageFlow
-public enum WorkMailMessageFlowErrorType: AWSErrorType {
-    case resourceNotFoundException(message: String?)
-}
+public struct WorkMailMessageFlowErrorType: AWSErrorType {
+    enum Code: String {
+        case resourceNotFoundException = "ResourceNotFoundException"
+    }
 
-extension WorkMailMessageFlowErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+}
+
+extension WorkMailMessageFlowErrorType: Equatable {
+    public static func == (lhs: WorkMailMessageFlowErrorType, rhs: WorkMailMessageFlowErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension WorkMailMessageFlowErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/WorkSpaces/WorkSpaces_Error.swift
+++ b/Sources/Soto/Services/WorkSpaces/WorkSpaces_Error.swift
@@ -17,95 +17,66 @@
 import SotoCore
 
 /// Error enum for WorkSpaces
-public enum WorkSpacesErrorType: AWSErrorType {
-    case accessDeniedException(message: String?)
-    case invalidParameterValuesException(message: String?)
-    case invalidResourceStateException(message: String?)
-    case operationInProgressException(message: String?)
-    case operationNotSupportedException(message: String?)
-    case resourceAlreadyExistsException(message: String?)
-    case resourceAssociatedException(message: String?)
-    case resourceCreationFailedException(message: String?)
-    case resourceLimitExceededException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case resourceUnavailableException(message: String?)
-    case unsupportedNetworkConfigurationException(message: String?)
-    case unsupportedWorkspaceConfigurationException(message: String?)
-    case workspacesDefaultRoleNotFoundException(message: String?)
-}
+public struct WorkSpacesErrorType: AWSErrorType {
+    enum Code: String {
+        case accessDeniedException = "AccessDeniedException"
+        case invalidParameterValuesException = "InvalidParameterValuesException"
+        case invalidResourceStateException = "InvalidResourceStateException"
+        case operationInProgressException = "OperationInProgressException"
+        case operationNotSupportedException = "OperationNotSupportedException"
+        case resourceAlreadyExistsException = "ResourceAlreadyExistsException"
+        case resourceAssociatedException = "ResourceAssociatedException"
+        case resourceCreationFailedException = "ResourceCreationFailedException"
+        case resourceLimitExceededException = "ResourceLimitExceededException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case resourceUnavailableException = "ResourceUnavailableException"
+        case unsupportedNetworkConfigurationException = "UnsupportedNetworkConfigurationException"
+        case unsupportedWorkspaceConfigurationException = "UnsupportedWorkspaceConfigurationException"
+        case workspacesDefaultRoleNotFoundException = "WorkspacesDefaultRoleNotFoundException"
+    }
 
-extension WorkSpacesErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "AccessDeniedException":
-            self = .accessDeniedException(message: message)
-        case "InvalidParameterValuesException":
-            self = .invalidParameterValuesException(message: message)
-        case "InvalidResourceStateException":
-            self = .invalidResourceStateException(message: message)
-        case "OperationInProgressException":
-            self = .operationInProgressException(message: message)
-        case "OperationNotSupportedException":
-            self = .operationNotSupportedException(message: message)
-        case "ResourceAlreadyExistsException":
-            self = .resourceAlreadyExistsException(message: message)
-        case "ResourceAssociatedException":
-            self = .resourceAssociatedException(message: message)
-        case "ResourceCreationFailedException":
-            self = .resourceCreationFailedException(message: message)
-        case "ResourceLimitExceededException":
-            self = .resourceLimitExceededException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "ResourceUnavailableException":
-            self = .resourceUnavailableException(message: message)
-        case "UnsupportedNetworkConfigurationException":
-            self = .unsupportedNetworkConfigurationException(message: message)
-        case "UnsupportedWorkspaceConfigurationException":
-            self = .unsupportedWorkspaceConfigurationException(message: message)
-        case "WorkspacesDefaultRoleNotFoundException":
-            self = .workspacesDefaultRoleNotFoundException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var accessDeniedException: Self { .init(.accessDeniedException) }
+    public static var invalidParameterValuesException: Self { .init(.invalidParameterValuesException) }
+    public static var invalidResourceStateException: Self { .init(.invalidResourceStateException) }
+    public static var operationInProgressException: Self { .init(.operationInProgressException) }
+    public static var operationNotSupportedException: Self { .init(.operationNotSupportedException) }
+    public static var resourceAlreadyExistsException: Self { .init(.resourceAlreadyExistsException) }
+    public static var resourceAssociatedException: Self { .init(.resourceAssociatedException) }
+    public static var resourceCreationFailedException: Self { .init(.resourceCreationFailedException) }
+    public static var resourceLimitExceededException: Self { .init(.resourceLimitExceededException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var resourceUnavailableException: Self { .init(.resourceUnavailableException) }
+    public static var unsupportedNetworkConfigurationException: Self { .init(.unsupportedNetworkConfigurationException) }
+    public static var unsupportedWorkspaceConfigurationException: Self { .init(.unsupportedWorkspaceConfigurationException) }
+    public static var workspacesDefaultRoleNotFoundException: Self { .init(.workspacesDefaultRoleNotFoundException) }
+}
+
+extension WorkSpacesErrorType: Equatable {
+    public static func == (lhs: WorkSpacesErrorType, rhs: WorkSpacesErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension WorkSpacesErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .accessDeniedException(let message):
-            return "AccessDeniedException: \(message ?? "")"
-        case .invalidParameterValuesException(let message):
-            return "InvalidParameterValuesException: \(message ?? "")"
-        case .invalidResourceStateException(let message):
-            return "InvalidResourceStateException: \(message ?? "")"
-        case .operationInProgressException(let message):
-            return "OperationInProgressException: \(message ?? "")"
-        case .operationNotSupportedException(let message):
-            return "OperationNotSupportedException: \(message ?? "")"
-        case .resourceAlreadyExistsException(let message):
-            return "ResourceAlreadyExistsException: \(message ?? "")"
-        case .resourceAssociatedException(let message):
-            return "ResourceAssociatedException: \(message ?? "")"
-        case .resourceCreationFailedException(let message):
-            return "ResourceCreationFailedException: \(message ?? "")"
-        case .resourceLimitExceededException(let message):
-            return "ResourceLimitExceededException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .resourceUnavailableException(let message):
-            return "ResourceUnavailableException: \(message ?? "")"
-        case .unsupportedNetworkConfigurationException(let message):
-            return "UnsupportedNetworkConfigurationException: \(message ?? "")"
-        case .unsupportedWorkspaceConfigurationException(let message):
-            return "UnsupportedWorkspaceConfigurationException: \(message ?? "")"
-        case .workspacesDefaultRoleNotFoundException(let message):
-            return "WorkspacesDefaultRoleNotFoundException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Sources/Soto/Services/XRay/XRay_Error.swift
+++ b/Sources/Soto/Services/XRay/XRay_Error.swift
@@ -17,50 +17,48 @@
 import SotoCore
 
 /// Error enum for XRay
-public enum XRayErrorType: AWSErrorType {
-    case invalidRequestException(message: String?)
-    case resourceNotFoundException(message: String?)
-    case ruleLimitExceededException(message: String?)
-    case throttledException(message: String?)
-    case tooManyTagsException(message: String?)
-}
+public struct XRayErrorType: AWSErrorType {
+    enum Code: String {
+        case invalidRequestException = "InvalidRequestException"
+        case resourceNotFoundException = "ResourceNotFoundException"
+        case ruleLimitExceededException = "RuleLimitExceededException"
+        case throttledException = "ThrottledException"
+        case tooManyTagsException = "TooManyTagsException"
+    }
 
-extension XRayErrorType {
+    private var error: Code
+    public var message: String?
+
     public init?(errorCode: String, message: String?) {
         var errorCode = errorCode
         if let index = errorCode.firstIndex(of: "#") {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
-        switch errorCode {
-        case "InvalidRequestException":
-            self = .invalidRequestException(message: message)
-        case "ResourceNotFoundException":
-            self = .resourceNotFoundException(message: message)
-        case "RuleLimitExceededException":
-            self = .ruleLimitExceededException(message: message)
-        case "ThrottledException":
-            self = .throttledException(message: message)
-        case "TooManyTagsException":
-            self = .tooManyTagsException(message: message)
-        default:
-            return nil
-        }
+        guard let error = Code(rawValue: errorCode) else { return nil }
+        self.error = error
+        self.message = message
+    }
+
+    internal init(_ error: Code) {
+        self.error = error
+        self.message = nil
+    }
+
+    public static var invalidRequestException: Self { .init(.invalidRequestException) }
+    public static var resourceNotFoundException: Self { .init(.resourceNotFoundException) }
+    public static var ruleLimitExceededException: Self { .init(.ruleLimitExceededException) }
+    public static var throttledException: Self { .init(.throttledException) }
+    public static var tooManyTagsException: Self { .init(.tooManyTagsException) }
+}
+
+extension XRayErrorType: Equatable {
+    public static func == (lhs: XRayErrorType, rhs: XRayErrorType) -> Bool {
+        lhs.error == rhs.error
     }
 }
 
 extension XRayErrorType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case .invalidRequestException(let message):
-            return "InvalidRequestException: \(message ?? "")"
-        case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
-        case .ruleLimitExceededException(let message):
-            return "RuleLimitExceededException: \(message ?? "")"
-        case .throttledException(let message):
-            return "ThrottledException: \(message ?? "")"
-        case .tooManyTagsException(let message):
-            return "TooManyTagsException: \(message ?? "")"
-        }
+        return "\(self.error.rawValue): \(self.message ?? "")"
     }
 }

--- a/Tests/SotoTests/Services/APIGateway/APIGatewayTests.swift
+++ b/Tests/SotoTests/Services/APIGateway/APIGatewayTests.swift
@@ -151,8 +151,8 @@ class APIGatewayTests: XCTestCase {
         let response = Self.apiGateway.getModels(.init(restApiId: "invalid-rest-api-id"))
         XCTAssertThrowsError(try response.wait()) { error in
             switch error {
-            case APIGatewayErrorType.notFoundException(let message):
-                XCTAssertNotNil(message)
+            case let error as APIGatewayErrorType where error == .notFoundException:
+                XCTAssertNotNil(error.message)
             default:
                 // local stack is returning a duff error at the moment
                 if TestEnvironment.isUsingLocalstack {

--- a/Tests/SotoTests/Services/CloudTrail/CloudTrailTests.swift
+++ b/Tests/SotoTests/Services/CloudTrail/CloudTrailTests.swift
@@ -59,8 +59,8 @@ class CloudTrailTests: XCTestCase {
         let response = Self.cloudTrail.getTrail(.init(name: "nonexistent-trail"))
         XCTAssertThrowsError(try response.wait()) { error in
             switch error {
-            case CloudTrailErrorType.trailNotFoundException(let message):
-                XCTAssertNotNil(message)
+            case let error as CloudTrailErrorType where error == .trailNotFoundException:
+                XCTAssertNotNil(error.message)
             default:
                 XCTFail("Wrong error: \(error)")
             }

--- a/Tests/SotoTests/Services/DynamoDB/DynamoDBCodableTests.swift
+++ b/Tests/SotoTests/Services/DynamoDB/DynamoDBCodableTests.swift
@@ -43,7 +43,7 @@ final class DynamoDBCodableTests: XCTestCase {
             }
             .flatMapErrorThrowing { error in
                 switch error {
-                case DynamoDBErrorType.resourceInUseException:
+                case let error as DynamoDBErrorType where error == .resourceInUseException:
                     print("Table (\(name)) already exists")
                     return
                 default:

--- a/Tests/SotoTests/Services/DynamoDB/DynamoDBTests.swift
+++ b/Tests/SotoTests/Services/DynamoDB/DynamoDBTests.swift
@@ -56,7 +56,7 @@ class DynamoDBTests: XCTestCase {
             }
             .flatMapErrorThrowing { error in
                 switch error {
-                case DynamoDBErrorType.resourceInUseException:
+                case let error as DynamoDBErrorType where error == .resourceInUseException:
                     print("Table (\(name)) already exists")
                     return
                 default:
@@ -183,8 +183,8 @@ class DynamoDBTests: XCTestCase {
         let response = Self.dynamoDB.describeTable(.init(tableName: "non-existent-table"))
         XCTAssertThrowsError(try response.wait()) { error in
             switch error {
-            case DynamoDBErrorType.resourceNotFoundException(let message):
-                XCTAssertNotNil(message)
+            case let error as DynamoDBErrorType where error == .resourceNotFoundException:
+                XCTAssertNotNil(error.message)
             default:
                 XCTFail("Wrong error: \(error)")
             }

--- a/Tests/SotoTests/Services/Glacier/GlacierTests.swift
+++ b/Tests/SotoTests/Services/Glacier/GlacierTests.swift
@@ -83,8 +83,8 @@ class GlacierTests: XCTestCase {
         let response = Self.glacier.initiateJob(inventoryJobInput)
         XCTAssertThrowsError(try response.wait()) { error in
             switch error {
-            case GlacierErrorType.resourceNotFoundException(let message):
-                XCTAssertNotNil(message)
+            case let error as GlacierErrorType where error == .resourceNotFoundException:
+                XCTAssertNotNil(error.message)
             default:
                 XCTFail("Wrong error: \(error)")
             }

--- a/Tests/SotoTests/Services/IAM/IAMTests.swift
+++ b/Tests/SotoTests/Services/IAM/IAMTests.swift
@@ -48,7 +48,7 @@ class IAMTests: XCTestCase {
             }
             .flatMapErrorThrowing { error in
                 switch error {
-                case IAMErrorType.entityAlreadyExistsException:
+                case let error as IAMErrorType where error == .entityAlreadyExistsException:
                     print("User (\(userName)) already exists")
                     return
                 default:
@@ -198,8 +198,8 @@ class IAMTests: XCTestCase {
         let response = Self.iam.getRole(.init(roleName: "_invalid-role-name"), logger: TestEnvironment.logger)
         XCTAssertThrowsError(try response.wait()) { error in
             switch error {
-            case IAMErrorType.noSuchEntityException(let message):
-                XCTAssertNotNil(message)
+            case let error as IAMErrorType where error == .noSuchEntityException:
+                XCTAssertNotNil(error.message)
             default:
                 XCTFail("Wrong error: \(error)")
             }

--- a/Tests/SotoTests/Services/Lambda/LambdaTests.swift
+++ b/Tests/SotoTests/Services/Lambda/LambdaTests.swift
@@ -61,8 +61,8 @@ class LambdaTests: XCTestCase {
         let response = Self.lambda.invoke(.init(functionName: "non-existent-function"))
         XCTAssertThrowsError(try response.wait()) { error in
             switch error {
-            case LambdaErrorType.resourceNotFoundException(let message):
-                XCTAssertNotNil(message)
+            case let error as LambdaErrorType where error == .resourceNotFoundException:
+                XCTAssertNotNil(error.message)
             default:
                 XCTFail("Wrong error: \(error)")
             }

--- a/Tests/SotoTests/Services/S3/S3ExtensionTests.swift
+++ b/Tests/SotoTests/Services/S3/S3ExtensionTests.swift
@@ -252,7 +252,7 @@ class S3ExtensionTests: XCTestCase {
             }
             .flatMapErrorThrowing { error -> Void in
                 switch error {
-                case S3ErrorType.noSuchBucket:
+                case let error as S3ErrorType where error == .noSuchBucket:
                     return
                 default:
                     XCTFail("Unexpected error: \(error)")

--- a/Tests/SotoTests/Services/SNS/SNSTests.swift
+++ b/Tests/SotoTests/Services/SNS/SNSTests.swift
@@ -111,8 +111,13 @@ class SNSTests: XCTestCase {
         let response = Self.sns.getTopicAttributes(.init(topicArn: "arn:sns:invalid"))
         XCTAssertThrowsError(try response.wait()) { error in
             switch error {
-            case SNSErrorType.invalidParameterException(let message), SNSErrorType.notFoundException(let message):
-                XCTAssertNotNil(message)
+            case let error as SNSErrorType:
+                switch error {
+                case .invalidParameterException, .notFoundException:
+                    XCTAssertNotNil(error.message)
+                default:
+                    XCTFail("Wrong error: \(error)")
+                }
             default:
                 XCTFail("Wrong error: \(error)")
             }

--- a/Tests/SotoTests/Services/SQS/SQSTests.swift
+++ b/Tests/SotoTests/Services/SQS/SQSTests.swift
@@ -129,8 +129,8 @@ class SQSTests: XCTestCase {
         let response = Self.sqs.addPermission(.init(actions: [], aWSAccountIds: [], label: "label", queueUrl: "http://aws-not-a-queue"))
         XCTAssertThrowsError(try response.wait()) { error in
             switch error {
-            case SQSErrorType.queueDoesNotExist(let message):
-                XCTAssertNotNil(message)
+            case let error as SQSErrorType where error == .queueDoesNotExist:
+                XCTAssertNotNil(error.message)
             default:
                 XCTFail("Wrong error: \(error)")
             }

--- a/Tests/SotoTests/Services/SSM/SSMTests.swift
+++ b/Tests/SotoTests/Services/SSM/SSMTests.swift
@@ -95,8 +95,8 @@ class SSMTests: XCTestCase {
         let response = Self.ssm.describeDocument(.init(name: "non-existent-document"))
         XCTAssertThrowsError(try response.wait()) { error in
             switch error {
-            case SSMErrorType.invalidDocument(let message):
-                XCTAssertNotNil(message)
+            case let error as SSMErrorType where error == .invalidDocument:
+                XCTAssertNotNil(error.message)
             default:
                 XCTFail("Wrong error: \(error)")
             }

--- a/Tests/SotoTests/Services/STS/STSTests.swift
+++ b/Tests/SotoTests/Services/STS/STSTests.swift
@@ -87,7 +87,7 @@ class STSTests: XCTestCase {
         let sns = SNS(client: client)
         XCTAssertThrowsError(try sns.listTopics(.init()).wait()) { error in
             switch error {
-            case SNSErrorType.authorizationErrorException:
+            case let error as SNSErrorType where error == .authorizationErrorException:
                 break
             default:
                 XCTFail("Wrong error \(error)")
@@ -101,8 +101,8 @@ class STSTests: XCTestCase {
             .map { _ in }
             .flatMapErrorThrowing { error in
                 switch error {
-                case STSErrorType.invalidIdentityTokenException(let message):
-                    XCTAssertNotNil(message)
+                case let error as STSErrorType where error == .invalidIdentityTokenException:
+                    XCTAssertNotNil(error.message)
                 default:
                     throw error
                 }


### PR DESCRIPTION
Replace enums with structs. Allows us to add new errors without a major version increase. Also allows us to provide more context for when an error is thrown.