### PR TITLE
Add Expect: 100-continue header for large S3 uploads

### DIFF
--- a/Sources/Soto/Extensions/S3/S3RequestMiddleware.swift
+++ b/Sources/Soto/Extensions/S3/S3RequestMiddleware.swift
@@ -27,7 +27,8 @@ public struct S3RequestMiddleware: AWSServiceMiddleware {
         self.virtualAddressFixup(request: &request, context: context)
         self.createBucketFixup(request: &request)
         self.calculateMD5(request: &request)
-
+        self.expect100Continue(request: &request)
+        
         return request
     }
 
@@ -132,6 +133,17 @@ public struct S3RequestMiddleware: AWSServiceMiddleware {
             return Data(Insecure.MD5.hash(data: bytes)).base64EncodedString()
         }) {
             request.httpHeaders.replaceOrAdd(name: "Content-MD5", value: encoded)
+        }
+    }
+
+    func expect100Continue(request: inout AWSRequest) {
+        if request.httpMethod == .PUT,
+            case .raw(let payload) = request.body,
+            let size = payload.size
+        {
+            if size > 1024 * 1024 {
+                request.httpHeaders.replaceOrAdd(name: "Expect", value: "100-continue")
+            }
         }
     }
 

--- a/Tests/SotoTests/Services/S3/S3Tests.swift
+++ b/Tests/SotoTests/Services/S3/S3Tests.swift
@@ -181,6 +181,44 @@ class S3Tests: XCTestCase {
         XCTAssertNoThrow(try response.wait())
     }
 
+    func testPut100Complete() {
+        struct Verify100CompleteMiddleware: AWSServiceMiddleware {
+            func chain(request: AWSRequest, context: AWSMiddlewareContext) throws -> AWSRequest {
+                XCTAssertEqual(request.httpHeaders["Expect"].first, "100-continue")
+                return request
+            }
+        }
+        let s3 = Self.s3.with(middlewares: [Verify100CompleteMiddleware()])
+        let name = TestEnvironment.generateResourceName()
+        let data = Self.createRandomBuffer(size: 3 * 1024 * 1024)
+        let response = Self.createBucket(name: name, s3: Self.s3)
+            .flatMap { _ -> EventLoopFuture<Void> in
+                // put request that will fail
+                let putRequest = S3.PutObjectRequest(
+                    body: .data(data),
+                    bucket: name + "fail",
+                    key: name
+                )
+                return s3.putObject(putRequest).map { _ in }
+            }
+            .flatMapError { _ -> EventLoopFuture<Void> in
+                return Self.eventLoopGroup.next().makeSucceededVoidFuture()
+            }
+            .flatMap { _ -> EventLoopFuture<Void> in
+                // put request that will be successful
+                let putRequest = S3.PutObjectRequest(
+                    body: .data(data),
+                    bucket: name,
+                    key: name
+                )
+                return s3.putObject(putRequest).map { _ in }
+            }
+            .flatAlways { _ in
+                return Self.deleteBucket(name: name, s3: Self.s3)
+            }
+        XCTAssertNoThrow(try response.wait())
+    }
+
     func testCopy() {
         let name = TestEnvironment.generateResourceName()
         let keyName = "file1"


### PR DESCRIPTION
Means requests will error immediately instead of waiting until upload has completed

Requires AHC v1.6.4, so I need to update SotoCore as well