### PR TITLE
Fix completedParts array in resumeMultipartUpload error

### DIFF
--- a/Sources/Soto/Extensions/S3/S3+multipart_API.swift
+++ b/Sources/Soto/Extensions/S3/S3+multipart_API.swift
@@ -405,7 +405,6 @@ extension S3 {
                         error: error
                     )
                 }
-                //throw S3ErrorType.multipart.abortedUpload(resumeRequest: input, error: error)
             }
             // if failure then abort the multipart upload
             let request = S3.AbortMultipartUploadRequest(


### PR DESCRIPTION
Return new `ResumeMultipartUploadRequest` with updated `completedParts` array when `resumeMultipartUpload` fails. Previously we were just using the original resume request and the `completedParts` never got updated.