### PR TITLE
Allow DateCoders for non-body response members

### DIFF
--- a/CodeGenerator/Sources/CodeGenerator/Models/API.swift
+++ b/CodeGenerator/Sources/CodeGenerator/Models/API.swift
@@ -376,6 +376,7 @@ class Shape: Decodable {
         enum TimeStampFormat: String, Decodable {
             case iso8601
             case unixTimestamp
+            case rfc822
             case unspecified
         }
 

--- a/CodeGenerator/Sources/CodeGenerator/patch.swift
+++ b/CodeGenerator/Sources/CodeGenerator/patch.swift
@@ -68,6 +68,7 @@ extension API {
             ReplacePatch(PatchKeyPath3(\.shapes["ReplicationStatus"], \.type.enum, \.cases[0]), value: "COMPLETED", originalValue: "COMPLETE"),
             ReplacePatch(PatchKeyPath2(\.shapes["Size"], \.type), value: .long(), originalValue: .integer()),
             ReplacePatch(PatchKeyPath3(\.shapes["CopySource"], \.type.string, \.pattern), value: ".+\\/.+", originalValue: "\\/.+\\/.+"),
+            AddPatch(PatchKeyPath3(\.shapes["LifecycleRule"], \.type.structure, \.required), value: "Filter"),
             // Add additional location constraints
             ReplacePatch(PatchKeyPath3(\.shapes["BucketLocationConstraint"], \.type.enum, \.isExtensible), value: true, originalValue: false),
             AddPatch(PatchKeyPath3(\.shapes["BucketLocationConstraint"], \.type.enum, \.cases), value: "us-east-1"),

--- a/Sources/Soto/Services/CodeGuruProfiler/CodeGuruProfiler_Shapes.swift
+++ b/Sources/Soto/Services/CodeGuruProfiler/CodeGuruProfiler_Shapes.swift
@@ -238,7 +238,8 @@ extension CodeGuruProfiler {
         ]
 
         ///  The end time of the time period for the returned time series values. This is specified using the ISO 8601 format. For example, 2020-06-01T13:15:02.001Z represents 1 millisecond past June 1, 2020 1:15:02 PM UTC.
-        public let endTime: Date?
+        @OptionalCustomCoding<ISO8601DateCoder>
+        public var endTime: Date?
         ///  The details of the metrics that are used to request a time series of values. The metric includes the name of the frame, the aggregation type to calculate the metric value for the frame, and the thread states to use to get the count for the metric value of the frame.
         public let frameMetrics: [FrameMetric]?
         ///  The duration of the frame metrics used to return the time series values. Specify using the ISO 8601 format. The maximum period duration is one day (PT24H or P1D).
@@ -246,7 +247,8 @@ extension CodeGuruProfiler {
         ///  The name of the profiling group associated with the the frame metrics used to return the time series values.
         public let profilingGroupName: String
         ///  The start time of the time period for the frame metrics used to return the time series values. This is specified using the ISO 8601 format. For example, 2020-06-01T13:15:02.001Z represents 1 millisecond past June 1, 2020 1:15:02 PM UTC.
-        public let startTime: Date?
+        @OptionalCustomCoding<ISO8601DateCoder>
+        public var startTime: Date?
         /// The requested resolution of time steps for the returned time series of values. If the requested target resolution is not available due to data not being retained we provide a best effort result by falling back to the most granular available resolution after the target resolution. There are 3 valid values.     P1D — 1 day     PT1H — 1 hour     PT5M — 5 minutes
         public let targetResolution: AggregationPeriod?
 
@@ -702,7 +704,8 @@ extension CodeGuruProfiler {
         ///  The format of the returned profiling data. The format maps to the Accept and Content-Type headers of the HTTP request. You can specify one of the following: or the default .   &lt;ul&gt; &lt;li&gt; &lt;p&gt; &lt;code&gt;application/json&lt;/code&gt; — standard JSON format &lt;/p&gt; &lt;/li&gt; &lt;li&gt; &lt;p&gt; &lt;code&gt;application/x-amzn-ion&lt;/code&gt; — the Amazon Ion data format. For more information, see &lt;a href=&quot;http://amzn.github.io/ion-docs/&quot;&gt;Amazon Ion&lt;/a&gt;. &lt;/p&gt; &lt;/li&gt; &lt;/ul&gt;
         public let accept: String?
         ///  The end time of the requested profile. Specify using the ISO 8601 format. For example, 2020-06-01T13:15:02.001Z represents 1 millisecond past June 1, 2020 1:15:02 PM UTC.   If you specify endTime, then you must also specify period or startTime, but not both.
-        public let endTime: Date?
+        @OptionalCustomCoding<ISO8601DateCoder>
+        public var endTime: Date?
         ///  The maximum depth of the stacks in the code that is represented in the aggregated profile. For example, if CodeGuru Profiler finds a method A, which calls method B, which calls method C, which calls method D, then the depth is 4. If the maxDepth is set to 2, then the aggregated profile contains representations of methods A and B.
         public let maxDepth: Int?
         ///  Used with startTime or endTime to specify the time range for the returned aggregated profile. Specify using the ISO 8601 format. For example, P1DT1H1M1S.   &lt;p&gt; To get the latest aggregated profile, specify only &lt;code&gt;period&lt;/code&gt;. &lt;/p&gt;
@@ -710,7 +713,8 @@ extension CodeGuruProfiler {
         /// The name of the profiling group to get.
         public let profilingGroupName: String
         /// The start time of the profile to get. Specify using the ISO 8601 format. For example, 2020-06-01T13:15:02.001Z represents 1 millisecond past June 1, 2020 1:15:02 PM UTC.  &lt;p&gt; If you specify &lt;code&gt;startTime&lt;/code&gt;, then you must also specify &lt;code&gt;period&lt;/code&gt; or &lt;code&gt;endTime&lt;/code&gt;, but not both. &lt;/p&gt;
-        public let startTime: Date?
+        @OptionalCustomCoding<ISO8601DateCoder>
+        public var startTime: Date?
 
         public init(accept: String? = nil, endTime: Date? = nil, maxDepth: Int? = nil, period: String? = nil, profilingGroupName: String, startTime: Date? = nil) {
             self.accept = accept
@@ -772,13 +776,15 @@ extension CodeGuruProfiler {
         ]
 
         ///  The start time of the profile to get analysis data about. You must specify startTime and endTime. This is specified using the ISO 8601 format. For example, 2020-06-01T13:15:02.001Z represents 1 millisecond past June 1, 2020 1:15:02 PM UTC.
-        public let endTime: Date
+        @CustomCoding<ISO8601DateCoder>
+        public var endTime: Date
         ///  The language used to provide analysis. Specify using a string that is one of the following BCP 47 language codes.     de-DE - German, Germany     en-GB - English, United Kingdom     en-US - English, United States     es-ES - Spanish, Spain     fr-FR - French, France     it-IT - Italian, Italy     ja-JP - Japanese, Japan     ko-KR - Korean, Republic of Korea     pt-BR - Portugese, Brazil     zh-CN - Chinese, China     zh-TW - Chinese, Taiwan
         public let locale: String?
         ///  The name of the profiling group to get analysis data about.
         public let profilingGroupName: String
         ///  The end time of the profile to get analysis data about. You must specify startTime and endTime. This is specified using the ISO 8601 format. For example, 2020-06-01T13:15:02.001Z represents 1 millisecond past June 1, 2020 1:15:02 PM UTC.
-        public let startTime: Date
+        @CustomCoding<ISO8601DateCoder>
+        public var startTime: Date
 
         public init(endTime: Date, locale: String? = nil, profilingGroupName: String, startTime: Date) {
             self.endTime = endTime
@@ -840,7 +846,8 @@ extension CodeGuruProfiler {
         /// A Boolean value indicating whether to only return reports from daily profiles. If set to True, only analysis data from daily profiles is returned. If set to False, analysis data is returned from smaller time windows (for example, one hour).
         public let dailyReportsOnly: Bool?
         ///  The end time of the profile to get analysis data about. You must specify startTime and endTime. This is specified using the ISO 8601 format. For example, 2020-06-01T13:15:02.001Z represents 1 millisecond past June 1, 2020 1:15:02 PM UTC.
-        public let endTime: Date
+        @CustomCoding<ISO8601DateCoder>
+        public var endTime: Date
         /// The maximum number of report results returned by ListFindingsReports in paginated output. When this parameter is used, ListFindingsReports only returns maxResults results in a single page along with a nextToken response element. The remaining results of the initial request can be seen by sending another ListFindingsReports request with the returned nextToken value.
         public let maxResults: Int?
         /// The nextToken value returned from a previous paginated ListFindingsReportsRequest request where maxResults was used and the results exceeded the value of that parameter. Pagination continues from the end of the previous results that returned the nextToken value.   This token should be treated as an opaque identifier that is only used to retrieve the next items in a list and not for other programmatic purposes.
@@ -848,7 +855,8 @@ extension CodeGuruProfiler {
         /// The name of the profiling group from which to search for analysis data.
         public let profilingGroupName: String
         ///  The start time of the profile to get analysis data about. You must specify startTime and endTime. This is specified using the ISO 8601 format. For example, 2020-06-01T13:15:02.001Z represents 1 millisecond past June 1, 2020 1:15:02 PM UTC.
-        public let startTime: Date
+        @CustomCoding<ISO8601DateCoder>
+        public var startTime: Date
 
         public init(dailyReportsOnly: Bool? = nil, endTime: Date, maxResults: Int? = nil, nextToken: String? = nil, profilingGroupName: String, startTime: Date) {
             self.dailyReportsOnly = dailyReportsOnly
@@ -902,7 +910,8 @@ extension CodeGuruProfiler {
         ]
 
         /// The end time of the time range from which to list the profiles.
-        public let endTime: Date
+        @CustomCoding<ISO8601DateCoder>
+        public var endTime: Date
         /// The maximum number of profile time results returned by ListProfileTimes in paginated output. When this parameter is used, ListProfileTimes only returns maxResults results in a single page with a nextToken response element. The remaining results of the initial request can be seen by sending another ListProfileTimes request with the returned nextToken value.
         public let maxResults: Int?
         /// The nextToken value returned from a previous paginated ListProfileTimes request where maxResults was used and the results exceeded the value of that parameter. Pagination continues from the end of the previous results that returned the nextToken value.   This token should be treated as an opaque identifier that is only used to retrieve the next items in a list and not for other programmatic purposes.
@@ -914,7 +923,8 @@ extension CodeGuruProfiler {
         /// The name of the profiling group.
         public let profilingGroupName: String
         /// The start time of the time range from which to list the profiles.
-        public let startTime: Date
+        @CustomCoding<ISO8601DateCoder>
+        public var startTime: Date
 
         public init(endTime: Date, maxResults: Int? = nil, nextToken: String? = nil, orderBy: OrderBy? = nil, period: AggregationPeriod, profilingGroupName: String, startTime: Date) {
             self.endTime = endTime

--- a/Sources/Soto/Services/IoT1ClickDevicesService/IoT1ClickDevicesService_Shapes.swift
+++ b/Sources/Soto/Services/IoT1ClickDevicesService/IoT1ClickDevicesService_Shapes.swift
@@ -307,10 +307,12 @@ extension IoT1ClickDevicesService {
         ]
 
         public let deviceId: String
-        public let fromTimeStamp: Date
+        @CustomCoding<ISO8601DateCoder>
+        public var fromTimeStamp: Date
         public let maxResults: Int?
         public let nextToken: String?
-        public let toTimeStamp: Date
+        @CustomCoding<ISO8601DateCoder>
+        public var toTimeStamp: Date
 
         public init(deviceId: String, fromTimeStamp: Date, maxResults: Int? = nil, nextToken: String? = nil, toTimeStamp: Date) {
             self.deviceId = deviceId

--- a/Sources/Soto/Services/MediaLive/MediaLive_Shapes.swift
+++ b/Sources/Soto/Services/MediaLive/MediaLive_Shapes.swift
@@ -3698,7 +3698,8 @@ extension MediaLive {
         public let contentLength: Int64?
         public let contentType: ContentType?
         public let eTag: String?
-        public let lastModified: Date?
+        @OptionalCustomCoding<HTTPHeaderDateCoder>
+        public var lastModified: Date?
 
         public init(body: AWSPayload? = nil, contentLength: Int64? = nil, contentType: ContentType? = nil, eTag: String? = nil, lastModified: Date? = nil) {
             self.body = body

--- a/Sources/Soto/Services/MediaStoreData/MediaStoreData_Shapes.swift
+++ b/Sources/Soto/Services/MediaStoreData/MediaStoreData_Shapes.swift
@@ -103,7 +103,8 @@ extension MediaStoreData {
         /// The ETag that represents a unique instance of the object.
         public let eTag: String?
         /// The date and time that the object was last modified.
-        public let lastModified: Date?
+        @OptionalCustomCoding<HTTPHeaderDateCoder>
+        public var lastModified: Date?
 
         public init(cacheControl: String? = nil, contentLength: Int64? = nil, contentType: String? = nil, eTag: String? = nil, lastModified: Date? = nil) {
             self.cacheControl = cacheControl
@@ -176,7 +177,8 @@ extension MediaStoreData {
         /// The ETag that represents a unique instance of the object.
         public let eTag: String?
         /// The date and time that the object was last modified.
-        public let lastModified: Date?
+        @OptionalCustomCoding<HTTPHeaderDateCoder>
+        public var lastModified: Date?
         /// The HTML status code of the request. Status codes ranging from 200 to 299 indicate success. All other status codes indicate the type of error that occurred.
         public let statusCode: Int
 

--- a/Sources/Soto/Services/Pinpoint/Pinpoint_Shapes.swift
+++ b/Sources/Soto/Services/Pinpoint/Pinpoint_Shapes.swift
@@ -4530,11 +4530,13 @@ extension Pinpoint {
         ]
 
         public let applicationId: String
-        public let endTime: Date?
+        @OptionalCustomCoding<ISO8601DateCoder>
+        public var endTime: Date?
         public let kpiName: String
         public let nextToken: String?
         public let pageSize: String?
-        public let startTime: Date?
+        @OptionalCustomCoding<ISO8601DateCoder>
+        public var startTime: Date?
 
         public init(applicationId: String, endTime: Date? = nil, kpiName: String, nextToken: String? = nil, pageSize: String? = nil, startTime: Date? = nil) {
             self.applicationId = applicationId
@@ -4719,11 +4721,13 @@ extension Pinpoint {
 
         public let applicationId: String
         public let campaignId: String
-        public let endTime: Date?
+        @OptionalCustomCoding<ISO8601DateCoder>
+        public var endTime: Date?
         public let kpiName: String
         public let nextToken: String?
         public let pageSize: String?
-        public let startTime: Date?
+        @OptionalCustomCoding<ISO8601DateCoder>
+        public var startTime: Date?
 
         public init(applicationId: String, campaignId: String, endTime: Date? = nil, kpiName: String, nextToken: String? = nil, pageSize: String? = nil, startTime: Date? = nil) {
             self.applicationId = applicationId
@@ -5264,12 +5268,14 @@ extension Pinpoint {
         ]
 
         public let applicationId: String
-        public let endTime: Date?
+        @OptionalCustomCoding<ISO8601DateCoder>
+        public var endTime: Date?
         public let journeyId: String
         public let kpiName: String
         public let nextToken: String?
         public let pageSize: String?
-        public let startTime: Date?
+        @OptionalCustomCoding<ISO8601DateCoder>
+        public var startTime: Date?
 
         public init(applicationId: String, endTime: Date? = nil, journeyId: String, kpiName: String, nextToken: String? = nil, pageSize: String? = nil, startTime: Date? = nil) {
             self.applicationId = applicationId

--- a/Sources/Soto/Services/S3/S3_Shapes.swift
+++ b/Sources/Soto/Services/S3/S3_Shapes.swift
@@ -1138,11 +1138,13 @@ extension S3 {
         /// Copies the object if its entity tag (ETag) matches the specified tag.
         public let copySourceIfMatch: String?
         /// Copies the object if it has been modified since the specified time.
-        public let copySourceIfModifiedSince: Date?
+        @OptionalCustomCoding<HTTPHeaderDateCoder>
+        public var copySourceIfModifiedSince: Date?
         /// Copies the object if its entity tag (ETag) is different than the specified ETag.
         public let copySourceIfNoneMatch: String?
         /// Copies the object if it hasn't been modified since the specified time.
-        public let copySourceIfUnmodifiedSince: Date?
+        @OptionalCustomCoding<HTTPHeaderDateCoder>
+        public var copySourceIfUnmodifiedSince: Date?
         /// Specifies the algorithm to use when decrypting the source object (for example, AES256).
         public let copySourceSSECustomerAlgorithm: String?
         /// Specifies the customer-provided encryption key for Amazon S3 to use to decrypt the source object. The encryption key provided in this header must be one that was used when the source object was created.
@@ -1154,7 +1156,8 @@ extension S3 {
         /// The account id of the expected source bucket owner. If the source bucket is owned by a different account, the request will fail with an HTTP 403 (Access Denied) error.
         public let expectedSourceBucketOwner: String?
         /// The date and time at which the object is no longer cacheable.
-        public let expires: Date?
+        @OptionalCustomCoding<HTTPHeaderDateCoder>
+        public var expires: Date?
         /// Gives the grantee READ, READ_ACP, and WRITE_ACP permissions on the object. This action is not supported by Amazon S3 on Outposts.
         public let grantFullControl: String?
         /// Allows grantee to read the object data and its metadata. This action is not supported by Amazon S3 on Outposts.
@@ -1174,7 +1177,8 @@ extension S3 {
         /// The Object Lock mode that you want to apply to the copied object.
         public let objectLockMode: ObjectLockMode?
         /// The date and time when you want the copied object's Object Lock to expire.
-        public let objectLockRetainUntilDate: Date?
+        @OptionalCustomCoding<ISO8601DateCoder>
+        public var objectLockRetainUntilDate: Date?
         public let requestPayer: RequestPayer?
         /// The server-side encryption algorithm used when storing this object in Amazon S3 (for example, AES256, aws:kms).
         public let serverSideEncryption: ServerSideEncryption?
@@ -1379,7 +1383,8 @@ extension S3 {
         ]
 
         /// If the bucket has a lifecycle rule configured with an action to abort incomplete multipart uploads and the prefix in the lifecycle rule matches the object name in the request, the response includes this header. The header indicates when the initiated multipart upload becomes eligible for an abort operation. For more information, see  Aborting Incomplete Multipart Uploads Using a Bucket Lifecycle Policy. The response also includes the x-amz-abort-rule-id header that provides the ID of the lifecycle configuration rule that defines this action.
-        public let abortDate: Date?
+        @OptionalCustomCoding<HTTPHeaderDateCoder>
+        public var abortDate: Date?
         /// This header is returned along with the x-amz-abort-date header. It identifies the applicable lifecycle configuration rule that defines the action to abort incomplete multipart uploads.
         public let abortRuleId: String?
         /// The name of the bucket to which the multipart upload was initiated.  When using this API with an access point, you must direct requests to the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com. When using this operation with an access point through the AWS SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see Using Access Points in the Amazon Simple Storage Service Developer Guide. When using this API with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form AccessPointName-AccountId.outpostID.s3-outposts.Region.amazonaws.com. When using this operation using S3 on Outposts through the AWS SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see Using S3 on Outposts in the Amazon Simple Storage Service Developer Guide.
@@ -1485,7 +1490,8 @@ extension S3 {
         /// The account id of the expected bucket owner. If the bucket is owned by a different account, the request will fail with an HTTP 403 (Access Denied) error.
         public let expectedBucketOwner: String?
         /// The date and time at which the object is no longer cacheable.
-        public let expires: Date?
+        @OptionalCustomCoding<HTTPHeaderDateCoder>
+        public var expires: Date?
         /// Gives the grantee READ, READ_ACP, and WRITE_ACP permissions on the object. This action is not supported by Amazon S3 on Outposts.
         public let grantFullControl: String?
         /// Allows grantee to read the object data and its metadata. This action is not supported by Amazon S3 on Outposts.
@@ -1503,7 +1509,8 @@ extension S3 {
         /// Specifies the Object Lock mode that you want to apply to the uploaded object.
         public let objectLockMode: ObjectLockMode?
         /// Specifies the date and time when you want the Object Lock to expire.
-        public let objectLockRetainUntilDate: Date?
+        @OptionalCustomCoding<ISO8601DateCoder>
+        public var objectLockRetainUntilDate: Date?
         public let requestPayer: RequestPayer?
         /// The server-side encryption algorithm used when storing this object in Amazon S3 (for example, AES256, aws:kms).
         public let serverSideEncryption: ServerSideEncryption?
@@ -3250,9 +3257,11 @@ extension S3 {
         /// If the object expiration is configured (see PUT Bucket lifecycle), the response includes this header. It includes the expiry-date and rule-id key-value pairs providing object expiration information. The value of the rule-id is URL encoded.
         public let expiration: String?
         /// The date and time at which the object is no longer cacheable.
-        public let expires: Date?
+        @OptionalCustomCoding<HTTPHeaderDateCoder>
+        public var expires: Date?
         /// Last modified date of the object
-        public let lastModified: Date?
+        @OptionalCustomCoding<HTTPHeaderDateCoder>
+        public var lastModified: Date?
         /// A map of metadata to store with the object in S3.
         public let metadata: [String: String]?
         /// This is set to the number of metadata entries not returned in x-amz-meta headers. This can happen if you create metadata using an API like SOAP that supports more flexible metadata than the REST API. For example, using SOAP, you can create metadata whose values are not legal HTTP headers.
@@ -3262,7 +3271,8 @@ extension S3 {
         /// The Object Lock mode currently in place for this object.
         public let objectLockMode: ObjectLockMode?
         /// The date and time when this object's Object Lock will expire.
-        public let objectLockRetainUntilDate: Date?
+        @OptionalCustomCoding<ISO8601DateCoder>
+        public var objectLockRetainUntilDate: Date?
         /// The count of parts this object has.
         public let partsCount: Int?
         /// Amazon S3 can return this if your request involves a bucket that is either a source or destination in a replication rule.
@@ -3389,11 +3399,13 @@ extension S3 {
         /// Return the object only if its entity tag (ETag) is the same as the one specified, otherwise return a 412 (precondition failed).
         public let ifMatch: String?
         /// Return the object only if it has been modified since the specified time, otherwise return a 304 (not modified).
-        public let ifModifiedSince: Date?
+        @OptionalCustomCoding<HTTPHeaderDateCoder>
+        public var ifModifiedSince: Date?
         /// Return the object only if its entity tag (ETag) is different from the one specified, otherwise return a 304 (not modified).
         public let ifNoneMatch: String?
         /// Return the object only if it has not been modified since the specified time, otherwise return a 412 (precondition failed).
-        public let ifUnmodifiedSince: Date?
+        @OptionalCustomCoding<HTTPHeaderDateCoder>
+        public var ifUnmodifiedSince: Date?
         /// Key of the object to get.
         public let key: String
         /// Part number of the object being read. This is a positive integer between 1 and 10,000. Effectively performs a 'ranged' GET request for the part specified. Useful for downloading just a part of an object.
@@ -3790,9 +3802,11 @@ extension S3 {
         /// If the object expiration is configured (see PUT Bucket lifecycle), the response includes this header. It includes the expiry-date and rule-id key-value pairs providing object expiration information. The value of the rule-id is URL encoded.
         public let expiration: String?
         /// The date and time at which the object is no longer cacheable.
-        public let expires: Date?
+        @OptionalCustomCoding<HTTPHeaderDateCoder>
+        public var expires: Date?
         /// Last modified date of the object
-        public let lastModified: Date?
+        @OptionalCustomCoding<HTTPHeaderDateCoder>
+        public var lastModified: Date?
         /// A map of metadata to store with the object in S3.
         public let metadata: [String: String]?
         /// This is set to the number of metadata entries not returned in x-amz-meta headers. This can happen if you create metadata using an API like SOAP that supports more flexible metadata than the REST API. For example, using SOAP, you can create metadata whose values are not legal HTTP headers.
@@ -3802,7 +3816,8 @@ extension S3 {
         /// The Object Lock mode, if any, that's in effect for this object. This header is only returned if the requester has the s3:GetObjectRetention permission. For more information about S3 Object Lock, see Object Lock.
         public let objectLockMode: ObjectLockMode?
         /// The date and time when the Object Lock retention period expires. This header is only returned if the requester has the s3:GetObjectRetention permission.
-        public let objectLockRetainUntilDate: Date?
+        @OptionalCustomCoding<ISO8601DateCoder>
+        public var objectLockRetainUntilDate: Date?
         /// The count of parts this object has.
         public let partsCount: Int?
         /// Amazon S3 can return this header if your request involves a bucket that is either a source or a destination in a replication rule. In replication, you have a source bucket on which you configure replication and destination bucket or buckets where Amazon S3 stores object replicas. When you request an object (GetObject) or object metadata (HeadObject) from these buckets, Amazon S3 will return the x-amz-replication-status header in the response as follows:   If requesting an object from the source bucket — Amazon S3 will return the x-amz-replication-status header if the object in your request is eligible for replication.  For example, suppose that in your replication configuration, you specify object prefix TaxDocs requesting Amazon S3 to replicate objects with key prefix TaxDocs. Any objects you upload with this key name prefix, for example TaxDocs/document1.pdf, are eligible for replication. For any object request with this key name prefix, Amazon S3 will return the x-amz-replication-status header with value PENDING, COMPLETED or FAILED indicating object replication status.   If requesting an object from a destination bucket — Amazon S3 will return the x-amz-replication-status header with value REPLICA if the object in your request is a replica that Amazon S3 created and there is no replica modification replication in progress.   When replicating objects to multiple destination buckets the x-amz-replication-status header acts differently. The header of the source object will only return a value of COMPLETED when replication is successful to all destinations. The header will remain at value PENDING until replication has completed for all destinations. If one or more destinations fails replication the header will return FAILED.    For more information, see Replication.
@@ -3917,11 +3932,13 @@ extension S3 {
         /// Return the object only if its entity tag (ETag) is the same as the one specified, otherwise return a 412 (precondition failed).
         public let ifMatch: String?
         /// Return the object only if it has been modified since the specified time, otherwise return a 304 (not modified).
-        public let ifModifiedSince: Date?
+        @OptionalCustomCoding<HTTPHeaderDateCoder>
+        public var ifModifiedSince: Date?
         /// Return the object only if its entity tag (ETag) is different from the one specified, otherwise return a 304 (not modified).
         public let ifNoneMatch: String?
         /// Return the object only if it has not been modified since the specified time, otherwise return a 412 (precondition failed).
-        public let ifUnmodifiedSince: Date?
+        @OptionalCustomCoding<HTTPHeaderDateCoder>
+        public var ifUnmodifiedSince: Date?
         /// The object key.
         public let key: String
         /// Part number of the object being read. This is a positive integer between 1 and 10,000. Effectively performs a 'ranged' HEAD request for the part specified. Useful querying about the size of the part and the number of parts in this object.
@@ -5015,7 +5032,8 @@ extension S3 {
         ]
 
         /// If the bucket has a lifecycle rule configured with an action to abort incomplete multipart uploads and the prefix in the lifecycle rule matches the object name in the request, then the response includes this header indicating when the initiated multipart upload will become eligible for abort operation. For more information, see Aborting Incomplete Multipart Uploads Using a Bucket Lifecycle Policy. The response will also include the x-amz-abort-rule-id header that will provide the ID of the lifecycle configuration rule that defines this action.
-        public let abortDate: Date?
+        @OptionalCustomCoding<HTTPHeaderDateCoder>
+        public var abortDate: Date?
         /// This header is returned along with the x-amz-abort-date header. It identifies applicable lifecycle configuration rule that defines the action to abort incomplete multipart uploads.
         public let abortRuleId: String?
         /// The name of the bucket to which the multipart upload was initiated.
@@ -6703,7 +6721,8 @@ extension S3 {
         /// The account id of the expected bucket owner. If the bucket is owned by a different account, the request will fail with an HTTP 403 (Access Denied) error.
         public let expectedBucketOwner: String?
         /// The date and time at which the object is no longer cacheable. For more information, see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.21.
-        public let expires: Date?
+        @OptionalCustomCoding<HTTPHeaderDateCoder>
+        public var expires: Date?
         /// Gives the grantee READ, READ_ACP, and WRITE_ACP permissions on the object. This action is not supported by Amazon S3 on Outposts.
         public let grantFullControl: String?
         /// Allows grantee to read the object data and its metadata. This action is not supported by Amazon S3 on Outposts.
@@ -6721,7 +6740,8 @@ extension S3 {
         /// The Object Lock mode that you want to apply to this object.
         public let objectLockMode: ObjectLockMode?
         /// The date and time when you want this object's Object Lock to expire.
-        public let objectLockRetainUntilDate: Date?
+        @OptionalCustomCoding<ISO8601DateCoder>
+        public var objectLockRetainUntilDate: Date?
         public let requestPayer: RequestPayer?
         /// The server-side encryption algorithm used when storing this object in Amazon S3 (for example, AES256, aws:kms).
         public let serverSideEncryption: ServerSideEncryption?
@@ -7994,11 +8014,13 @@ extension S3 {
         /// Copies the object if its entity tag (ETag) matches the specified tag.
         public let copySourceIfMatch: String?
         /// Copies the object if it has been modified since the specified time.
-        public let copySourceIfModifiedSince: Date?
+        @OptionalCustomCoding<HTTPHeaderDateCoder>
+        public var copySourceIfModifiedSince: Date?
         /// Copies the object if its entity tag (ETag) is different than the specified ETag.
         public let copySourceIfNoneMatch: String?
         /// Copies the object if it hasn't been modified since the specified time.
-        public let copySourceIfUnmodifiedSince: Date?
+        @OptionalCustomCoding<HTTPHeaderDateCoder>
+        public var copySourceIfUnmodifiedSince: Date?
         /// The range of bytes to copy from the source object. The range value must use the form bytes=first-last, where the first and last are the zero-based byte offsets to copy. For example, bytes=0-9 indicates that you want to copy the first 10 bytes of the source. You can copy a range only if the source object is greater than 5 MB.
         public let copySourceRange: String?
         /// Specifies the algorithm to use when decrypting the source object (for example, AES256).

--- a/Sources/Soto/Services/S3/S3_Shapes.swift
+++ b/Sources/Soto/Services/S3/S3_Shapes.swift
@@ -4312,7 +4312,7 @@ extension S3 {
         public let abortIncompleteMultipartUpload: AbortIncompleteMultipartUpload?
         /// Specifies the expiration for the lifecycle of the object in the form of date, days and, whether the object has a delete marker.
         public let expiration: LifecycleExpiration?
-        public let filter: LifecycleRuleFilter?
+        public let filter: LifecycleRuleFilter
         /// Unique identifier for the rule. The value cannot be longer than 255 characters.
         public let id: String?
         public let noncurrentVersionExpiration: NoncurrentVersionExpiration?
@@ -4323,7 +4323,7 @@ extension S3 {
         /// Specifies when an Amazon S3 object transitions to a specified storage class.
         public let transitions: [Transition]?
 
-        public init(abortIncompleteMultipartUpload: AbortIncompleteMultipartUpload? = nil, expiration: LifecycleExpiration? = nil, filter: LifecycleRuleFilter? = nil, id: String? = nil, noncurrentVersionExpiration: NoncurrentVersionExpiration? = nil, noncurrentVersionTransitions: [NoncurrentVersionTransition]? = nil, status: ExpirationStatus, transitions: [Transition]? = nil) {
+        public init(abortIncompleteMultipartUpload: AbortIncompleteMultipartUpload? = nil, expiration: LifecycleExpiration? = nil, filter: LifecycleRuleFilter, id: String? = nil, noncurrentVersionExpiration: NoncurrentVersionExpiration? = nil, noncurrentVersionTransitions: [NoncurrentVersionTransition]? = nil, status: ExpirationStatus, transitions: [Transition]? = nil) {
             self.abortIncompleteMultipartUpload = abortIncompleteMultipartUpload
             self.expiration = expiration
             self.filter = filter
@@ -4335,7 +4335,7 @@ extension S3 {
         }
 
         public func validate(name: String) throws {
-            try self.filter?.validate(name: "\(name).filter")
+            try self.filter.validate(name: "\(name).filter")
         }
 
         private enum CodingKeys: String, CodingKey {

--- a/Tests/SotoTests/AWSRequestTests.swift
+++ b/Tests/SotoTests/AWSRequestTests.swift
@@ -97,19 +97,20 @@ class AWSRequestTests: XCTestCase {
     func testS3PutBucketLifecycleConfigurationRequest() {
         let s3 = S3(client: Self.client)
         let expectedResult =
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><LifecycleConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>7</DaysAfterInitiation></AbortIncompleteMultipartUpload><Status>Enabled</Status></Rule><Rule><Expiration><Days>30</Days><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>temp</Prefix></Filter><Status>Enabled</Status></Rule><Rule><Status>Enabled</Status><Transition><Days>20</Days><StorageClass>GLACIER</StorageClass></Transition><Transition><Days>180</Days><StorageClass>DEEP_ARCHIVE</StorageClass></Transition></Rule><Rule><NoncurrentVersionExpiration><NoncurrentDays>90</NoncurrentDays></NoncurrentVersionExpiration><Status>Disabled</Status></Rule></LifecycleConfiguration>"
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><LifecycleConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>7</DaysAfterInitiation></AbortIncompleteMultipartUpload><Filter><Prefix></Prefix></Filter><Status>Enabled</Status></Rule><Rule><Expiration><Days>30</Days><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Filter><Prefix>temp</Prefix></Filter><Status>Enabled</Status></Rule><Rule><Filter><Prefix></Prefix></Filter><Status>Enabled</Status><Transition><Days>20</Days><StorageClass>GLACIER</StorageClass></Transition><Transition><Days>180</Days><StorageClass>DEEP_ARCHIVE</StorageClass></Transition></Rule><Rule><Filter><Prefix></Prefix></Filter><NoncurrentVersionExpiration><NoncurrentDays>90</NoncurrentDays></NoncurrentVersionExpiration><Status>Disabled</Status></Rule></LifecycleConfiguration>"
 
-        let abortRule = S3.LifecycleRule(abortIncompleteMultipartUpload: S3.AbortIncompleteMultipartUpload(daysAfterInitiation: 7), status: .enabled)
+        let abortRule = S3.LifecycleRule(abortIncompleteMultipartUpload: S3.AbortIncompleteMultipartUpload(daysAfterInitiation: 7), filter: .init(prefix: ""), status: .enabled)
         let tempFileRule = S3.LifecycleRule(
             expiration: S3.LifecycleExpiration(days: 30, expiredObjectDeleteMarker: true),
             filter: S3.LifecycleRuleFilter(prefix: "temp"),
             status: .enabled
         )
         let glacierRule = S3.LifecycleRule(
+            filter: .init(prefix: ""),
             status: .enabled,
             transitions: [S3.Transition(days: 20, storageClass: .glacier), S3.Transition(days: 180, storageClass: .deepArchive)]
         )
-        let versionsRule = S3.LifecycleRule(noncurrentVersionExpiration: S3.NoncurrentVersionExpiration(noncurrentDays: 90), status: .disabled)
+        let versionsRule = S3.LifecycleRule(filter: .init(prefix: ""), noncurrentVersionExpiration: S3.NoncurrentVersionExpiration(noncurrentDays: 90), status: .disabled)
         let rules = [abortRule, tempFileRule, glacierRule, versionsRule]
         let lifecycleConfiguration = S3.BucketLifecycleConfiguration(rules: rules)
         let request = S3.PutBucketLifecycleConfigurationRequest(bucket: "bucket", lifecycleConfiguration: lifecycleConfiguration)

--- a/Tests/SotoTests/Services/S3/S3Tests.swift
+++ b/Tests/SotoTests/Services/S3/S3Tests.swift
@@ -506,10 +506,10 @@ class S3Tests: XCTestCase {
         let name = TestEnvironment.generateResourceName()
         let response = Self.createBucket(name: name, s3: Self.s3)
             .flatMap { _ -> EventLoopFuture<Void> in
-                let rule = S3.LifecycleRule(abortIncompleteMultipartUpload: .init(daysAfterInitiation:7), filter: .init(prefix: ""), id: "multipart-upload", status: .enabled)
+                let rule = S3.LifecycleRule(abortIncompleteMultipartUpload: .init(daysAfterInitiation: 7), filter: .init(prefix: ""), id: "multipart-upload", status: .enabled)
                 let request = S3.PutBucketLifecycleConfigurationRequest(
                     bucket: name,
-                    lifecycleConfiguration: .init(rules:[rule])
+                    lifecycleConfiguration: .init(rules: [rule])
                 )
                 return Self.s3.putBucketLifecycleConfiguration(request)
             }
@@ -517,14 +517,13 @@ class S3Tests: XCTestCase {
                 Self.s3.createMultipartUpload(.init(bucket: name, key: "test"))
             }
             .flatMap { response -> EventLoopFuture<S3.AbortMultipartUploadOutput> in
-                guard let uploadId = response.uploadId else { return Self.s3.eventLoopGroup.next().makeFailedFuture(AWSClientError.missingParameter)}
+                guard let uploadId = response.uploadId else { return Self.s3.eventLoopGroup.next().makeFailedFuture(AWSClientError.missingParameter) }
                 return Self.s3.abortMultipartUpload(.init(bucket: name, key: "test", uploadId: uploadId))
             }
             .flatAlways { _ in
                 return Self.deleteBucket(name: name, s3: Self.s3)
             }
         XCTAssertNoThrow(try response.wait())
-
     }
 
     func testSignedURL() {

--- a/Tests/SotoTests/Services/S3/S3Tests.swift
+++ b/Tests/SotoTests/Services/S3/S3Tests.swift
@@ -501,6 +501,32 @@ class S3Tests: XCTestCase {
         XCTAssertNoThrow(try response.wait())
     }
 
+    /// testing Date format in response headers
+    func testMultipartAbortDate() {
+        let name = TestEnvironment.generateResourceName()
+        let response = Self.createBucket(name: name, s3: Self.s3)
+            .flatMap { _ -> EventLoopFuture<Void> in
+                let rule = S3.LifecycleRule(abortIncompleteMultipartUpload: .init(daysAfterInitiation:7), filter: .init(prefix: ""), id: "multipart-upload", status: .enabled)
+                let request = S3.PutBucketLifecycleConfigurationRequest(
+                    bucket: name,
+                    lifecycleConfiguration: .init(rules:[rule])
+                )
+                return Self.s3.putBucketLifecycleConfiguration(request)
+            }
+            .flatMap { _ -> EventLoopFuture<S3.CreateMultipartUploadOutput> in
+                Self.s3.createMultipartUpload(.init(bucket: name, key: "test"))
+            }
+            .flatMap { response -> EventLoopFuture<S3.AbortMultipartUploadOutput> in
+                guard let uploadId = response.uploadId else { return Self.s3.eventLoopGroup.next().makeFailedFuture(AWSClientError.missingParameter)}
+                return Self.s3.abortMultipartUpload(.init(bucket: name, key: "test", uploadId: uploadId))
+            }
+            .flatAlways { _ in
+                return Self.deleteBucket(name: name, s3: Self.s3)
+            }
+        XCTAssertNoThrow(try response.wait())
+
+    }
+
     func testSignedURL() {
         let name = TestEnvironment.generateResourceName()
         let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)


### PR DESCRIPTION
Also assume unless otherwise indicated that dates stored in headers use the HttpHeader date format.
This fixes an issue with S3 multipart upload abort date not being decoded correctly