### PR TITLE
STS credential request renew closures

### DIFF
--- a/Sources/Soto/Extensions/CognitoIdentity/CognitoIdentity+CredentialProvider.swift
+++ b/Sources/Soto/Extensions/CognitoIdentity/CognitoIdentity+CredentialProvider.swift
@@ -18,17 +18,6 @@ import NIO
 import SotoCore
 
 extension CognitoIdentity {
-    struct RotatingCredential: ExpiringCredential {
-        func isExpiring(within interval: TimeInterval) -> Bool {
-            return self.expiration.timeIntervalSinceNow < interval
-        }
-
-        let accessKeyId: String
-        let secretAccessKey: String
-        let sessionToken: String?
-        let expiration: Date
-    }
-
     struct IdentityCredentialProvider: CredentialProvider {
         let logins: [String: String]?
         let client: AWSClient

--- a/Sources/Soto/Extensions/STS/STS+CredentialProvider.swift
+++ b/Sources/Soto/Extensions/STS/STS+CredentialProvider.swift
@@ -51,7 +51,7 @@ extension STS {
 
     enum RequestProvider<Request> {
         case `static`(Request)
-        case dynamic((EventLoop)->EventLoopFuture<Request>)
+        case dynamic((EventLoop) -> EventLoopFuture<Request>)
 
         func request(on eventLoop: EventLoop) -> EventLoopFuture<Request> {
             switch self {
@@ -227,7 +227,7 @@ extension CredentialProviderFactory {
     ///   - credentialProvider: Credential provider used in client that runs the AssumeRole operation
     ///   - region: Region to run request in
     public static func stsAssumeRole(
-        requestProvider: @escaping (EventLoop)->EventLoopFuture<STS.AssumeRoleRequest>,
+        requestProvider: @escaping (EventLoop) -> EventLoopFuture<STS.AssumeRoleRequest>,
         credentialProvider: CredentialProviderFactory = .default,
         region: Region
     ) -> CredentialProviderFactory {
@@ -258,7 +258,7 @@ extension CredentialProviderFactory {
     ///   - requestProvider: Function that returns a EventLoopFuture to be fulfillled with an AssumeRoleWithSAML request struct
     ///   - region: Region to run request in
     public static func stsSAML(
-        requestProvider: @escaping (EventLoop)->EventLoopFuture<STS.AssumeRoleWithSAMLRequest>,
+        requestProvider: @escaping (EventLoop) -> EventLoopFuture<STS.AssumeRoleWithSAMLRequest>,
         region: Region
     ) -> CredentialProviderFactory {
         .custom { context in
@@ -283,7 +283,7 @@ extension CredentialProviderFactory {
     ///   - requestProvider: Function that returns a EventLoopFuture to be fulfillled with an AssumeRoleWithWebIdentity request struct
     ///   - region: Region to run request in
     public static func stsWebIdentity(
-        requestProvider: @escaping (EventLoop)->EventLoopFuture<STS.AssumeRoleWithWebIdentityRequest>,
+        requestProvider: @escaping (EventLoop) -> EventLoopFuture<STS.AssumeRoleWithWebIdentityRequest>,
         region: Region
     ) -> CredentialProviderFactory {
         .custom { context in
@@ -340,7 +340,7 @@ extension CredentialProviderFactory {
     ///   - credentialProvider: Credential provider used in client that runs the GetSessionToken operation
     ///   - region: Region to run request in
     public static func stsSessionToken(
-        requestProvider: @escaping (EventLoop)->EventLoopFuture<STS.GetSessionTokenRequest>,
+        requestProvider: @escaping (EventLoop) -> EventLoopFuture<STS.GetSessionTokenRequest>,
         credentialProvider: CredentialProviderFactory = .default,
         region: Region
     ) -> CredentialProviderFactory {

--- a/Sources/Soto/Extensions/STS/STS+CredentialProvider.swift
+++ b/Sources/Soto/Extensions/STS/STS+CredentialProvider.swift
@@ -38,17 +38,6 @@ extension CredentialProviderWithClient {
 }
 
 extension STS {
-    struct RotatingCredential: ExpiringCredential {
-        func isExpiring(within interval: TimeInterval) -> Bool {
-            return self.expiration.timeIntervalSinceNow < interval
-        }
-
-        let accessKeyId: String
-        let secretAccessKey: String
-        let sessionToken: String?
-        let expiration: Date
-    }
-
     enum RequestProvider<Request> {
         case `static`(Request)
         case dynamic((EventLoop) -> EventLoopFuture<Request>)

--- a/Sources/Soto/Extensions/STS/STS+CredentialProvider.swift
+++ b/Sources/Soto/Extensions/STS/STS+CredentialProvider.swift
@@ -81,7 +81,7 @@ extension STS {
 
         func getCredential(on eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<Credential> {
             return requestProvider.request(on: eventLoop).flatMap { request in
-                sts.assumeRole(request, on: eventLoop)
+                self.sts.assumeRole(request, on: eventLoop)
             }.flatMapThrowing { response in
                 guard let credentials = response.credentials else { throw CredentialProviderError.noProvider }
                 return RotatingCredential(
@@ -107,7 +107,7 @@ extension STS {
 
         func getCredential(on eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<Credential> {
             return requestProvider.request(on: eventLoop).flatMap { request in
-                sts.assumeRoleWithSAML(request, on: eventLoop)
+                self.sts.assumeRoleWithSAML(request, on: eventLoop)
             }.flatMapThrowing { response in
                 guard let credentials = response.credentials else { throw CredentialProviderError.noProvider }
                 return RotatingCredential(
@@ -133,7 +133,7 @@ extension STS {
 
         func getCredential(on eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<Credential> {
             return requestProvider.request(on: eventLoop).flatMap { request in
-                sts.assumeRoleWithWebIdentity(request, on: eventLoop)
+                self.sts.assumeRoleWithWebIdentity(request, on: eventLoop)
             }.flatMapThrowing { response in
                 guard let credentials = response.credentials else { throw CredentialProviderError.noProvider }
                 return RotatingCredential(
@@ -159,7 +159,7 @@ extension STS {
 
         func getCredential(on eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<Credential> {
             return requestProvider.request(on: eventLoop).flatMap { request in
-                sts.getFederationToken(request, on: eventLoop)
+                self.sts.getFederationToken(request, on: eventLoop)
             }.flatMapThrowing { response in
                 guard let credentials = response.credentials else { throw CredentialProviderError.noProvider }
                 return RotatingCredential(
@@ -185,7 +185,7 @@ extension STS {
 
         func getCredential(on eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<Credential> {
             return requestProvider.request(on: eventLoop).flatMap { request in
-                sts.getSessionToken(request, on: eventLoop)
+                self.sts.getSessionToken(request, on: eventLoop)
             }.flatMapThrowing { response in
                 guard let credentials = response.credentials else { throw CredentialProviderError.noProvider }
                 return RotatingCredential(
@@ -227,9 +227,9 @@ extension CredentialProviderFactory {
     ///   - credentialProvider: Credential provider used in client that runs the AssumeRole operation
     ///   - region: Region to run request in
     public static func stsAssumeRole(
-        requestProvider: @escaping (EventLoop) -> EventLoopFuture<STS.AssumeRoleRequest>,
         credentialProvider: CredentialProviderFactory = .default,
-        region: Region
+        region: Region,
+        requestProvider: @escaping (EventLoop) -> EventLoopFuture<STS.AssumeRoleRequest>
     ) -> CredentialProviderFactory {
         .custom { context in
             let provider = STS.AssumeRoleCredentialProvider(
@@ -258,8 +258,8 @@ extension CredentialProviderFactory {
     ///   - requestProvider: Function that returns a EventLoopFuture to be fulfillled with an AssumeRoleWithSAML request struct
     ///   - region: Region to run request in
     public static func stsSAML(
-        requestProvider: @escaping (EventLoop) -> EventLoopFuture<STS.AssumeRoleWithSAMLRequest>,
-        region: Region
+        region: Region,
+        requestProvider: @escaping (EventLoop) -> EventLoopFuture<STS.AssumeRoleWithSAMLRequest>
     ) -> CredentialProviderFactory {
         .custom { context in
             let provider = STS.AssumeRoleWithSAMLCredentialProvider(requestProvider: .dynamic(requestProvider), region: region, httpClient: context.httpClient)
@@ -283,8 +283,8 @@ extension CredentialProviderFactory {
     ///   - requestProvider: Function that returns a EventLoopFuture to be fulfillled with an AssumeRoleWithWebIdentity request struct
     ///   - region: Region to run request in
     public static func stsWebIdentity(
-        requestProvider: @escaping (EventLoop) -> EventLoopFuture<STS.AssumeRoleWithWebIdentityRequest>,
-        region: Region
+        region: Region,
+        requestProvider: @escaping (EventLoop) -> EventLoopFuture<STS.AssumeRoleWithWebIdentityRequest>
     ) -> CredentialProviderFactory {
         .custom { context in
             let provider = STS.AssumeRoleWithWebIdentityCredentialProvider(requestProvider: .dynamic(requestProvider), region: region, httpClient: context.httpClient)
@@ -340,9 +340,9 @@ extension CredentialProviderFactory {
     ///   - credentialProvider: Credential provider used in client that runs the GetSessionToken operation
     ///   - region: Region to run request in
     public static func stsSessionToken(
-        requestProvider: @escaping (EventLoop) -> EventLoopFuture<STS.GetSessionTokenRequest>,
         credentialProvider: CredentialProviderFactory = .default,
-        region: Region
+        region: Region,
+        requestProvider: @escaping (EventLoop) -> EventLoopFuture<STS.GetSessionTokenRequest>
     ) -> CredentialProviderFactory {
         .custom { context in
             let provider = STS.SessionTokenCredentialProvider(


### PR DESCRIPTION
Added new versions of `.stsAssumeRole`, `.stsAssumeSAMLRole`, `.stsAssumeWebIdentityRole`, `.stsSessionToken` which take a closure that returns an `EventLoopFuture<Request>` instead of a static `Request`.

No need to do this for `.stsFederationToken` as the request parameters would never needed updated