### PR TITLE
Identity provider protocol for Cognito Identity

### DIFF
--- a/Sources/Soto/Extensions/CognitoIdentity/CognitoIdentity+CredentialProvider.swift
+++ b/Sources/Soto/Extensions/CognitoIdentity/CognitoIdentity+CredentialProvider.swift
@@ -107,4 +107,29 @@ extension CredentialProviderFactory {
             return RotatingCredentialProvider(context: context, provider: provider)
         }
     }
-}
+
+    /// Use CognitoIdentity GetId and GetCredentialsForIdentity to provide credentials
+    /// - Parameters:
+    ///   - identityPoolId: Identity pool to get identity from
+    ///   - logins: Optional tokens for authenticating login
+    ///   - region: Region where we can find the identity pool
+    public static func cognitoUserPoolIdentity(
+        identityPoolId: String,
+        userPoolId: String,
+        idToken: String,
+        region: Region,
+        logger: Logger = AWSClient.loggingDisabled
+    ) -> CredentialProviderFactory {
+        .custom { context in
+            let identityProvider = "cognito-idp.\(region.rawValue).amazonaws.com/\(userPoolId)"
+            let provider = CognitoIdentity.IdentityCredentialProvider(
+                identityPoolId: identityPoolId,
+                logins: [identityProvider: idToken],
+                region: region,
+                httpClient: context.httpClient,
+                logger: logger,
+                eventLoop: context.eventLoop
+            )
+            return RotatingCredentialProvider(context: context, provider: provider)
+        }
+    }}

--- a/Sources/Soto/Extensions/CognitoIdentity/CognitoIdentity+CredentialProvider.swift
+++ b/Sources/Soto/Extensions/CognitoIdentity/CognitoIdentity+CredentialProvider.swift
@@ -111,7 +111,8 @@ extension CredentialProviderFactory {
     /// Use CognitoIdentity GetId and GetCredentialsForIdentity to provide credentials
     /// - Parameters:
     ///   - identityPoolId: Identity pool to get identity from
-    ///   - logins: Optional tokens for authenticating login
+    ///   - userPoolId: User pool used as identity provider
+    ///   - idToken: Cognito Id Token
     ///   - region: Region where we can find the identity pool
     public static func cognitoUserPoolIdentity(
         identityPoolId: String,

--- a/Sources/Soto/Extensions/CognitoIdentity/CognitoIdentity+IdentityProvider.swift
+++ b/Sources/Soto/Extensions/CognitoIdentity/CognitoIdentity+IdentityProvider.swift
@@ -71,20 +71,20 @@ extension CognitoIdentity {
                     identityIdPromise.fail(CredentialProviderError.noProvider)
                 case .success(let response):
                     guard let identityId = response.identityId else {
-                        identityIdPromise.fail(CredentialProviderError.noProvider);
+                        identityIdPromise.fail(CredentialProviderError.noProvider)
                         return
                     }
                     identityIdPromise.succeed(identityId)
                 }
             }
         }
-        
+
         func shutdown(on eventLoop: EventLoop) -> EventLoopFuture<Void> {
-            return identityIdPromise.futureResult.map { _ in }.hop(to: eventLoop)
+            return self.identityIdPromise.futureResult.map { _ in }.hop(to: eventLoop)
         }
-        
+
         func getIdentity(on eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<IdentityParams> {
-            return identityIdPromise.futureResult.map { identityId in
+            return self.identityIdPromise.futureResult.map { identityId in
                 return .init(id: identityId, logins: self.logins)
             }.hop(to: eventLoop)
         }

--- a/Sources/Soto/Extensions/CognitoIdentity/CognitoIdentity+IdentityProvider.swift
+++ b/Sources/Soto/Extensions/CognitoIdentity/CognitoIdentity+IdentityProvider.swift
@@ -51,6 +51,11 @@ extension CognitoIdentity {
     public struct IdentityParams {
         let id: String
         let logins: [String: String]?
+
+        public init(id: String, logins: [String: String]?) {
+            self.id = id
+            self.logins = logins
+        }
     }
 
     struct StaticIdentityProvider: IdentityProvider {

--- a/Sources/Soto/Extensions/CognitoIdentity/CognitoIdentity+IdentityProvider.swift
+++ b/Sources/Soto/Extensions/CognitoIdentity/CognitoIdentity+IdentityProvider.swift
@@ -1,0 +1,73 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Soto for AWS open source project
+//
+// Copyright (c) 2017-2020 the Soto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Soto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Logging
+import NIO
+
+public protocol IdentityProvider {
+    func getIdentity(on eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<CognitoIdentity.IdentityParams>
+}
+
+extension CognitoIdentity {
+    public struct IdentityParams {
+        let id: String
+        let logins: [String: String]?
+    }
+
+    struct DefaultIdentityProvider: IdentityProvider {
+        let identityPoolId: String
+        let logins: [String: String]?
+        let cognitoIdentity: CognitoIdentity
+
+        func getIdentity(on eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<IdentityParams> {
+            let request = CognitoIdentity.GetIdInput(identityPoolId: identityPoolId, logins: logins)
+            return cognitoIdentity.getId(request, logger: logger, on: eventLoop).flatMapThrowing { response -> IdentityParams in
+                guard let identityId = response.identityId else { throw CredentialProviderError.noProvider }
+                return .init(id: identityId, logins: logins)
+            }
+        }
+    }
+}
+
+/// A helper struct to defer the creation of an `IdentityProvider` until after the `IdentityCredentialProvider` has been created.
+public struct IdentityProviderFactory {
+    /// The initialization context for a `IdentityProvider`
+    public struct Context {
+        public let cognitoIdentity: CognitoIdentity
+        public let identityPoolId: String
+    }
+
+    private let cb: (Context) -> IdentityProvider
+
+    private init(cb: @escaping (Context) -> IdentityProvider) {
+        self.cb = cb
+    }
+
+    internal func createProvider(context: Context) -> IdentityProvider {
+        self.cb(context)
+    }
+}
+
+extension IdentityProviderFactory {
+    /// Use this method to initialize your custom `IdentityProvider`
+    public static func custom(_ factory: @escaping (Context) -> IdentityProvider) -> Self {
+        Self(cb: factory)
+    }
+
+    static func `default`(logins: [String: String]?) -> Self {
+        return Self { context in
+            return CognitoIdentity.DefaultIdentityProvider(identityPoolId: context.identityPoolId, logins: logins, cognitoIdentity: context.cognitoIdentity)
+        }
+    }
+}


### PR DESCRIPTION
Instead of providing static `logins` map to `cognitoIdentity` supply a struct conforming to `IdentityProvider`. The `IdentityProvider` protocol has a function `getIdentity` which returns an EventLoopFuture<> which will be fulfilled with the details required for the call to `GetCredentialsForIdentity`.

When credentials expire this function will be called again to get a new identity details to be used to get new credentials.