### PR TITLE
create a lambda function to test invoke()

### DIFF
--- a/Tests/SotoTests/Services/Lambda/LambdaTests.swift
+++ b/Tests/SotoTests/Services/Lambda/LambdaTests.swift
@@ -12,15 +12,99 @@
 //
 //===----------------------------------------------------------------------===//
 
+/*
+
+ The testing code for the AWS Lambda function is created with the following commands:
+
+ echo "exports.handler = async (event) => { return \"hello world\" };" > lambda.js
+ zip lambda.zip lambda.js
+ cat lambda.zip | base64
+ rm lambda.zip
+ rm lambda.js
+
+ */
+
 import NIO
-import SotoLambda
 import XCTest
+
+@testable import SotoIAM
+@testable import SotoLambda
 
 // testing query service
 
 class LambdaTests: XCTestCase {
     static var client: AWSClient!
     static var lambda: Lambda!
+    static var iam: IAM!
+
+    static var functionName: String!
+    static var functionExecutionRoleName: String!
+
+    class func randomString(length: Int) -> String {
+        let letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        return String((0..<length).map { _ in letters.randomElement()! })
+    }
+
+    class func createLambdaFunction(roleArn: String) -> EventLoopFuture<Lambda.FunctionConfiguration> {
+        // create a "UnitTestSotoLambda-xxxx" function
+        // use pseudo random name to avoid name conflicts
+        self.functionName = "UnitTestSotoLambda-" + Self.randomString(length: 5)
+
+        // ZIPped version of "exports.handler = async (event) => { return \"hello world\" };"
+        let code = "UEsDBAoAAAAAAPFWXFGfGXl5PQAAAD0AAAAJABwAbGFtYmRhLmpzVVQJAAMVQJlfuD+ZX3V4CwABBC8Om1YEzHsDcWV4cG9ydHMuaGFuZGxlciA9IGFzeW5jIChldmVudCkgPT4geyByZXR1cm4gImhlbGxvIHdvcmxkIiB9OwpQSwECHgMKAAAAAADxVlxRnxl5eT0AAAA9AAAACQAYAAAAAAABAAAApIEAAAAAbGFtYmRhLmpzVVQFAAMVQJlfdXgLAAEELw6bVgTMewNxUEsFBgAAAAABAAEATwAAAIAAAAAAAA=="
+        let functionCode = Lambda.FunctionCode(zipFile: Data(base64Encoded: code))
+        let functionRuntime = Lambda.Runtime.nodejs12X
+        let functionHandler = "lambda.handler"
+        let cfr = Lambda.CreateFunctionRequest(
+            code: functionCode,
+            functionName: self.functionName,
+            handler: functionHandler,
+            role: roleArn,
+            runtime: functionRuntime
+        )
+        print("Creating Lambda Function : \(self.functionName!)")
+        return Self.lambda.createFunction(cfr)
+    }
+
+    class func deleteLambdaFunction() -> EventLoopFuture<Void> {
+        let dfr = Lambda.DeleteFunctionRequest(functionName: self.functionName)
+        print("Deleting Lambda function \(self.functionName!)")
+        return Self.lambda.deleteFunction(dfr)
+    }
+
+    class func createIAMRole() -> EventLoopFuture<IAM.CreateRoleResponse> {
+        self.functionExecutionRoleName = "lambda_execution_role-" + Self.randomString(length: 5)
+
+        // as documented at https://docs.aws.amazon.com/lambda/latest/dg/lambda-intro-execution-role.html
+        let assumeRolePolicyDocument = """
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Action": "sts:AssumeRole",
+                    "Effect": "Allow",
+                    "Principal": {
+                        "Service": "lambda.amazonaws.com"
+                    }
+                }
+            ]
+        }
+        """
+        let crr = IAM.CreateRoleRequest(
+            assumeRolePolicyDocument: assumeRolePolicyDocument,
+            roleName: self.functionExecutionRoleName
+        )
+        // no policies are required, create an empty role
+
+        print("Creating IAM Role : \(self.functionExecutionRoleName!)")
+        return Self.iam.createRole(crr)
+    }
+
+    class func deleteIAMRole() -> EventLoopFuture<Void> {
+        let drr = IAM.DeleteRoleRequest(roleName: self.functionExecutionRoleName)
+        print("Deleting IAM Role : \(self.functionExecutionRoleName!)")
+        return Self.iam.deleteRole(drr)
+    }
 
     override class func setUp() {
         if TestEnvironment.isUsingLocalstack {
@@ -29,15 +113,42 @@ class LambdaTests: XCTestCase {
             print("Connecting to AWS")
         }
 
-        Self.client = AWSClient(credentialProvider: TestEnvironment.credentialProvider, middlewares: TestEnvironment.middlewares, httpClientProvider: .createNew)
+        Self.client = AWSClient(
+            credentialProvider: TestEnvironment.credentialProvider,
+            middlewares: TestEnvironment.middlewares,
+            httpClientProvider: .createNew
+        )
         Self.lambda = Lambda(
             client: LambdaTests.client,
             region: .euwest1,
             endpoint: TestEnvironment.getEndPoint(environment: "LOCALSTACK_ENDPOINT")
         )
+        Self.iam = IAM(
+            client: Self.client,
+            endpoint: TestEnvironment.getEndPoint(environment: "LOCALSTACK_ENDPOINT")
+        )
+
+        // create a lambda function to test invoke()
+        do {
+            let response = try Self.createIAMRole().wait()
+            // IAM needs some time after Role creation, before the role can be attached to a Lambda function
+            // https://stackoverflow.com/a/37438525/663360
+            print("Sleeping 15 secs, waiting for IAM Role to be created")
+            sleep(15)
+            _ = try Self.createLambdaFunction(roleArn: response.role.arn).wait()
+        } catch {
+            XCTFail("Can not create prerequisites resources in the cloud, before to execute the tests: \(error)")
+        }
     }
 
     override class func tearDown() {
+        do {
+            try Self.deleteIAMRole().wait()
+            try Self.deleteLambdaFunction().wait()
+        } catch {
+            XCTFail("Can not delete testing resources in the cloud: \(error)")
+        }
+
         XCTAssertNoThrow(try Self.client.syncShutdown())
     }
 
@@ -47,7 +158,7 @@ class LambdaTests: XCTestCase {
         // This doesnt work with LocalStack
         guard !TestEnvironment.isUsingLocalstack else { return }
         // assumes there is a "Hello" function available
-        let request = Lambda.InvocationRequest(functionName: "Hello", logType: .tail, payload: .string("{}"))
+        let request = Lambda.InvocationRequest(functionName: Self.functionName, logType: .tail, payload: .string("{}"))
         let response = Self.lambda.invoke(request)
         XCTAssertNoThrow(try response.wait())
     }

--- a/Tests/SotoTests/Services/Lambda/LambdaTests.swift
+++ b/Tests/SotoTests/Services/Lambda/LambdaTests.swift
@@ -120,18 +120,17 @@ class LambdaTests: XCTestCase {
             client: Self.client,
             endpoint: TestEnvironment.getEndPoint(environment: "LOCALSTACK_ENDPOINT")
         )
-        
-        //create an IAM role
+
+        // create an IAM role
         let response = Self.createIAMRole()
             .flatMap { response -> EventLoopFuture<Lambda.FunctionConfiguration> in
                 let eventLoop = Self.client.eventLoopGroup.next()
-                
+
                 // IAM needs some time after Role creation,
                 // before the role can be attached to a Lambda function
                 // https://stackoverflow.com/a/37438525/663360
                 print("Sleeping 15 secs, waiting for IAM Role to be created")
                 let scheduled = eventLoop.flatScheduleTask(in: .seconds(15)) {
-                    
                     // create a Lambda function
                     Self.createLambdaFunction(roleArn: response.role.arn)
                 }
@@ -141,14 +140,13 @@ class LambdaTests: XCTestCase {
     }
 
     override class func tearDown() {
-
         let response = Self.deleteIAMRole()
-            .flatMap { response -> EventLoopFuture<Void> in
+            .flatMap { _ -> EventLoopFuture<Void> in
                 Self.deleteLambdaFunction()
             }
-        
+
         XCTAssertNoThrow(try response.wait())
-        
+
         XCTAssertNoThrow(try Self.client.syncShutdown())
     }
 

--- a/Tests/SotoTests/Services/Lambda/LambdaTests.swift
+++ b/Tests/SotoTests/Services/Lambda/LambdaTests.swift
@@ -155,10 +155,21 @@ class LambdaTests: XCTestCase {
     func testInvoke() {
         // This doesnt work with LocalStack
         guard !TestEnvironment.isUsingLocalstack else { return }
-        // assumes there is a "Hello" function available
+
+        // invoke the Lambda function created by setUp()
         let request = Lambda.InvocationRequest(functionName: Self.functionName, logType: .tail, payload: .string("{}"))
-        let response = Self.lambda.invoke(request)
-        XCTAssertNoThrow(try response.wait())
+        _ = Self.lambda.invoke(request)
+            .map { response -> Void in
+                // is there an function execution error returned by the service?
+                XCTAssertNil(response.functionError)
+
+                // check the payload matches the one from the Lambda function
+                guard let payload = response.payload?.asString() else {
+                    XCTFail("Lambda function should return a payload")
+                    return
+                }
+                XCTAssertEqual(payload, "\"hello world\"")
+            }
     }
 
     func testListFunctions() {


### PR DESCRIPTION
As [discussed](https://soto-project.slack.com/archives/C012XA3DE1F/p1603823562069100), the existing LambdaTests assumes a `Hello` Lambda function exists in the testing AWS Account.  This change ensures a Lambda function is created specifically before to run the test, and deletes the function afterwards.

It's a bit longer than I though because IAM Execution Roles are mandatory for Lambda functions, so the code also creates and deletes an role with no permission, to attach to the Lambda function at runtime.

On my Github / AWS accounts, the CI GitHub Actions now runs with success !