### PR TITLE
Add Expect: 100-continue header for large S3 uploads

### DIFF
--- a/Sources/Soto/Extensions/S3/S3RequestMiddleware.swift
+++ b/Sources/Soto/Extensions/S3/S3RequestMiddleware.swift
@@ -28,7 +28,7 @@ public struct S3RequestMiddleware: AWSServiceMiddleware {
         self.createBucketFixup(request: &request)
         self.calculateMD5(request: &request)
         self.expect100Continue(request: &request)
-        
+
         return request
     }
 
@@ -138,8 +138,8 @@ public struct S3RequestMiddleware: AWSServiceMiddleware {
 
     func expect100Continue(request: inout AWSRequest) {
         if request.httpMethod == .PUT,
-            case .raw(let payload) = request.body,
-            let size = payload.size
+           case .raw(let payload) = request.body,
+           let size = payload.size
         {
             if size > 128 * 1024 {
                 request.httpHeaders.replaceOrAdd(name: "Expect", value: "100-continue")

--- a/Sources/Soto/Extensions/S3/S3RequestMiddleware.swift
+++ b/Sources/Soto/Extensions/S3/S3RequestMiddleware.swift
@@ -141,7 +141,7 @@ public struct S3RequestMiddleware: AWSServiceMiddleware {
             case .raw(let payload) = request.body,
             let size = payload.size
         {
-            if size > 1024 * 1024 {
+            if size > 128 * 1024 {
                 request.httpHeaders.replaceOrAdd(name: "Expect", value: "100-continue")
             }
         }

--- a/Sources/Soto/Extensions/S3/S3RequestMiddleware.swift
+++ b/Sources/Soto/Extensions/S3/S3RequestMiddleware.swift
@@ -27,7 +27,8 @@ public struct S3RequestMiddleware: AWSServiceMiddleware {
         self.virtualAddressFixup(request: &request, context: context)
         self.createBucketFixup(request: &request)
         self.calculateMD5(request: &request)
-
+        self.expect100Continue(request: &request)
+        
         return request
     }
 
@@ -132,6 +133,17 @@ public struct S3RequestMiddleware: AWSServiceMiddleware {
             return Data(Insecure.MD5.hash(data: bytes)).base64EncodedString()
         }) {
             request.httpHeaders.replaceOrAdd(name: "Content-MD5", value: encoded)
+        }
+    }
+
+    func expect100Continue(request: inout AWSRequest) {
+        if request.httpMethod == .PUT,
+            case .raw(let payload) = request.body,
+            let size = payload.size
+        {
+            if size > 1024 * 1024 {
+                request.httpHeaders.replaceOrAdd(name: "Expect", value: "100-continue")
+            }
         }
     }
 

--- a/Tests/SotoTests/Services/S3/S3Tests.swift
+++ b/Tests/SotoTests/Services/S3/S3Tests.swift
@@ -269,7 +269,7 @@ class S3Tests: XCTestCase {
         }
         let s3 = Self.s3.with(middlewares: [Verify100CompleteMiddleware()])
         let name = TestEnvironment.generateResourceName()
-        let blockSize = 64*1024
+        let blockSize = 64 * 1024
         let data = Self.createRandomBuffer(size: 8 * 1024 * 1024)
         var byteBuffer = ByteBuffer(data: data)
         // put request that will fail


### PR DESCRIPTION
Means requests will error immediately instead of waiting until upload has completed

Requires AHC v1.6.4, so I need to update SotoCore as well