### PR TITLE
Added CredentialProviderFactory.stsWebIdentityTokenFile 

### DIFF
--- a/Sources/Soto/Extensions/STS/Environment.swift
+++ b/Sources/Soto/Extensions/STS/Environment.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Soto for AWS open source project
+//
+// Copyright (c) 2017-2020 the Soto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Soto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if os(Linux)
+import Glibc
+#else
+import Darwin.C
+#endif
+
+internal enum Environment {
+    internal static subscript(_ name: String) -> String? {
+        guard let value = getenv(name) else {
+            return nil
+        }
+        return String(cString: value)
+    }
+}

--- a/Sources/Soto/Extensions/STS/STS+CredentialProvider.swift
+++ b/Sources/Soto/Extensions/STS/STS+CredentialProvider.swift
@@ -171,16 +171,19 @@ extension STS {
             )
         }
 
+        /// Shutdown credential provider. Need to shutdown webIdentity credential provider
         func shutdown(on eventLoop: EventLoop) -> EventLoopFuture<Void> {
             return tokenPromise.futureResult.flatMap { _ in
-                webIdentityProvider.shutdown(on: eventLoop)
+                self.webIdentityProvider.shutdown(on: eventLoop)
             }
         }
 
+        /// get credentials
         func getCredential(on eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<Credential> {
             return webIdentityProvider.getCredential(on: eventLoop, logger: logger)
         }
 
+        /// Load web identity token file
         static func loadTokenFile(_ tokenFile: String, on eventLoop: EventLoop) -> EventLoopFuture<String> {
             let threadPool = NIOThreadPool(numberOfThreads: 1)
             threadPool.start()
@@ -214,6 +217,7 @@ extension STS {
         }
     }
 
+    /// Credential provider using Federation Tokens
     struct FederatedTokenCredentialProvider: CredentialProviderWithClient {
         let requestProvider: RequestProvider<STS.GetFederationTokenRequest>
         let client: AWSClient
@@ -240,6 +244,7 @@ extension STS {
         }
     }
 
+    /// Credential provider using session tokens
     struct SessionTokenCredentialProvider: CredentialProviderWithClient {
         let requestProvider: RequestProvider<STS.GetSessionTokenRequest>
         let client: AWSClient
@@ -269,6 +274,9 @@ extension STS {
 
 extension CredentialProviderFactory {
     /// Use AssumeRole to provide credentials
+    ///
+    /// See [AWS Documention](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_assumerole)
+    ///
     /// - Parameters:
     ///   - request: AssumeRole request structure
     ///   - credentialProvider: Credential provider used in client that runs the AssumeRole operation
@@ -290,10 +298,13 @@ extension CredentialProviderFactory {
     }
 
     /// Use AssumeRole to provide credentials
+    ///
+    /// See [AWS Documention](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_assumerole)
+    ///
     /// - Parameters:
-    ///   - request: Function that returns a EventLoopFuture to be fulfillled with an AssumeRole request structure
     ///   - credentialProvider: Credential provider used in client that runs the AssumeRole operation
     ///   - region: Region to run request in
+    ///   - requestProvider: Function that returns a EventLoopFuture to be fulfillled with an AssumeRole request struct
     public static func stsAssumeRole(
         credentialProvider: CredentialProviderFactory = .default,
         region: Region,
@@ -311,6 +322,9 @@ extension CredentialProviderFactory {
     }
 
     /// Use AssumeRoleWithSAML to provide credentials
+    ///
+    /// See [AWS Documention](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_assumerolewithsaml)
+    ///
     /// - Parameters:
     ///   - request: AssumeRoleWithSAML request struct
     ///   - region: Region to run request in
@@ -322,9 +336,12 @@ extension CredentialProviderFactory {
     }
 
     /// Use AssumeRoleWithSAML to provide credentials
+    ///
+    /// See [AWS Documention](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_assumerolewithsaml)
+    ///
     /// - Parameters:
-    ///   - requestProvider: Function that returns a EventLoopFuture to be fulfillled with an AssumeRoleWithSAML request struct
     ///   - region: Region to run request in
+    ///   - requestProvider: Function that returns a EventLoopFuture to be fulfillled with an AssumeRoleWithSAML request struct
     public static func stsSAML(
         region: Region,
         requestProvider: @escaping (EventLoop) -> EventLoopFuture<STS.AssumeRoleWithSAMLRequest>
@@ -336,6 +353,9 @@ extension CredentialProviderFactory {
     }
 
     /// Use AssumeRoleWithWebIdentity to provide credentials
+    ///
+    /// See [AWS Documention](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_assumerolewithwebidentity)
+    ///
     /// - Parameters:
     ///   - request: AssumeRoleWithWebIdentity request struct
     ///   - region: Region to run request in
@@ -347,9 +367,12 @@ extension CredentialProviderFactory {
     }
 
     /// Use AssumeRoleWithWebIdentity to provide credentials
+    ///
+    /// See [AWS Documention](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_assumerolewithwebidentity)
+    ///
     /// - Parameters:
-    ///   - requestProvider: Function that returns a EventLoopFuture to be fulfillled with an AssumeRoleWithWebIdentity request struct
     ///   - region: Region to run request in
+    ///   - requestProvider: Function that returns a EventLoopFuture to be fulfillled with an AssumeRoleWithWebIdentity request struct
     public static func stsWebIdentity(
         region: Region,
         requestProvider: @escaping (EventLoop) -> EventLoopFuture<STS.AssumeRoleWithWebIdentityRequest>
@@ -362,7 +385,8 @@ extension CredentialProviderFactory {
 
     /// Use AssumeRoleWithWebIdentity to provide credentials for EKS clusters. Uses environment variables `AWS_WEB_IDENTITY_TOKEN_FILE`,
     /// `AWS_ROLE_ARN`, and `AWS_ROLE_SESSION_NAME`. The web identity token can be found in the file pointed to by `AWS_WEB_IDENTITY_TOKEN_FILE`.
-    /// See https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html#pod-configuration
+    ///
+    /// See [AWS Documention](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html#pod-configuration)
     ///
     /// - Parameters:
     ///   - region: Region to run request in
@@ -378,6 +402,9 @@ extension CredentialProviderFactory {
     }
 
     /// Use GetFederationToken to provide credentials
+    ///
+    /// See [AWS Documention](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_getfederationtoken)
+    ///
     /// - Parameters:
     ///   - request: AssumeRole request structure
     ///   - credentialProvider: Credential provider used in client that runs the GetFederationToken operation
@@ -399,6 +426,9 @@ extension CredentialProviderFactory {
     }
 
     /// Use GetSessionToken to provide credentials
+    ///
+    /// See [AWS Documention](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_getsessiontoken)
+    ///
     /// - Parameters:
     ///   - request: SessionToken request structure
     ///   - credentialProvider: Credential provider used in client that runs the GetSessionToken operation
@@ -420,10 +450,13 @@ extension CredentialProviderFactory {
     }
 
     /// Use GetSessionToken to provide credentials
+    ///
+    /// See [AWS Documention](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_getsessiontoken)
+    ///
     /// - Parameters:
-    ///   - requestProvider: Function that returns a EventLoopFuture to be fulfillled with a SessionToken request structure
     ///   - credentialProvider: Credential provider used in client that runs the GetSessionToken operation
     ///   - region: Region to run request in
+    ///   - requestProvider: Function that returns a EventLoopFuture to be fulfillled with a SessionToken request structure
     public static func stsSessionToken(
         credentialProvider: CredentialProviderFactory = .default,
         region: Region,

--- a/Sources/Soto/Extensions/STS/STS+CredentialProvider.swift
+++ b/Sources/Soto/Extensions/STS/STS+CredentialProvider.swift
@@ -152,7 +152,7 @@ extension STS {
             let sessionName = Environment["AWS_ROLE_SESSION_NAME"]
 
             self.webIdentityProvider = AssumeRoleWithWebIdentityCredentialProvider(
-                requestProvider: .dynamic { eventLoop in
+                requestProvider: .dynamic { _ in
                     return Self.loadTokenFile(tokenFile, on: context.eventLoop).map { token in
                         STS.AssumeRoleWithWebIdentityRequest(
                             roleArn: roleArn,
@@ -169,7 +169,7 @@ extension STS {
         func shutdown(on eventLoop: EventLoop) -> EventLoopFuture<Void> {
             return webIdentityProvider.shutdown(on: eventLoop)
         }
-        
+
         /// get credentials
         func getCredential(on eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<Credential> {
             return webIdentityProvider.getCredential(on: eventLoop, logger: logger)


### PR DESCRIPTION
Used in EKS clusters. Looks for environment variables `AWS_WEB_IDENTITY_TOKEN_FILE`, `AWS_ROLE_ARN`, and `AWS_ROLE_SESSION_NAME` to fill out AssumeRoleWithWebIdentity request