### PR TITLE
resumeMultipartUpload recursive function call fix

### DIFF
--- a/Sources/Soto/Extensions/S3/S3+multipart_API.swift
+++ b/Sources/Soto/Extensions/S3/S3+multipart_API.swift
@@ -687,7 +687,9 @@ extension S3 {
                         return
                     }
                     completedParts.append(part)
-                    multipartUploadPart(partNumber: partNumber + 1, uploadId: uploadId)
+                    _ = eventLoop.submit {
+                        multipartUploadPart(partNumber: partNumber + 1, uploadId: uploadId)
+                    }
                 }.cascadeFailure(to: promise)
             } else {
                 // supply payload data


### PR DESCRIPTION
If you call `whenComplete`, `map` etc on a completed `EventLoopFuture` if will call the closure immediately. This was causing `resumeMultipartUpload` to overflow the stack if you were uploading a large enough object and enough of the parts could be skipped.

We avoid the stack overflow by putting the recursive call inside a `EventLoop.submit` call.