### PR TITLE
Add support for using S3 dualstack and accelerated transfer endpoints

### DIFF
--- a/Sources/Soto/Extensions/S3/S3RequestMiddleware.swift
+++ b/Sources/Soto/Extensions/S3/S3RequestMiddleware.swift
@@ -56,7 +56,7 @@ public struct S3RequestMiddleware: AWSServiceMiddleware {
             let isAmazonUrl = host.hasSuffix("amazonaws.com")
 
             var hostComponents = host.split(separator: ".")
-            if isAmazonUrl && !context.options.intersection([.s3UseDualStackEndpoint, .s3UseTransferAcceleratedEndpoint]).isEmpty {
+            if isAmazonUrl, !context.options.intersection([.s3UseDualStackEndpoint, .s3UseTransferAcceleratedEndpoint]).isEmpty {
                 if let s3Index = hostComponents.firstIndex(where: { $0 == "s3" }) {
                     var s3 = "s3"
                     if context.options.contains(.s3UseTransferAcceleratedEndpoint) {
@@ -74,7 +74,7 @@ public struct S3RequestMiddleware: AWSServiceMiddleware {
             }
 
             // if host name contains amazonaws.com and bucket name doesn't contain a period do virtual address look up
-            if (isAmazonUrl || context.options.contains(.s3ForceVirtualHost)), !bucket.contains(".") {
+            if isAmazonUrl || context.options.contains(.s3ForceVirtualHost), !bucket.contains(".") {
                 let pathsWithoutBucket = paths.dropFirst() // bucket
                 urlPath = pathsWithoutBucket.joined(separator: "/")
 

--- a/Tests/SotoTests/Services/S3/S3Tests.swift
+++ b/Tests/SotoTests/Services/S3/S3Tests.swift
@@ -591,7 +591,6 @@ class S3Tests: XCTestCase {
                 return Self.deleteBucket(name: name, s3: s3)
             }
         XCTAssertNoThrow(try response.wait())
-
     }
 
     func testTransferAccelerated() {
@@ -626,7 +625,6 @@ class S3Tests: XCTestCase {
                 return Self.deleteBucket(name: name, s3: Self.s3)
             }
         XCTAssertNoThrow(try response.wait())
-
     }
 
     func testError() {


### PR DESCRIPTION
To use dualstack endpoint
```swift
let s3 = S3(client: awsClient, region: .euwest1, options: .s3UseDualStackEndpoint)
```
To use transfer accelerated endpoint
```swift
let s3 = S3(client: awsClient, region: .euwest1, options: .s3UseTransferAcceleratedEndpoint)
```
Alternatively if you already have an S3 object then you can do the following
```swift
let s3Accelerated = s3.with(options: .s3UseTransferAcceleratedEndpoint)
```