### PR TITLE
DynamoDB: Encode string, number arrays as lists and not sets

### DIFF
--- a/Sources/Soto/Extensions/DynamoDB/DynamoDBDecoder.swift
+++ b/Sources/Soto/Extensions/DynamoDB/DynamoDBDecoder.swift
@@ -256,7 +256,7 @@ private class _DynamoDBDecoder: Decoder {
                 guard case .n(let value) = attribute else {
                     throw DecodingError.typeMismatch(type(of: self.attribute), .init(codingPath: self.codingPath, debugDescription: "Expected DynamoDB.AttributeValue.l holding a number attribute"))
                 }
-                currentIndex += 1
+                self.currentIndex += 1
                 return value
             default:
                 throw DecodingError.typeMismatch(type(of: self.attribute), .init(codingPath: self.codingPath, debugDescription: "Expected DynamoDB.AttributeValue.l"))
@@ -274,7 +274,7 @@ private class _DynamoDBDecoder: Decoder {
                 guard case .s(let value) = attribute else {
                     throw DecodingError.typeMismatch(type(of: self.attribute), .init(codingPath: self.codingPath, debugDescription: "Expected DynamoDB.AttributeValue.l holding a string attribute"))
                 }
-                currentIndex += 1
+                self.currentIndex += 1
                 return value
             default:
                 throw DecodingError.typeMismatch(type(of: self.attribute), .init(codingPath: self.codingPath, debugDescription: "Expected DynamoDB.AttributeValue.l"))

--- a/Sources/Soto/Extensions/DynamoDB/DynamoDBDecoder.swift
+++ b/Sources/Soto/Extensions/DynamoDB/DynamoDBDecoder.swift
@@ -246,21 +246,39 @@ private class _DynamoDBDecoder: Decoder {
         }
 
         mutating func getNumberValue() throws -> String {
-            guard case .ns(let values) = self.attribute else {
+            switch self.attribute {
+            case .ns(let values):
+                let value = values[currentIndex]
+                currentIndex += 1
+                return value
+            case .l(let attributes):
+                let attribute = attributes[currentIndex]
+                guard case .n(let value) = attribute else {
+                    throw DecodingError.typeMismatch(type(of: self.attribute), .init(codingPath: self.codingPath, debugDescription: "Expected DynamoDB.AttributeValue.l holding a number attribute"))
+                }
+                currentIndex += 1
+                return value
+            default:
                 throw DecodingError.typeMismatch(type(of: self.attribute), .init(codingPath: self.codingPath, debugDescription: "Expected DynamoDB.AttributeValue.l"))
             }
-            let value = values[currentIndex]
-            currentIndex += 1
-            return value
         }
 
         mutating func getStringValue() throws -> String {
-            guard case .ss(let values) = self.attribute else {
+            switch self.attribute {
+            case .ss(let values):
+                let value = values[currentIndex]
+                currentIndex += 1
+                return value
+            case .l(let attributes):
+                let attribute = attributes[currentIndex]
+                guard case .s(let value) = attribute else {
+                    throw DecodingError.typeMismatch(type(of: self.attribute), .init(codingPath: self.codingPath, debugDescription: "Expected DynamoDB.AttributeValue.l holding a string attribute"))
+                }
+                currentIndex += 1
+                return value
+            default:
                 throw DecodingError.typeMismatch(type(of: self.attribute), .init(codingPath: self.codingPath, debugDescription: "Expected DynamoDB.AttributeValue.l"))
             }
-            let value = values[currentIndex]
-            currentIndex += 1
-            return value
         }
 
         mutating func decodeNil() throws -> Bool {

--- a/Sources/Soto/Extensions/DynamoDB/DynamoDBEncoder.swift
+++ b/Sources/Soto/Extensions/DynamoDB/DynamoDBEncoder.swift
@@ -73,27 +73,7 @@ private class _EncoderUnkeyedContainer: _EncoderContainer {
     var attribute: DynamoDB.AttributeValue {
         // merge child values, plus nested containers
         let values = self.values + self.nestedContainers.map { $0.attribute }
-
-        // choose array type based on first element type
-        switch values.first {
-        case .b:
-            return .bs(values.compactMap {
-                guard case .b(let value) = $0 else { return nil }
-                return value
-            })
-        case .s:
-            return .ss(values.compactMap {
-                guard case .s(let value) = $0 else { return nil }
-                return value
-            })
-        case .n:
-            return .ns(values.compactMap {
-                guard case .n(let value) = $0 else { return nil }
-                return value
-            })
-        default:
-            return .l(values)
-        }
+        return .l(values)
     }
 }
 

--- a/Tests/SotoTests/Services/DynamoDB/DynamoDBCodableTests.swift
+++ b/Tests/SotoTests/Services/DynamoDB/DynamoDBCodableTests.swift
@@ -90,7 +90,7 @@ final class DynamoDBCodableTests: XCTestCase {
             let pets: [String]?
         }
         let id = UUID().uuidString
-        let test = TestObject(id: id, name: "John", surname: "Smith", age: 32, address: "1 Park Lane", pets: ["cat", "dog"])
+        let test = TestObject(id: id, name: "John", surname: "Smith", age: 32, address: "1 Park Lane", pets: ["zebra", "cat", "dog", "cat"])
 
         let tableName = TestEnvironment.generateResourceName()
         let response = self.createTable(name: tableName)

--- a/Tests/SotoTests/Services/DynamoDB/DynamoDBCoderTests.swift
+++ b/Tests/SotoTests/Services/DynamoDB/DynamoDBCoderTests.swift
@@ -58,11 +58,12 @@ final class DynamoDBCoderTests: XCTestCase {
         struct Arrays: Codable, Equatable {
             let i: [Int]
             let s: [String]
+            let set: Set<String>?
         }
-        XCTAssertNoThrow(try self.testEncodeDecode(Arrays(i: [2, 8, 24], s: ["TestString", "TestString1"])))
+        XCTAssertNoThrow(try self.testEncodeDecode(Arrays(i: [2, 8, 24], s: ["TestString", "TestString1"], set: .init(["hello", "goodbye"]))))
         XCTAssertNoThrow(try self.testDecodeEncode([
-            "i": .ns(["24", "78", "1"]),
-            "s": .ss(["this", "is", "a", "test"]),
+            "i": .l([.n("24"), .n("78"), .n("1")]),
+            "s": .l([.s("this"), .s("is"), .s("a"), .s("test")]),
         ], type: Arrays.self))
     }
 
@@ -207,7 +208,7 @@ final class DynamoDBCoderTests: XCTestCase {
         }
         XCTAssertNoThrow(try self.testEncodeDecode(NestedUKDCTest(indices: [1, 4, 7, 8], selected: 3)))
         XCTAssertNoThrow(try self.testDecodeEncode([
-            "test": .ns(["3", "6", "8", "24"]),
+            "test": .l([.n("1"), .n("4"), .n("7"), .n("8")]),
             "selected": .n("3"),
         ], type: NestedUKDCTest.self))
     }


### PR DESCRIPTION
Previously we were using string and number sets for storing Arrays of strings or numbers. This will mean we don't use `.ss` or `.ns` at any point. When encoding it isn't possible to tell if we are encoding a `Set<>` or an `Array<>`.