### PR TITLE
Add CognitoIdentity renewing external identity provider

### DIFF
--- a/Sources/Soto/Extensions/CognitoIdentity/CognitoIdentity+IdentityProvider.swift
+++ b/Sources/Soto/Extensions/CognitoIdentity/CognitoIdentity+IdentityProvider.swift
@@ -127,10 +127,10 @@ extension CognitoIdentity {
                 eventLoop: eventLoop,
                 logger: logger
             )
-            return loginsProvider(context)
+            return self.loginsProvider(context)
                 .flatMap { logins in
                     let request = CognitoIdentity.GetIdInput(identityPoolId: context.identityPoolId, logins: logins)
-                    return identityProviderContext.cognitoIdentity.getId(request, logger: context.logger, on: eventLoop).map { (logins: logins, response: $0) }
+                    return self.identityProviderContext.cognitoIdentity.getId(request, logger: context.logger, on: eventLoop).map { (logins: logins, response: $0) }
                 }
                 .flatMapThrowing { (result: (logins: [String: String], response: GetIdResponse)) -> IdentityParams in
                     guard let identityId = result.response.identityId else { throw CredentialProviderError.noProvider }
@@ -160,7 +160,7 @@ extension IdentityProviderFactory {
     /// See https://docs.aws.amazon.com/cognitoidentity/latest/APIReference/API_GetId.html
     /// and https://docs.aws.amazon.com/cognito/latest/developerguide/external-identity-providers.html
     /// for details on what to return from the tokenProvider closure
-    /// 
+    ///
     /// Below is an example using a Cognito UserPool to authenticate.
     /// ```
     /// let credentialProvider: CredentialProviderFactory = .cognitoIdentity(


### PR DESCRIPTION
Previously there was no way to renew the credentials that generated the Identity required for the Cognito Identity credential provider. So when the identity credentials expired you had to create a new `AWSClient`. This PR adds a new `IdentityProvider` via `.externalIdentityProvider` which renews the identity as well when credentials expire. The closure included is called every time a new identity is needed. It returns a set of name-value pairs that map provider names to provider tokens.

Here is an example using Cognito Userpools for identity. In this case the closure is returning 
  
```swift
let credentialProvider: CredentialProviderFactory = .cognitoIdentity(
    identityPoolId: "my-identiy-pool-id",
    identityProvider: .externalIdentityProvider(tokenProvider: { context in
        let userPoolIdentityProvider = "cognito-idp.\(context.region).amazonaws.com/\(userPoolId)"
        let cognitoIdentityProvider = CognitoIdentityProvider(client: context.client, region: context.region)
        let request = CognitoIdentityProvider.InitiateAuthRequest(
            authFlow: .userPasswordAuth,
            authParameters: ["USERNAME": "my-username", "PASSWORD": "my-password"],
            clientId: "my-client-id"
        )
        return cognitoIdentityProvider.initiateAuth(request, logger: context.logger, on: context.eventLoop)
            .flatMapThrowing { response in
                guard let idToken = response.authenticationResult?.idToken else { throw CredentialProviderError.noProvider }
                return [userPoolIdentityProvider: idToken]
            }
    }),
    region: .euwest1
)
```