### PR TITLE
Deprecated member initializers

### DIFF
--- a/Sources/Soto/Services/AppStream/AppStream_Shapes.swift
+++ b/Sources/Soto/Services/AppStream/AppStream_Shapes.swift
@@ -3471,6 +3471,30 @@ extension AppStream {
         /// The VPC configuration for the fleet. This is required for Elastic fleets, but not required for other fleet types. Elastic fleets require that you specify at least two subnets in different availability zones.
         public let vpcConfig: VpcConfig?
 
+        public init(attributesToDelete: [FleetAttribute]? = nil, computeCapacity: ComputeCapacity? = nil, description: String? = nil, disconnectTimeoutInSeconds: Int? = nil, displayName: String? = nil, domainJoinInfo: DomainJoinInfo? = nil, enableDefaultInternetAccess: Bool? = nil, iamRoleArn: String? = nil, idleDisconnectTimeoutInSeconds: Int? = nil, imageArn: String? = nil, imageName: String? = nil, instanceType: String? = nil, maxConcurrentSessions: Int? = nil, maxUserDurationInSeconds: Int? = nil, name: String? = nil, platform: PlatformType? = nil, streamView: StreamView? = nil, usbDeviceFilterStrings: [String]? = nil, vpcConfig: VpcConfig? = nil) {
+            self.attributesToDelete = attributesToDelete
+            self.computeCapacity = computeCapacity
+            self.deleteVpcConfig = nil
+            self.description = description
+            self.disconnectTimeoutInSeconds = disconnectTimeoutInSeconds
+            self.displayName = displayName
+            self.domainJoinInfo = domainJoinInfo
+            self.enableDefaultInternetAccess = enableDefaultInternetAccess
+            self.iamRoleArn = iamRoleArn
+            self.idleDisconnectTimeoutInSeconds = idleDisconnectTimeoutInSeconds
+            self.imageArn = imageArn
+            self.imageName = imageName
+            self.instanceType = instanceType
+            self.maxConcurrentSessions = maxConcurrentSessions
+            self.maxUserDurationInSeconds = maxUserDurationInSeconds
+            self.name = name
+            self.platform = platform
+            self.streamView = streamView
+            self.usbDeviceFilterStrings = usbDeviceFilterStrings
+            self.vpcConfig = vpcConfig
+        }
+
+        @available(*, deprecated, message: "Members deleteVpcConfig have been deprecated")
         public init(attributesToDelete: [FleetAttribute]? = nil, computeCapacity: ComputeCapacity? = nil, deleteVpcConfig: Bool? = nil, description: String? = nil, disconnectTimeoutInSeconds: Int? = nil, displayName: String? = nil, domainJoinInfo: DomainJoinInfo? = nil, enableDefaultInternetAccess: Bool? = nil, iamRoleArn: String? = nil, idleDisconnectTimeoutInSeconds: Int? = nil, imageArn: String? = nil, imageName: String? = nil, instanceType: String? = nil, maxConcurrentSessions: Int? = nil, maxUserDurationInSeconds: Int? = nil, name: String? = nil, platform: PlatformType? = nil, streamView: StreamView? = nil, usbDeviceFilterStrings: [String]? = nil, vpcConfig: VpcConfig? = nil) {
             self.attributesToDelete = attributesToDelete
             self.computeCapacity = computeCapacity
@@ -3603,6 +3627,22 @@ extension AppStream {
         /// The actions that are enabled or disabled for users during their streaming sessions. By default, these actions are enabled.
         public let userSettings: [UserSetting]?
 
+        public init(accessEndpoints: [AccessEndpoint]? = nil, applicationSettings: ApplicationSettings? = nil, attributesToDelete: [StackAttribute]? = nil, description: String? = nil, displayName: String? = nil, embedHostDomains: [String]? = nil, feedbackURL: String? = nil, name: String, redirectURL: String? = nil, storageConnectors: [StorageConnector]? = nil, userSettings: [UserSetting]? = nil) {
+            self.accessEndpoints = accessEndpoints
+            self.applicationSettings = applicationSettings
+            self.attributesToDelete = attributesToDelete
+            self.deleteStorageConnectors = nil
+            self.description = description
+            self.displayName = displayName
+            self.embedHostDomains = embedHostDomains
+            self.feedbackURL = feedbackURL
+            self.name = name
+            self.redirectURL = redirectURL
+            self.storageConnectors = storageConnectors
+            self.userSettings = userSettings
+        }
+
+        @available(*, deprecated, message: "Members deleteStorageConnectors have been deprecated")
         public init(accessEndpoints: [AccessEndpoint]? = nil, applicationSettings: ApplicationSettings? = nil, attributesToDelete: [StackAttribute]? = nil, deleteStorageConnectors: Bool? = nil, description: String? = nil, displayName: String? = nil, embedHostDomains: [String]? = nil, feedbackURL: String? = nil, name: String, redirectURL: String? = nil, storageConnectors: [StorageConnector]? = nil, userSettings: [UserSetting]? = nil) {
             self.accessEndpoints = accessEndpoints
             self.applicationSettings = applicationSettings

--- a/Sources/Soto/Services/Batch/Batch_Shapes.swift
+++ b/Sources/Soto/Services/Batch/Batch_Shapes.swift
@@ -390,6 +390,27 @@ extension Batch {
         /// The type of compute environment: EC2, SPOT, FARGATE, or FARGATE_SPOT. For more information, see Compute Environments in the Batch User Guide. If you choose SPOT, you must also specify an Amazon EC2 Spot Fleet role with the spotIamFleetRole parameter. For more information, see Amazon EC2 Spot Fleet role in the Batch User Guide.
         public let type: CRType
 
+        public init(allocationStrategy: CRAllocationStrategy? = nil, bidPercentage: Int? = nil, desiredvCpus: Int? = nil, ec2Configuration: [Ec2Configuration]? = nil, ec2KeyPair: String? = nil, instanceRole: String? = nil, instanceTypes: [String]? = nil, launchTemplate: LaunchTemplateSpecification? = nil, maxvCpus: Int, minvCpus: Int? = nil, placementGroup: String? = nil, securityGroupIds: [String]? = nil, spotIamFleetRole: String? = nil, subnets: [String], tags: [String: String]? = nil, type: CRType) {
+            self.allocationStrategy = allocationStrategy
+            self.bidPercentage = bidPercentage
+            self.desiredvCpus = desiredvCpus
+            self.ec2Configuration = ec2Configuration
+            self.ec2KeyPair = ec2KeyPair
+            self.imageId = nil
+            self.instanceRole = instanceRole
+            self.instanceTypes = instanceTypes
+            self.launchTemplate = launchTemplate
+            self.maxvCpus = maxvCpus
+            self.minvCpus = minvCpus
+            self.placementGroup = placementGroup
+            self.securityGroupIds = securityGroupIds
+            self.spotIamFleetRole = spotIamFleetRole
+            self.subnets = subnets
+            self.tags = tags
+            self.type = type
+        }
+
+        @available(*, deprecated, message: "Members imageId have been deprecated")
         public init(allocationStrategy: CRAllocationStrategy? = nil, bidPercentage: Int? = nil, desiredvCpus: Int? = nil, ec2Configuration: [Ec2Configuration]? = nil, ec2KeyPair: String? = nil, imageId: String? = nil, instanceRole: String? = nil, instanceTypes: [String]? = nil, launchTemplate: LaunchTemplateSpecification? = nil, maxvCpus: Int, minvCpus: Int? = nil, placementGroup: String? = nil, securityGroupIds: [String]? = nil, spotIamFleetRole: String? = nil, subnets: [String], tags: [String: String]? = nil, type: CRType) {
             self.allocationStrategy = allocationStrategy
             self.bidPercentage = bidPercentage
@@ -593,6 +614,16 @@ extension Batch {
         /// This parameter is deprecated, use resourceRequirements to override the vcpus parameter that's set in the job definition. It's not supported for jobs that run on Fargate resources. For jobs run on EC2 resources, it overrides the vcpus parameter set in the job definition, but doesn't override any vCPU requirement specified in the resourceRequirements structure in the job definition. To override vCPU requirements that are specified in the resourceRequirements structure in the job definition, resourceRequirements must be specified in the SubmitJob request, with type set to VCPU and value set to the new value. For more information, see Can't override job definition resource requirements in the Batch User Guide.
         public let vcpus: Int?
 
+        public init(command: [String]? = nil, environment: [KeyValuePair]? = nil, instanceType: String? = nil, resourceRequirements: [ResourceRequirement]? = nil) {
+            self.command = command
+            self.environment = environment
+            self.instanceType = instanceType
+            self.memory = nil
+            self.resourceRequirements = resourceRequirements
+            self.vcpus = nil
+        }
+
+        @available(*, deprecated, message: "Members memory, vcpus have been deprecated")
         public init(command: [String]? = nil, environment: [KeyValuePair]? = nil, instanceType: String? = nil, memory: Int? = nil, resourceRequirements: [ResourceRequirement]? = nil, vcpus: Int? = nil) {
             self.command = command
             self.environment = environment
@@ -654,6 +685,30 @@ extension Batch {
         /// A list of data volumes used in a job.
         public let volumes: [Volume]?
 
+        public init(command: [String]? = nil, environment: [KeyValuePair]? = nil, executionRoleArn: String? = nil, fargatePlatformConfiguration: FargatePlatformConfiguration? = nil, image: String? = nil, instanceType: String? = nil, jobRoleArn: String? = nil, linuxParameters: LinuxParameters? = nil, logConfiguration: LogConfiguration? = nil, mountPoints: [MountPoint]? = nil, networkConfiguration: NetworkConfiguration? = nil, privileged: Bool? = nil, readonlyRootFilesystem: Bool? = nil, resourceRequirements: [ResourceRequirement]? = nil, secrets: [Secret]? = nil, ulimits: [Ulimit]? = nil, user: String? = nil, volumes: [Volume]? = nil) {
+            self.command = command
+            self.environment = environment
+            self.executionRoleArn = executionRoleArn
+            self.fargatePlatformConfiguration = fargatePlatformConfiguration
+            self.image = image
+            self.instanceType = instanceType
+            self.jobRoleArn = jobRoleArn
+            self.linuxParameters = linuxParameters
+            self.logConfiguration = logConfiguration
+            self.memory = nil
+            self.mountPoints = mountPoints
+            self.networkConfiguration = networkConfiguration
+            self.privileged = privileged
+            self.readonlyRootFilesystem = readonlyRootFilesystem
+            self.resourceRequirements = resourceRequirements
+            self.secrets = secrets
+            self.ulimits = ulimits
+            self.user = user
+            self.vcpus = nil
+            self.volumes = volumes
+        }
+
+        @available(*, deprecated, message: "Members memory, vcpus have been deprecated")
         public init(command: [String]? = nil, environment: [KeyValuePair]? = nil, executionRoleArn: String? = nil, fargatePlatformConfiguration: FargatePlatformConfiguration? = nil, image: String? = nil, instanceType: String? = nil, jobRoleArn: String? = nil, linuxParameters: LinuxParameters? = nil, logConfiguration: LogConfiguration? = nil, memory: Int? = nil, mountPoints: [MountPoint]? = nil, networkConfiguration: NetworkConfiguration? = nil, privileged: Bool? = nil, readonlyRootFilesystem: Bool? = nil, resourceRequirements: [ResourceRequirement]? = nil, secrets: [Secret]? = nil, ulimits: [Ulimit]? = nil, user: String? = nil, vcpus: Int? = nil, volumes: [Volume]? = nil) {
             self.command = command
             self.environment = environment

--- a/Sources/Soto/Services/CloudFront/CloudFront_Shapes.swift
+++ b/Sources/Soto/Services/CloudFront/CloudFront_Shapes.swift
@@ -522,6 +522,29 @@ extension CloudFront {
         ///
         public let viewerProtocolPolicy: ViewerProtocolPolicy
 
+        public init(allowedMethods: AllowedMethods? = nil, cachePolicyId: String? = nil, compress: Bool? = nil, fieldLevelEncryptionId: String? = nil, functionAssociations: FunctionAssociations? = nil, lambdaFunctionAssociations: LambdaFunctionAssociations? = nil, originRequestPolicyId: String? = nil, pathPattern: String, realtimeLogConfigArn: String? = nil, responseHeadersPolicyId: String? = nil, smoothStreaming: Bool? = nil, targetOriginId: String, trustedKeyGroups: TrustedKeyGroups? = nil, trustedSigners: TrustedSigners? = nil, viewerProtocolPolicy: ViewerProtocolPolicy) {
+            self.allowedMethods = allowedMethods
+            self.cachePolicyId = cachePolicyId
+            self.compress = compress
+            self.defaultTTL = nil
+            self.fieldLevelEncryptionId = fieldLevelEncryptionId
+            self.forwardedValues = nil
+            self.functionAssociations = functionAssociations
+            self.lambdaFunctionAssociations = lambdaFunctionAssociations
+            self.maxTTL = nil
+            self.minTTL = nil
+            self.originRequestPolicyId = originRequestPolicyId
+            self.pathPattern = pathPattern
+            self.realtimeLogConfigArn = realtimeLogConfigArn
+            self.responseHeadersPolicyId = responseHeadersPolicyId
+            self.smoothStreaming = smoothStreaming
+            self.targetOriginId = targetOriginId
+            self.trustedKeyGroups = trustedKeyGroups
+            self.trustedSigners = trustedSigners
+            self.viewerProtocolPolicy = viewerProtocolPolicy
+        }
+
+        @available(*, deprecated, message: "Members defaultTTL, forwardedValues, maxTTL, minTTL have been deprecated")
         public init(allowedMethods: AllowedMethods? = nil, cachePolicyId: String? = nil, compress: Bool? = nil, defaultTTL: Int64? = nil, fieldLevelEncryptionId: String? = nil, forwardedValues: ForwardedValues? = nil, functionAssociations: FunctionAssociations? = nil, lambdaFunctionAssociations: LambdaFunctionAssociations? = nil, maxTTL: Int64? = nil, minTTL: Int64? = nil, originRequestPolicyId: String? = nil, pathPattern: String, realtimeLogConfigArn: String? = nil, responseHeadersPolicyId: String? = nil, smoothStreaming: Bool? = nil, targetOriginId: String, trustedKeyGroups: TrustedKeyGroups? = nil, trustedSigners: TrustedSigners? = nil, viewerProtocolPolicy: ViewerProtocolPolicy) {
             self.allowedMethods = allowedMethods
             self.cachePolicyId = cachePolicyId
@@ -2235,6 +2258,28 @@ extension CloudFront {
         ///
         public let viewerProtocolPolicy: ViewerProtocolPolicy
 
+        public init(allowedMethods: AllowedMethods? = nil, cachePolicyId: String? = nil, compress: Bool? = nil, fieldLevelEncryptionId: String? = nil, functionAssociations: FunctionAssociations? = nil, lambdaFunctionAssociations: LambdaFunctionAssociations? = nil, originRequestPolicyId: String? = nil, realtimeLogConfigArn: String? = nil, responseHeadersPolicyId: String? = nil, smoothStreaming: Bool? = nil, targetOriginId: String, trustedKeyGroups: TrustedKeyGroups? = nil, trustedSigners: TrustedSigners? = nil, viewerProtocolPolicy: ViewerProtocolPolicy) {
+            self.allowedMethods = allowedMethods
+            self.cachePolicyId = cachePolicyId
+            self.compress = compress
+            self.defaultTTL = nil
+            self.fieldLevelEncryptionId = fieldLevelEncryptionId
+            self.forwardedValues = nil
+            self.functionAssociations = functionAssociations
+            self.lambdaFunctionAssociations = lambdaFunctionAssociations
+            self.maxTTL = nil
+            self.minTTL = nil
+            self.originRequestPolicyId = originRequestPolicyId
+            self.realtimeLogConfigArn = realtimeLogConfigArn
+            self.responseHeadersPolicyId = responseHeadersPolicyId
+            self.smoothStreaming = smoothStreaming
+            self.targetOriginId = targetOriginId
+            self.trustedKeyGroups = trustedKeyGroups
+            self.trustedSigners = trustedSigners
+            self.viewerProtocolPolicy = viewerProtocolPolicy
+        }
+
+        @available(*, deprecated, message: "Members defaultTTL, forwardedValues, maxTTL, minTTL have been deprecated")
         public init(allowedMethods: AllowedMethods? = nil, cachePolicyId: String? = nil, compress: Bool? = nil, defaultTTL: Int64? = nil, fieldLevelEncryptionId: String? = nil, forwardedValues: ForwardedValues? = nil, functionAssociations: FunctionAssociations? = nil, lambdaFunctionAssociations: LambdaFunctionAssociations? = nil, maxTTL: Int64? = nil, minTTL: Int64? = nil, originRequestPolicyId: String? = nil, realtimeLogConfigArn: String? = nil, responseHeadersPolicyId: String? = nil, smoothStreaming: Bool? = nil, targetOriginId: String, trustedKeyGroups: TrustedKeyGroups? = nil, trustedSigners: TrustedSigners? = nil, viewerProtocolPolicy: ViewerProtocolPolicy) {
             self.allowedMethods = allowedMethods
             self.cachePolicyId = cachePolicyId
@@ -8760,6 +8805,17 @@ extension CloudFront {
         /// 			d111111abcdef8.cloudfront.net, don’t set a value for this field.
         public let sSLSupportMethod: SSLSupportMethod?
 
+        public init(aCMCertificateArn: String? = nil, cloudFrontDefaultCertificate: Bool? = nil, iAMCertificateId: String? = nil, minimumProtocolVersion: MinimumProtocolVersion? = nil, sSLSupportMethod: SSLSupportMethod? = nil) {
+            self.aCMCertificateArn = aCMCertificateArn
+            self.certificate = nil
+            self.certificateSource = nil
+            self.cloudFrontDefaultCertificate = cloudFrontDefaultCertificate
+            self.iAMCertificateId = iAMCertificateId
+            self.minimumProtocolVersion = minimumProtocolVersion
+            self.sSLSupportMethod = sSLSupportMethod
+        }
+
+        @available(*, deprecated, message: "Members certificate, certificateSource have been deprecated")
         public init(aCMCertificateArn: String? = nil, certificate: String? = nil, certificateSource: CertificateSource? = nil, cloudFrontDefaultCertificate: Bool? = nil, iAMCertificateId: String? = nil, minimumProtocolVersion: MinimumProtocolVersion? = nil, sSLSupportMethod: SSLSupportMethod? = nil) {
             self.aCMCertificateArn = aCMCertificateArn
             self.certificate = certificate

--- a/Sources/Soto/Services/CloudTrail/CloudTrail_Shapes.swift
+++ b/Sources/Soto/Services/CloudTrail/CloudTrail_Shapes.swift
@@ -263,6 +263,23 @@ extension CloudTrail {
         /// Specifies the ARN of the trail that was created. The format of a trail ARN is:  arn:aws:cloudtrail:us-east-2:123456789012:trail/MyTrail
         public let trailARN: String?
 
+        public init(cloudWatchLogsLogGroupArn: String? = nil, cloudWatchLogsRoleArn: String? = nil, includeGlobalServiceEvents: Bool? = nil, isMultiRegionTrail: Bool? = nil, isOrganizationTrail: Bool? = nil, kmsKeyId: String? = nil, logFileValidationEnabled: Bool? = nil, name: String? = nil, s3BucketName: String? = nil, s3KeyPrefix: String? = nil, snsTopicARN: String? = nil, trailARN: String? = nil) {
+            self.cloudWatchLogsLogGroupArn = cloudWatchLogsLogGroupArn
+            self.cloudWatchLogsRoleArn = cloudWatchLogsRoleArn
+            self.includeGlobalServiceEvents = includeGlobalServiceEvents
+            self.isMultiRegionTrail = isMultiRegionTrail
+            self.isOrganizationTrail = isOrganizationTrail
+            self.kmsKeyId = kmsKeyId
+            self.logFileValidationEnabled = logFileValidationEnabled
+            self.name = name
+            self.s3BucketName = s3BucketName
+            self.s3KeyPrefix = s3KeyPrefix
+            self.snsTopicARN = snsTopicARN
+            self.snsTopicName = nil
+            self.trailARN = trailARN
+        }
+
+        @available(*, deprecated, message: "Members snsTopicName have been deprecated")
         public init(cloudWatchLogsLogGroupArn: String? = nil, cloudWatchLogsRoleArn: String? = nil, includeGlobalServiceEvents: Bool? = nil, isMultiRegionTrail: Bool? = nil, isOrganizationTrail: Bool? = nil, kmsKeyId: String? = nil, logFileValidationEnabled: Bool? = nil, name: String? = nil, s3BucketName: String? = nil, s3KeyPrefix: String? = nil, snsTopicARN: String? = nil, snsTopicName: String? = nil, trailARN: String? = nil) {
             self.cloudWatchLogsLogGroupArn = cloudWatchLogsLogGroupArn
             self.cloudWatchLogsRoleArn = cloudWatchLogsRoleArn
@@ -1043,6 +1060,26 @@ extension CloudTrail {
         /// Specifies the ARN of the trail. The following is the format of a trail ARN.  arn:aws:cloudtrail:us-east-2:123456789012:trail/MyTrail
         public let trailARN: String?
 
+        public init(cloudWatchLogsLogGroupArn: String? = nil, cloudWatchLogsRoleArn: String? = nil, hasCustomEventSelectors: Bool? = nil, hasInsightSelectors: Bool? = nil, homeRegion: String? = nil, includeGlobalServiceEvents: Bool? = nil, isMultiRegionTrail: Bool? = nil, isOrganizationTrail: Bool? = nil, kmsKeyId: String? = nil, logFileValidationEnabled: Bool? = nil, name: String? = nil, s3BucketName: String? = nil, s3KeyPrefix: String? = nil, snsTopicARN: String? = nil, trailARN: String? = nil) {
+            self.cloudWatchLogsLogGroupArn = cloudWatchLogsLogGroupArn
+            self.cloudWatchLogsRoleArn = cloudWatchLogsRoleArn
+            self.hasCustomEventSelectors = hasCustomEventSelectors
+            self.hasInsightSelectors = hasInsightSelectors
+            self.homeRegion = homeRegion
+            self.includeGlobalServiceEvents = includeGlobalServiceEvents
+            self.isMultiRegionTrail = isMultiRegionTrail
+            self.isOrganizationTrail = isOrganizationTrail
+            self.kmsKeyId = kmsKeyId
+            self.logFileValidationEnabled = logFileValidationEnabled
+            self.name = name
+            self.s3BucketName = s3BucketName
+            self.s3KeyPrefix = s3KeyPrefix
+            self.snsTopicARN = snsTopicARN
+            self.snsTopicName = nil
+            self.trailARN = trailARN
+        }
+
+        @available(*, deprecated, message: "Members snsTopicName have been deprecated")
         public init(cloudWatchLogsLogGroupArn: String? = nil, cloudWatchLogsRoleArn: String? = nil, hasCustomEventSelectors: Bool? = nil, hasInsightSelectors: Bool? = nil, homeRegion: String? = nil, includeGlobalServiceEvents: Bool? = nil, isMultiRegionTrail: Bool? = nil, isOrganizationTrail: Bool? = nil, kmsKeyId: String? = nil, logFileValidationEnabled: Bool? = nil, name: String? = nil, s3BucketName: String? = nil, s3KeyPrefix: String? = nil, snsTopicARN: String? = nil, snsTopicName: String? = nil, trailARN: String? = nil) {
             self.cloudWatchLogsLogGroupArn = cloudWatchLogsLogGroupArn
             self.cloudWatchLogsRoleArn = cloudWatchLogsRoleArn
@@ -1184,6 +1221,23 @@ extension CloudTrail {
         /// Specifies the ARN of the trail that was updated. The following is the format of a trail ARN.  arn:aws:cloudtrail:us-east-2:123456789012:trail/MyTrail
         public let trailARN: String?
 
+        public init(cloudWatchLogsLogGroupArn: String? = nil, cloudWatchLogsRoleArn: String? = nil, includeGlobalServiceEvents: Bool? = nil, isMultiRegionTrail: Bool? = nil, isOrganizationTrail: Bool? = nil, kmsKeyId: String? = nil, logFileValidationEnabled: Bool? = nil, name: String? = nil, s3BucketName: String? = nil, s3KeyPrefix: String? = nil, snsTopicARN: String? = nil, trailARN: String? = nil) {
+            self.cloudWatchLogsLogGroupArn = cloudWatchLogsLogGroupArn
+            self.cloudWatchLogsRoleArn = cloudWatchLogsRoleArn
+            self.includeGlobalServiceEvents = includeGlobalServiceEvents
+            self.isMultiRegionTrail = isMultiRegionTrail
+            self.isOrganizationTrail = isOrganizationTrail
+            self.kmsKeyId = kmsKeyId
+            self.logFileValidationEnabled = logFileValidationEnabled
+            self.name = name
+            self.s3BucketName = s3BucketName
+            self.s3KeyPrefix = s3KeyPrefix
+            self.snsTopicARN = snsTopicARN
+            self.snsTopicName = nil
+            self.trailARN = trailARN
+        }
+
+        @available(*, deprecated, message: "Members snsTopicName have been deprecated")
         public init(cloudWatchLogsLogGroupArn: String? = nil, cloudWatchLogsRoleArn: String? = nil, includeGlobalServiceEvents: Bool? = nil, isMultiRegionTrail: Bool? = nil, isOrganizationTrail: Bool? = nil, kmsKeyId: String? = nil, logFileValidationEnabled: Bool? = nil, name: String? = nil, s3BucketName: String? = nil, s3KeyPrefix: String? = nil, snsTopicARN: String? = nil, snsTopicName: String? = nil, trailARN: String? = nil) {
             self.cloudWatchLogsLogGroupArn = cloudWatchLogsLogGroupArn
             self.cloudWatchLogsRoleArn = cloudWatchLogsRoleArn

--- a/Sources/Soto/Services/CloudWatch/CloudWatch_Shapes.swift
+++ b/Sources/Soto/Services/CloudWatch/CloudWatch_Shapes.swift
@@ -186,6 +186,18 @@ extension CloudWatch {
         /// The current status of the anomaly detector's training. The possible values are TRAINED | PENDING_TRAINING | TRAINED_INSUFFICIENT_DATA
         public let stateValue: AnomalyDetectorStateValue?
 
+        public init(configuration: AnomalyDetectorConfiguration? = nil, metricMathAnomalyDetector: MetricMathAnomalyDetector? = nil, singleMetricAnomalyDetector: SingleMetricAnomalyDetector? = nil, stateValue: AnomalyDetectorStateValue? = nil) {
+            self.configuration = configuration
+            self.dimensions = nil
+            self.metricMathAnomalyDetector = metricMathAnomalyDetector
+            self.metricName = nil
+            self.namespace = nil
+            self.singleMetricAnomalyDetector = singleMetricAnomalyDetector
+            self.stat = nil
+            self.stateValue = stateValue
+        }
+
+        @available(*, deprecated, message: "Members dimensions, metricName, namespace, stat have been deprecated")
         public init(configuration: AnomalyDetectorConfiguration? = nil, dimensions: [Dimension]? = nil, metricMathAnomalyDetector: MetricMathAnomalyDetector? = nil, metricName: String? = nil, namespace: String? = nil, singleMetricAnomalyDetector: SingleMetricAnomalyDetector? = nil, stat: String? = nil, stateValue: AnomalyDetectorStateValue? = nil) {
             self.configuration = configuration
             self.dimensions = dimensions
@@ -438,6 +450,16 @@ extension CloudWatch {
         /// The statistic associated with the anomaly detection model to delete.
         public let stat: String?
 
+        public init(metricMathAnomalyDetector: MetricMathAnomalyDetector? = nil, singleMetricAnomalyDetector: SingleMetricAnomalyDetector? = nil) {
+            self.dimensions = nil
+            self.metricMathAnomalyDetector = metricMathAnomalyDetector
+            self.metricName = nil
+            self.namespace = nil
+            self.singleMetricAnomalyDetector = singleMetricAnomalyDetector
+            self.stat = nil
+        }
+
+        @available(*, deprecated, message: "Members dimensions, metricName, namespace, stat have been deprecated")
         public init(dimensions: [Dimension]? = nil, metricMathAnomalyDetector: MetricMathAnomalyDetector? = nil, metricName: String? = nil, namespace: String? = nil, singleMetricAnomalyDetector: SingleMetricAnomalyDetector? = nil, stat: String? = nil) {
             self.dimensions = dimensions
             self.metricMathAnomalyDetector = metricMathAnomalyDetector
@@ -2512,6 +2534,17 @@ extension CloudWatch {
         /// The statistic to use for the metric and the anomaly detection model.
         public let stat: String?
 
+        public init(configuration: AnomalyDetectorConfiguration? = nil, metricMathAnomalyDetector: MetricMathAnomalyDetector? = nil, singleMetricAnomalyDetector: SingleMetricAnomalyDetector? = nil) {
+            self.configuration = configuration
+            self.dimensions = nil
+            self.metricMathAnomalyDetector = metricMathAnomalyDetector
+            self.metricName = nil
+            self.namespace = nil
+            self.singleMetricAnomalyDetector = singleMetricAnomalyDetector
+            self.stat = nil
+        }
+
+        @available(*, deprecated, message: "Members dimensions, metricName, namespace, stat have been deprecated")
         public init(configuration: AnomalyDetectorConfiguration? = nil, dimensions: [Dimension]? = nil, metricMathAnomalyDetector: MetricMathAnomalyDetector? = nil, metricName: String? = nil, namespace: String? = nil, singleMetricAnomalyDetector: SingleMetricAnomalyDetector? = nil, stat: String? = nil) {
             self.configuration = configuration
             self.dimensions = dimensions

--- a/Sources/Soto/Services/CloudWatchLogs/CloudWatchLogs_Paginator.swift
+++ b/Sources/Soto/Services/CloudWatchLogs/CloudWatchLogs_Paginator.swift
@@ -455,7 +455,6 @@ extension CloudWatchLogs.FilterLogEventsRequest: AWSPaginateToken {
         return .init(
             endTime: self.endTime,
             filterPattern: self.filterPattern,
-            interleaved: self.interleaved,
             limit: self.limit,
             logGroupName: self.logGroupName,
             logStreamNamePrefix: self.logStreamNamePrefix,

--- a/Sources/Soto/Services/CloudWatchLogs/CloudWatchLogs_Shapes.swift
+++ b/Sources/Soto/Services/CloudWatchLogs/CloudWatchLogs_Shapes.swift
@@ -1038,6 +1038,19 @@ extension CloudWatchLogs {
         /// The start of the time range, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC. Events with a timestamp before this time are not returned.
         public let startTime: Int64?
 
+        public init(endTime: Int64? = nil, filterPattern: String? = nil, limit: Int? = nil, logGroupName: String, logStreamNamePrefix: String? = nil, logStreamNames: [String]? = nil, nextToken: String? = nil, startTime: Int64? = nil) {
+            self.endTime = endTime
+            self.filterPattern = filterPattern
+            self.interleaved = nil
+            self.limit = limit
+            self.logGroupName = logGroupName
+            self.logStreamNamePrefix = logStreamNamePrefix
+            self.logStreamNames = logStreamNames
+            self.nextToken = nextToken
+            self.startTime = startTime
+        }
+
+        @available(*, deprecated, message: "Members interleaved have been deprecated")
         public init(endTime: Int64? = nil, filterPattern: String? = nil, interleaved: Bool? = nil, limit: Int? = nil, logGroupName: String, logStreamNamePrefix: String? = nil, logStreamNames: [String]? = nil, nextToken: String? = nil, startTime: Int64? = nil) {
             self.endTime = endTime
             self.filterPattern = filterPattern
@@ -1433,6 +1446,18 @@ extension CloudWatchLogs {
         /// The sequence token.
         public let uploadSequenceToken: String?
 
+        public init(arn: String? = nil, creationTime: Int64? = nil, firstEventTimestamp: Int64? = nil, lastEventTimestamp: Int64? = nil, lastIngestionTime: Int64? = nil, logStreamName: String? = nil, uploadSequenceToken: String? = nil) {
+            self.arn = arn
+            self.creationTime = creationTime
+            self.firstEventTimestamp = firstEventTimestamp
+            self.lastEventTimestamp = lastEventTimestamp
+            self.lastIngestionTime = lastIngestionTime
+            self.logStreamName = logStreamName
+            self.storedBytes = nil
+            self.uploadSequenceToken = uploadSequenceToken
+        }
+
+        @available(*, deprecated, message: "Members storedBytes have been deprecated")
         public init(arn: String? = nil, creationTime: Int64? = nil, firstEventTimestamp: Int64? = nil, lastEventTimestamp: Int64? = nil, lastIngestionTime: Int64? = nil, logStreamName: String? = nil, storedBytes: Int64? = nil, uploadSequenceToken: String? = nil) {
             self.arn = arn
             self.creationTime = creationTime

--- a/Sources/Soto/Services/DatabaseMigrationService/DatabaseMigrationService_Shapes.swift
+++ b/Sources/Soto/Services/DatabaseMigrationService/DatabaseMigrationService_Shapes.swift
@@ -3902,6 +3902,33 @@ extension DatabaseMigrationService {
         /// The VPC security group for the instance.
         public let vpcSecurityGroups: [VpcSecurityGroupMembership]?
 
+        public init(allocatedStorage: Int? = nil, autoMinorVersionUpgrade: Bool? = nil, availabilityZone: String? = nil, dnsNameServers: String? = nil, engineVersion: String? = nil, freeUntil: Date? = nil, instanceCreateTime: Date? = nil, kmsKeyId: String? = nil, multiAZ: Bool? = nil, pendingModifiedValues: ReplicationPendingModifiedValues? = nil, preferredMaintenanceWindow: String? = nil, publiclyAccessible: Bool? = nil, replicationInstanceArn: String? = nil, replicationInstanceClass: String? = nil, replicationInstanceIdentifier: String? = nil, replicationInstancePrivateIpAddresses: [String]? = nil, replicationInstancePublicIpAddresses: [String]? = nil, replicationInstanceStatus: String? = nil, replicationSubnetGroup: ReplicationSubnetGroup? = nil, secondaryAvailabilityZone: String? = nil, vpcSecurityGroups: [VpcSecurityGroupMembership]? = nil) {
+            self.allocatedStorage = allocatedStorage
+            self.autoMinorVersionUpgrade = autoMinorVersionUpgrade
+            self.availabilityZone = availabilityZone
+            self.dnsNameServers = dnsNameServers
+            self.engineVersion = engineVersion
+            self.freeUntil = freeUntil
+            self.instanceCreateTime = instanceCreateTime
+            self.kmsKeyId = kmsKeyId
+            self.multiAZ = multiAZ
+            self.pendingModifiedValues = pendingModifiedValues
+            self.preferredMaintenanceWindow = preferredMaintenanceWindow
+            self.publiclyAccessible = publiclyAccessible
+            self.replicationInstanceArn = replicationInstanceArn
+            self.replicationInstanceClass = replicationInstanceClass
+            self.replicationInstanceIdentifier = replicationInstanceIdentifier
+            self.replicationInstancePrivateIpAddress = nil
+            self.replicationInstancePrivateIpAddresses = replicationInstancePrivateIpAddresses
+            self.replicationInstancePublicIpAddress = nil
+            self.replicationInstancePublicIpAddresses = replicationInstancePublicIpAddresses
+            self.replicationInstanceStatus = replicationInstanceStatus
+            self.replicationSubnetGroup = replicationSubnetGroup
+            self.secondaryAvailabilityZone = secondaryAvailabilityZone
+            self.vpcSecurityGroups = vpcSecurityGroups
+        }
+
+        @available(*, deprecated, message: "Members replicationInstancePrivateIpAddress, replicationInstancePublicIpAddress have been deprecated")
         public init(allocatedStorage: Int? = nil, autoMinorVersionUpgrade: Bool? = nil, availabilityZone: String? = nil, dnsNameServers: String? = nil, engineVersion: String? = nil, freeUntil: Date? = nil, instanceCreateTime: Date? = nil, kmsKeyId: String? = nil, multiAZ: Bool? = nil, pendingModifiedValues: ReplicationPendingModifiedValues? = nil, preferredMaintenanceWindow: String? = nil, publiclyAccessible: Bool? = nil, replicationInstanceArn: String? = nil, replicationInstanceClass: String? = nil, replicationInstanceIdentifier: String? = nil, replicationInstancePrivateIpAddress: String? = nil, replicationInstancePrivateIpAddresses: [String]? = nil, replicationInstancePublicIpAddress: String? = nil, replicationInstancePublicIpAddresses: [String]? = nil, replicationInstanceStatus: String? = nil, replicationSubnetGroup: ReplicationSubnetGroup? = nil, secondaryAvailabilityZone: String? = nil, vpcSecurityGroups: [VpcSecurityGroupMembership]? = nil) {
             self.allocatedStorage = allocatedStorage
             self.autoMinorVersionUpgrade = autoMinorVersionUpgrade

--- a/Sources/Soto/Services/Detective/Detective_Shapes.swift
+++ b/Sources/Soto/Services/Detective/Detective_Shapes.swift
@@ -505,6 +505,23 @@ extension Detective {
         @OptionalCustomCoding<ISO8601DateCoder>
         public var volumeUsageUpdatedTime: Date?
 
+        public init(accountId: String? = nil, administratorId: String? = nil, disabledReason: MemberDisabledReason? = nil, emailAddress: String? = nil, graphArn: String? = nil, invitedTime: Date? = nil, status: MemberStatus? = nil, updatedTime: Date? = nil, volumeUsageInBytes: Int64? = nil, volumeUsageUpdatedTime: Date? = nil) {
+            self.accountId = accountId
+            self.administratorId = administratorId
+            self.disabledReason = disabledReason
+            self.emailAddress = emailAddress
+            self.graphArn = graphArn
+            self.invitedTime = invitedTime
+            self.masterId = nil
+            self.percentOfGraphUtilization = nil
+            self.percentOfGraphUtilizationUpdatedTime = nil
+            self.status = status
+            self.updatedTime = updatedTime
+            self.volumeUsageInBytes = volumeUsageInBytes
+            self.volumeUsageUpdatedTime = volumeUsageUpdatedTime
+        }
+
+        @available(*, deprecated, message: "Members masterId, percentOfGraphUtilization, percentOfGraphUtilizationUpdatedTime have been deprecated")
         public init(accountId: String? = nil, administratorId: String? = nil, disabledReason: MemberDisabledReason? = nil, emailAddress: String? = nil, graphArn: String? = nil, invitedTime: Date? = nil, masterId: String? = nil, percentOfGraphUtilization: Double? = nil, percentOfGraphUtilizationUpdatedTime: Date? = nil, status: MemberStatus? = nil, updatedTime: Date? = nil, volumeUsageInBytes: Int64? = nil, volumeUsageUpdatedTime: Date? = nil) {
             self.accountId = accountId
             self.administratorId = administratorId

--- a/Sources/Soto/Services/EC2/EC2_Shapes.swift
+++ b/Sources/Soto/Services/EC2/EC2_Shapes.swift
@@ -5872,6 +5872,31 @@ extension EC2 {
         /// The protocol used by the VPN session.
         public let vpnProtocol: VpnProtocol?
 
+        public init(authenticationOptions: [ClientVpnAuthentication]? = nil, clientCidrBlock: String? = nil, clientConnectOptions: ClientConnectResponseOptions? = nil, clientVpnEndpointId: String? = nil, connectionLogOptions: ConnectionLogResponseOptions? = nil, creationTime: String? = nil, deletionTime: String? = nil, description: String? = nil, dnsName: String? = nil, dnsServers: [String]? = nil, securityGroupIds: [String]? = nil, selfServicePortalUrl: String? = nil, serverCertificateArn: String? = nil, splitTunnel: Bool? = nil, status: ClientVpnEndpointStatus? = nil, tags: [Tag]? = nil, transportProtocol: TransportProtocol? = nil, vpcId: String? = nil, vpnPort: Int? = nil, vpnProtocol: VpnProtocol? = nil) {
+            self.associatedTargetNetworks = nil
+            self.authenticationOptions = authenticationOptions
+            self.clientCidrBlock = clientCidrBlock
+            self.clientConnectOptions = clientConnectOptions
+            self.clientVpnEndpointId = clientVpnEndpointId
+            self.connectionLogOptions = connectionLogOptions
+            self.creationTime = creationTime
+            self.deletionTime = deletionTime
+            self.description = description
+            self.dnsName = dnsName
+            self.dnsServers = dnsServers
+            self.securityGroupIds = securityGroupIds
+            self.selfServicePortalUrl = selfServicePortalUrl
+            self.serverCertificateArn = serverCertificateArn
+            self.splitTunnel = splitTunnel
+            self.status = status
+            self.tags = tags
+            self.transportProtocol = transportProtocol
+            self.vpcId = vpcId
+            self.vpnPort = vpnPort
+            self.vpnProtocol = vpnProtocol
+        }
+
+        @available(*, deprecated, message: "Members associatedTargetNetworks have been deprecated")
         public init(associatedTargetNetworks: [AssociatedTargetNetwork]? = nil, authenticationOptions: [ClientVpnAuthentication]? = nil, clientCidrBlock: String? = nil, clientConnectOptions: ClientConnectResponseOptions? = nil, clientVpnEndpointId: String? = nil, connectionLogOptions: ConnectionLogResponseOptions? = nil, creationTime: String? = nil, deletionTime: String? = nil, description: String? = nil, dnsName: String? = nil, dnsServers: [String]? = nil, securityGroupIds: [String]? = nil, selfServicePortalUrl: String? = nil, serverCertificateArn: String? = nil, splitTunnel: Bool? = nil, status: ClientVpnEndpointStatus? = nil, tags: [Tag]? = nil, transportProtocol: TransportProtocol? = nil, vpcId: String? = nil, vpnPort: Int? = nil, vpnProtocol: VpnProtocol? = nil) {
             self.associatedTargetNetworks = associatedTargetNetworks
             self.authenticationOptions = authenticationOptions

--- a/Sources/Soto/Services/ECR/ECR_Shapes.swift
+++ b/Sources/Soto/Services/ECR/ECR_Shapes.swift
@@ -871,6 +871,11 @@ extension ECR {
         /// A list of Amazon Web Services account IDs that are associated with the registries for which to get AuthorizationData objects. If you do not specify a registry, the default registry is assumed.
         public let registryIds: [String]?
 
+        public init() {
+            self.registryIds = nil
+        }
+
+        @available(*, deprecated, message: "Members registryIds have been deprecated")
         public init(registryIds: [String]? = nil) {
             self.registryIds = registryIds
         }

--- a/Sources/Soto/Services/EMRContainers/EMRContainers_Shapes.swift
+++ b/Sources/Soto/Services/EMRContainers/EMRContainers_Shapes.swift
@@ -275,6 +275,19 @@ extension EMRContainers {
         /// The ID of the virtual cluster for which a managed endpoint is created.
         public let virtualClusterId: String
 
+        public init(clientToken: String = CreateManagedEndpointRequest.idempotencyToken(), configurationOverrides: ConfigurationOverrides? = nil, executionRoleArn: String, name: String, releaseLabel: String, tags: [String: String]? = nil, type: String, virtualClusterId: String) {
+            self.certificateArn = nil
+            self.clientToken = clientToken
+            self.configurationOverrides = configurationOverrides
+            self.executionRoleArn = executionRoleArn
+            self.name = name
+            self.releaseLabel = releaseLabel
+            self.tags = tags
+            self.type = type
+            self.virtualClusterId = virtualClusterId
+        }
+
+        @available(*, deprecated, message: "Members certificateArn have been deprecated")
         public init(certificateArn: String? = nil, clientToken: String = CreateManagedEndpointRequest.idempotencyToken(), configurationOverrides: ConfigurationOverrides? = nil, executionRoleArn: String, name: String, releaseLabel: String, tags: [String: String]? = nil, type: String, virtualClusterId: String) {
             self.certificateArn = certificateArn
             self.clientToken = clientToken
@@ -673,6 +686,28 @@ extension EMRContainers {
         /// The ID of the endpoint's virtual cluster.
         public let virtualClusterId: String?
 
+        public init(arn: String? = nil, certificateAuthority: Certificate? = nil, configurationOverrides: ConfigurationOverrides? = nil, createdAt: Date? = nil, executionRoleArn: String? = nil, failureReason: FailureReason? = nil, id: String? = nil, name: String? = nil, releaseLabel: String? = nil, securityGroup: String? = nil, serverUrl: String? = nil, state: EndpointState? = nil, stateDetails: String? = nil, subnetIds: [String]? = nil, tags: [String: String]? = nil, type: String? = nil, virtualClusterId: String? = nil) {
+            self.arn = arn
+            self.certificateArn = nil
+            self.certificateAuthority = certificateAuthority
+            self.configurationOverrides = configurationOverrides
+            self.createdAt = createdAt
+            self.executionRoleArn = executionRoleArn
+            self.failureReason = failureReason
+            self.id = id
+            self.name = name
+            self.releaseLabel = releaseLabel
+            self.securityGroup = securityGroup
+            self.serverUrl = serverUrl
+            self.state = state
+            self.stateDetails = stateDetails
+            self.subnetIds = subnetIds
+            self.tags = tags
+            self.type = type
+            self.virtualClusterId = virtualClusterId
+        }
+
+        @available(*, deprecated, message: "Members certificateArn have been deprecated")
         public init(arn: String? = nil, certificateArn: String? = nil, certificateAuthority: Certificate? = nil, configurationOverrides: ConfigurationOverrides? = nil, createdAt: Date? = nil, executionRoleArn: String? = nil, failureReason: FailureReason? = nil, id: String? = nil, name: String? = nil, releaseLabel: String? = nil, securityGroup: String? = nil, serverUrl: String? = nil, state: EndpointState? = nil, stateDetails: String? = nil, subnetIds: [String]? = nil, tags: [String: String]? = nil, type: String? = nil, virtualClusterId: String? = nil) {
             self.arn = arn
             self.certificateArn = certificateArn

--- a/Sources/Soto/Services/ElastiCache/ElastiCache_Shapes.swift
+++ b/Sources/Soto/Services/ElastiCache/ElastiCache_Shapes.swift
@@ -3722,6 +3722,35 @@ extension ElastiCache {
         @OptionalCustomCoding<StandardArrayCoder>
         public var userGroupIdsToRemove: [String]?
 
+        public init(applyImmediately: Bool? = nil, authToken: String? = nil, authTokenUpdateStrategy: AuthTokenUpdateStrategyType? = nil, automaticFailoverEnabled: Bool? = nil, autoMinorVersionUpgrade: Bool? = nil, cacheNodeType: String? = nil, cacheParameterGroupName: String? = nil, cacheSecurityGroupNames: [String]? = nil, engineVersion: String? = nil, logDeliveryConfigurations: [LogDeliveryConfigurationRequest]? = nil, multiAZEnabled: Bool? = nil, notificationTopicArn: String? = nil, notificationTopicStatus: String? = nil, preferredMaintenanceWindow: String? = nil, primaryClusterId: String? = nil, removeUserGroups: Bool? = nil, replicationGroupDescription: String? = nil, replicationGroupId: String, securityGroupIds: [String]? = nil, snapshotRetentionLimit: Int? = nil, snapshottingClusterId: String? = nil, snapshotWindow: String? = nil, userGroupIdsToAdd: [String]? = nil, userGroupIdsToRemove: [String]? = nil) {
+            self.applyImmediately = applyImmediately
+            self.authToken = authToken
+            self.authTokenUpdateStrategy = authTokenUpdateStrategy
+            self.automaticFailoverEnabled = automaticFailoverEnabled
+            self.autoMinorVersionUpgrade = autoMinorVersionUpgrade
+            self.cacheNodeType = cacheNodeType
+            self.cacheParameterGroupName = cacheParameterGroupName
+            self.cacheSecurityGroupNames = cacheSecurityGroupNames
+            self.engineVersion = engineVersion
+            self.logDeliveryConfigurations = logDeliveryConfigurations
+            self.multiAZEnabled = multiAZEnabled
+            self.nodeGroupId = nil
+            self.notificationTopicArn = notificationTopicArn
+            self.notificationTopicStatus = notificationTopicStatus
+            self.preferredMaintenanceWindow = preferredMaintenanceWindow
+            self.primaryClusterId = primaryClusterId
+            self.removeUserGroups = removeUserGroups
+            self.replicationGroupDescription = replicationGroupDescription
+            self.replicationGroupId = replicationGroupId
+            self.securityGroupIds = securityGroupIds
+            self.snapshotRetentionLimit = snapshotRetentionLimit
+            self.snapshottingClusterId = snapshottingClusterId
+            self.snapshotWindow = snapshotWindow
+            self.userGroupIdsToAdd = userGroupIdsToAdd
+            self.userGroupIdsToRemove = userGroupIdsToRemove
+        }
+
+        @available(*, deprecated, message: "Members nodeGroupId have been deprecated")
         public init(applyImmediately: Bool? = nil, authToken: String? = nil, authTokenUpdateStrategy: AuthTokenUpdateStrategyType? = nil, automaticFailoverEnabled: Bool? = nil, autoMinorVersionUpgrade: Bool? = nil, cacheNodeType: String? = nil, cacheParameterGroupName: String? = nil, cacheSecurityGroupNames: [String]? = nil, engineVersion: String? = nil, logDeliveryConfigurations: [LogDeliveryConfigurationRequest]? = nil, multiAZEnabled: Bool? = nil, nodeGroupId: String? = nil, notificationTopicArn: String? = nil, notificationTopicStatus: String? = nil, preferredMaintenanceWindow: String? = nil, primaryClusterId: String? = nil, removeUserGroups: Bool? = nil, replicationGroupDescription: String? = nil, replicationGroupId: String, securityGroupIds: [String]? = nil, snapshotRetentionLimit: Int? = nil, snapshottingClusterId: String? = nil, snapshotWindow: String? = nil, userGroupIdsToAdd: [String]? = nil, userGroupIdsToRemove: [String]? = nil) {
             self.applyImmediately = applyImmediately
             self.authToken = authToken

--- a/Sources/Soto/Services/ElasticTranscoder/ElasticTranscoder_Shapes.swift
+++ b/Sources/Soto/Services/ElasticTranscoder/ElasticTranscoder_Shapes.swift
@@ -248,6 +248,13 @@ extension ElasticTranscoder {
         /// A policy that determines how Elastic Transcoder handles the existence of multiple captions.    MergeOverride: Elastic Transcoder transcodes both embedded and sidecar captions into outputs. If captions for a language are embedded in the input file and also appear in a sidecar file, Elastic Transcoder uses the sidecar captions and ignores the embedded captions for that language.    MergeRetain:  Elastic Transcoder transcodes both embedded and sidecar captions into outputs. If captions for a language are embedded in the input file and also appear in a sidecar file, Elastic Transcoder uses the embedded captions and ignores the sidecar captions for that language. If CaptionSources is empty, Elastic Transcoder omits all sidecar captions from the output files.    Override: Elastic Transcoder transcodes only the sidecar captions that you specify in CaptionSources.    MergePolicy cannot be null.
         public let mergePolicy: String?
 
+        public init(captionFormats: [CaptionFormat]? = nil) {
+            self.captionFormats = captionFormats
+            self.captionSources = nil
+            self.mergePolicy = nil
+        }
+
+        @available(*, deprecated, message: "Members captionSources, mergePolicy have been deprecated")
         public init(captionFormats: [CaptionFormat]? = nil, captionSources: [CaptionSource]? = nil, mergePolicy: String? = nil) {
             self.captionFormats = captionFormats
             self.captionSources = captionSources
@@ -315,6 +322,21 @@ extension ElasticTranscoder {
         /// Information about the watermarks that you want Elastic Transcoder to add to the video during transcoding.  You can specify up to four watermarks for each output. Settings for each watermark must be defined  in the preset for the current output.
         public let watermarks: [JobWatermark]?
 
+        public init(albumArt: JobAlbumArt? = nil, captions: Captions? = nil, encryption: Encryption? = nil, key: String? = nil, presetId: String? = nil, rotate: String? = nil, segmentDuration: String? = nil, thumbnailEncryption: Encryption? = nil, thumbnailPattern: String? = nil, watermarks: [JobWatermark]? = nil) {
+            self.albumArt = albumArt
+            self.captions = captions
+            self.composition = nil
+            self.encryption = encryption
+            self.key = key
+            self.presetId = presetId
+            self.rotate = rotate
+            self.segmentDuration = segmentDuration
+            self.thumbnailEncryption = thumbnailEncryption
+            self.thumbnailPattern = thumbnailPattern
+            self.watermarks = watermarks
+        }
+
+        @available(*, deprecated, message: "Members composition have been deprecated")
         public init(albumArt: JobAlbumArt? = nil, captions: Captions? = nil, composition: [Clip]? = nil, encryption: Encryption? = nil, key: String? = nil, presetId: String? = nil, rotate: String? = nil, segmentDuration: String? = nil, thumbnailEncryption: Encryption? = nil, thumbnailPattern: String? = nil, watermarks: [JobWatermark]? = nil) {
             self.albumArt = albumArt
             self.captions = captions
@@ -995,6 +1017,31 @@ extension ElasticTranscoder {
         /// Specifies the width of the output file in pixels.
         public let width: Int?
 
+        public init(albumArt: JobAlbumArt? = nil, appliedColorSpaceConversion: String? = nil, captions: Captions? = nil, duration: Int64? = nil, durationMillis: Int64? = nil, encryption: Encryption? = nil, fileSize: Int64? = nil, frameRate: String? = nil, height: Int? = nil, id: String? = nil, key: String? = nil, presetId: String? = nil, rotate: String? = nil, segmentDuration: String? = nil, status: String? = nil, statusDetail: String? = nil, thumbnailEncryption: Encryption? = nil, thumbnailPattern: String? = nil, watermarks: [JobWatermark]? = nil, width: Int? = nil) {
+            self.albumArt = albumArt
+            self.appliedColorSpaceConversion = appliedColorSpaceConversion
+            self.captions = captions
+            self.composition = nil
+            self.duration = duration
+            self.durationMillis = durationMillis
+            self.encryption = encryption
+            self.fileSize = fileSize
+            self.frameRate = frameRate
+            self.height = height
+            self.id = id
+            self.key = key
+            self.presetId = presetId
+            self.rotate = rotate
+            self.segmentDuration = segmentDuration
+            self.status = status
+            self.statusDetail = statusDetail
+            self.thumbnailEncryption = thumbnailEncryption
+            self.thumbnailPattern = thumbnailPattern
+            self.watermarks = watermarks
+            self.width = width
+        }
+
+        @available(*, deprecated, message: "Members composition have been deprecated")
         public init(albumArt: JobAlbumArt? = nil, appliedColorSpaceConversion: String? = nil, captions: Captions? = nil, composition: [Clip]? = nil, duration: Int64? = nil, durationMillis: Int64? = nil, encryption: Encryption? = nil, fileSize: Int64? = nil, frameRate: String? = nil, height: Int? = nil, id: String? = nil, key: String? = nil, presetId: String? = nil, rotate: String? = nil, segmentDuration: String? = nil, status: String? = nil, statusDetail: String? = nil, thumbnailEncryption: Encryption? = nil, thumbnailPattern: String? = nil, watermarks: [JobWatermark]? = nil, width: Int? = nil) {
             self.albumArt = albumArt
             self.appliedColorSpaceConversion = appliedColorSpaceConversion

--- a/Sources/Soto/Services/Firehose/Firehose_Shapes.swift
+++ b/Sources/Soto/Services/Firehose/Firehose_Shapes.swift
@@ -531,6 +531,22 @@ extension Firehose {
         ///  You can specify up to 50 tags when creating a delivery stream.
         public let tags: [Tag]?
 
+        public init(amazonopensearchserviceDestinationConfiguration: AmazonopensearchserviceDestinationConfiguration? = nil, deliveryStreamEncryptionConfigurationInput: DeliveryStreamEncryptionConfigurationInput? = nil, deliveryStreamName: String, deliveryStreamType: DeliveryStreamType? = nil, elasticsearchDestinationConfiguration: ElasticsearchDestinationConfiguration? = nil, extendedS3DestinationConfiguration: ExtendedS3DestinationConfiguration? = nil, httpEndpointDestinationConfiguration: HttpEndpointDestinationConfiguration? = nil, kinesisStreamSourceConfiguration: KinesisStreamSourceConfiguration? = nil, redshiftDestinationConfiguration: RedshiftDestinationConfiguration? = nil, splunkDestinationConfiguration: SplunkDestinationConfiguration? = nil, tags: [Tag]? = nil) {
+            self.amazonopensearchserviceDestinationConfiguration = amazonopensearchserviceDestinationConfiguration
+            self.deliveryStreamEncryptionConfigurationInput = deliveryStreamEncryptionConfigurationInput
+            self.deliveryStreamName = deliveryStreamName
+            self.deliveryStreamType = deliveryStreamType
+            self.elasticsearchDestinationConfiguration = elasticsearchDestinationConfiguration
+            self.extendedS3DestinationConfiguration = extendedS3DestinationConfiguration
+            self.httpEndpointDestinationConfiguration = httpEndpointDestinationConfiguration
+            self.kinesisStreamSourceConfiguration = kinesisStreamSourceConfiguration
+            self.redshiftDestinationConfiguration = redshiftDestinationConfiguration
+            self.s3DestinationConfiguration = nil
+            self.splunkDestinationConfiguration = splunkDestinationConfiguration
+            self.tags = tags
+        }
+
+        @available(*, deprecated, message: "Members s3DestinationConfiguration have been deprecated")
         public init(amazonopensearchserviceDestinationConfiguration: AmazonopensearchserviceDestinationConfiguration? = nil, deliveryStreamEncryptionConfigurationInput: DeliveryStreamEncryptionConfigurationInput? = nil, deliveryStreamName: String, deliveryStreamType: DeliveryStreamType? = nil, elasticsearchDestinationConfiguration: ElasticsearchDestinationConfiguration? = nil, extendedS3DestinationConfiguration: ExtendedS3DestinationConfiguration? = nil, httpEndpointDestinationConfiguration: HttpEndpointDestinationConfiguration? = nil, kinesisStreamSourceConfiguration: KinesisStreamSourceConfiguration? = nil, redshiftDestinationConfiguration: RedshiftDestinationConfiguration? = nil, s3DestinationConfiguration: S3DestinationConfiguration? = nil, splunkDestinationConfiguration: SplunkDestinationConfiguration? = nil, tags: [Tag]? = nil) {
             self.amazonopensearchserviceDestinationConfiguration = amazonopensearchserviceDestinationConfiguration
             self.deliveryStreamEncryptionConfigurationInput = deliveryStreamEncryptionConfigurationInput
@@ -3075,6 +3091,20 @@ extension Firehose {
         /// Describes an update for a destination in Splunk.
         public let splunkDestinationUpdate: SplunkDestinationUpdate?
 
+        public init(amazonopensearchserviceDestinationUpdate: AmazonopensearchserviceDestinationUpdate? = nil, currentDeliveryStreamVersionId: String, deliveryStreamName: String, destinationId: String, elasticsearchDestinationUpdate: ElasticsearchDestinationUpdate? = nil, extendedS3DestinationUpdate: ExtendedS3DestinationUpdate? = nil, httpEndpointDestinationUpdate: HttpEndpointDestinationUpdate? = nil, redshiftDestinationUpdate: RedshiftDestinationUpdate? = nil, splunkDestinationUpdate: SplunkDestinationUpdate? = nil) {
+            self.amazonopensearchserviceDestinationUpdate = amazonopensearchserviceDestinationUpdate
+            self.currentDeliveryStreamVersionId = currentDeliveryStreamVersionId
+            self.deliveryStreamName = deliveryStreamName
+            self.destinationId = destinationId
+            self.elasticsearchDestinationUpdate = elasticsearchDestinationUpdate
+            self.extendedS3DestinationUpdate = extendedS3DestinationUpdate
+            self.httpEndpointDestinationUpdate = httpEndpointDestinationUpdate
+            self.redshiftDestinationUpdate = redshiftDestinationUpdate
+            self.s3DestinationUpdate = nil
+            self.splunkDestinationUpdate = splunkDestinationUpdate
+        }
+
+        @available(*, deprecated, message: "Members s3DestinationUpdate have been deprecated")
         public init(amazonopensearchserviceDestinationUpdate: AmazonopensearchserviceDestinationUpdate? = nil, currentDeliveryStreamVersionId: String, deliveryStreamName: String, destinationId: String, elasticsearchDestinationUpdate: ElasticsearchDestinationUpdate? = nil, extendedS3DestinationUpdate: ExtendedS3DestinationUpdate? = nil, httpEndpointDestinationUpdate: HttpEndpointDestinationUpdate? = nil, redshiftDestinationUpdate: RedshiftDestinationUpdate? = nil, s3DestinationUpdate: S3DestinationUpdate? = nil, splunkDestinationUpdate: SplunkDestinationUpdate? = nil) {
             self.amazonopensearchserviceDestinationUpdate = amazonopensearchserviceDestinationUpdate
             self.currentDeliveryStreamVersionId = currentDeliveryStreamVersionId

--- a/Sources/Soto/Services/Forecast/Forecast_Shapes.swift
+++ b/Sources/Soto/Services/Forecast/Forecast_Shapes.swift
@@ -2986,6 +2986,14 @@ extension Forecast {
         /// An array of weighted quantile losses. Quantiles divide a probability distribution into regions of equal probability. The distribution in this case is the loss function.
         public let weightedQuantileLosses: [WeightedQuantileLoss]?
 
+        public init(averageWeightedQuantileLoss: Double? = nil, errorMetrics: [ErrorMetric]? = nil, weightedQuantileLosses: [WeightedQuantileLoss]? = nil) {
+            self.averageWeightedQuantileLoss = averageWeightedQuantileLoss
+            self.errorMetrics = errorMetrics
+            self.rmse = nil
+            self.weightedQuantileLosses = weightedQuantileLosses
+        }
+
+        @available(*, deprecated, message: "Members rmse have been deprecated")
         public init(averageWeightedQuantileLoss: Double? = nil, errorMetrics: [ErrorMetric]? = nil, rmse: Double? = nil, weightedQuantileLosses: [WeightedQuantileLoss]? = nil) {
             self.averageWeightedQuantileLoss = averageWeightedQuantileLoss
             self.errorMetrics = errorMetrics

--- a/Sources/Soto/Services/Glue/Glue_Shapes.swift
+++ b/Sources/Soto/Services/Glue/Glue_Shapes.swift
@@ -2859,6 +2859,29 @@ extension Glue {
         /// 	          For the Standard worker type, each worker provides 4 vCPU, 16 GB of memory and a 50GB disk, and 2 executors per worker.   For the G.1X worker type, each worker maps to 1 DPU (4 vCPU, 16 GB of memory, 64 GB disk), and provides 1 executor per worker. We recommend this worker type for memory-intensive jobs.   For the G.2X worker type, each worker maps to 2 DPU (8 vCPU, 32 GB of memory, 128 GB disk), and provides 1 executor per worker. We recommend this worker type for memory-intensive jobs.
         public let workerType: WorkerType?
 
+        public init(command: JobCommand, connections: ConnectionsList? = nil, defaultArguments: [String: String]? = nil, description: String? = nil, executionProperty: ExecutionProperty? = nil, glueVersion: String? = nil, logUri: String? = nil, maxCapacity: Double? = nil, maxRetries: Int? = nil, name: String, nonOverridableArguments: [String: String]? = nil, notificationProperty: NotificationProperty? = nil, numberOfWorkers: Int? = nil, role: String, securityConfiguration: String? = nil, tags: [String: String]? = nil, timeout: Int? = nil, workerType: WorkerType? = nil) {
+            self.allocatedCapacity = nil
+            self.command = command
+            self.connections = connections
+            self.defaultArguments = defaultArguments
+            self.description = description
+            self.executionProperty = executionProperty
+            self.glueVersion = glueVersion
+            self.logUri = logUri
+            self.maxCapacity = maxCapacity
+            self.maxRetries = maxRetries
+            self.name = name
+            self.nonOverridableArguments = nonOverridableArguments
+            self.notificationProperty = notificationProperty
+            self.numberOfWorkers = numberOfWorkers
+            self.role = role
+            self.securityConfiguration = securityConfiguration
+            self.tags = tags
+            self.timeout = timeout
+            self.workerType = workerType
+        }
+
+        @available(*, deprecated, message: "Members allocatedCapacity have been deprecated")
         public init(allocatedCapacity: Int? = nil, command: JobCommand, connections: ConnectionsList? = nil, defaultArguments: [String: String]? = nil, description: String? = nil, executionProperty: ExecutionProperty? = nil, glueVersion: String? = nil, logUri: String? = nil, maxCapacity: Double? = nil, maxRetries: Int? = nil, name: String, nonOverridableArguments: [String: String]? = nil, notificationProperty: NotificationProperty? = nil, numberOfWorkers: Int? = nil, role: String, securityConfiguration: String? = nil, tags: [String: String]? = nil, timeout: Int? = nil, workerType: WorkerType? = nil) {
             self.allocatedCapacity = allocatedCapacity
             self.command = command
@@ -8017,6 +8040,30 @@ extension Glue {
         /// 	          For the Standard worker type, each worker provides 4 vCPU, 16 GB of memory and a 50GB disk, and 2 executors per worker.   For the G.1X worker type, each worker maps to 1 DPU (4 vCPU, 16 GB of memory, 64 GB disk), and provides 1 executor per worker. We recommend this worker type for memory-intensive jobs.   For the G.2X worker type, each worker maps to 2 DPU (8 vCPU, 32 GB of memory, 128 GB disk), and provides 1 executor per worker. We recommend this worker type for memory-intensive jobs.
         public let workerType: WorkerType?
 
+        public init(command: JobCommand? = nil, connections: ConnectionsList? = nil, createdOn: Date? = nil, defaultArguments: [String: String]? = nil, description: String? = nil, executionProperty: ExecutionProperty? = nil, glueVersion: String? = nil, lastModifiedOn: Date? = nil, logUri: String? = nil, maxCapacity: Double? = nil, maxRetries: Int? = nil, name: String? = nil, nonOverridableArguments: [String: String]? = nil, notificationProperty: NotificationProperty? = nil, numberOfWorkers: Int? = nil, role: String? = nil, securityConfiguration: String? = nil, timeout: Int? = nil, workerType: WorkerType? = nil) {
+            self.allocatedCapacity = nil
+            self.command = command
+            self.connections = connections
+            self.createdOn = createdOn
+            self.defaultArguments = defaultArguments
+            self.description = description
+            self.executionProperty = executionProperty
+            self.glueVersion = glueVersion
+            self.lastModifiedOn = lastModifiedOn
+            self.logUri = logUri
+            self.maxCapacity = maxCapacity
+            self.maxRetries = maxRetries
+            self.name = name
+            self.nonOverridableArguments = nonOverridableArguments
+            self.notificationProperty = notificationProperty
+            self.numberOfWorkers = numberOfWorkers
+            self.role = role
+            self.securityConfiguration = securityConfiguration
+            self.timeout = timeout
+            self.workerType = workerType
+        }
+
+        @available(*, deprecated, message: "Members allocatedCapacity have been deprecated")
         public init(allocatedCapacity: Int? = nil, command: JobCommand? = nil, connections: ConnectionsList? = nil, createdOn: Date? = nil, defaultArguments: [String: String]? = nil, description: String? = nil, executionProperty: ExecutionProperty? = nil, glueVersion: String? = nil, lastModifiedOn: Date? = nil, logUri: String? = nil, maxCapacity: Double? = nil, maxRetries: Int? = nil, name: String? = nil, nonOverridableArguments: [String: String]? = nil, notificationProperty: NotificationProperty? = nil, numberOfWorkers: Int? = nil, role: String? = nil, securityConfiguration: String? = nil, timeout: Int? = nil, workerType: WorkerType? = nil) {
             self.allocatedCapacity = allocatedCapacity
             self.command = command
@@ -8212,6 +8259,32 @@ extension Glue {
         /// The type of predefined worker that is allocated when a job runs. Accepts a value of Standard, G.1X, or G.2X.   For the Standard worker type, each worker provides 4 vCPU, 16 GB of memory and a 50GB disk, and 2 executors per worker.   For the G.1X worker type, each worker provides 4 vCPU, 16 GB of memory and a 64GB disk, and 1 executor per worker.   For the G.2X worker type, each worker provides 8 vCPU, 32 GB of memory and a 128GB disk, and 1 executor per worker.
         public let workerType: WorkerType?
 
+        public init(arguments: [String: String]? = nil, attempt: Int? = nil, completedOn: Date? = nil, errorMessage: String? = nil, executionTime: Int? = nil, glueVersion: String? = nil, id: String? = nil, jobName: String? = nil, jobRunState: JobRunState? = nil, lastModifiedOn: Date? = nil, logGroupName: String? = nil, maxCapacity: Double? = nil, notificationProperty: NotificationProperty? = nil, numberOfWorkers: Int? = nil, predecessorRuns: [Predecessor]? = nil, previousRunId: String? = nil, securityConfiguration: String? = nil, startedOn: Date? = nil, timeout: Int? = nil, triggerName: String? = nil, workerType: WorkerType? = nil) {
+            self.allocatedCapacity = nil
+            self.arguments = arguments
+            self.attempt = attempt
+            self.completedOn = completedOn
+            self.errorMessage = errorMessage
+            self.executionTime = executionTime
+            self.glueVersion = glueVersion
+            self.id = id
+            self.jobName = jobName
+            self.jobRunState = jobRunState
+            self.lastModifiedOn = lastModifiedOn
+            self.logGroupName = logGroupName
+            self.maxCapacity = maxCapacity
+            self.notificationProperty = notificationProperty
+            self.numberOfWorkers = numberOfWorkers
+            self.predecessorRuns = predecessorRuns
+            self.previousRunId = previousRunId
+            self.securityConfiguration = securityConfiguration
+            self.startedOn = startedOn
+            self.timeout = timeout
+            self.triggerName = triggerName
+            self.workerType = workerType
+        }
+
+        @available(*, deprecated, message: "Members allocatedCapacity have been deprecated")
         public init(allocatedCapacity: Int? = nil, arguments: [String: String]? = nil, attempt: Int? = nil, completedOn: Date? = nil, errorMessage: String? = nil, executionTime: Int? = nil, glueVersion: String? = nil, id: String? = nil, jobName: String? = nil, jobRunState: JobRunState? = nil, lastModifiedOn: Date? = nil, logGroupName: String? = nil, maxCapacity: Double? = nil, notificationProperty: NotificationProperty? = nil, numberOfWorkers: Int? = nil, predecessorRuns: [Predecessor]? = nil, previousRunId: String? = nil, securityConfiguration: String? = nil, startedOn: Date? = nil, timeout: Int? = nil, triggerName: String? = nil, workerType: WorkerType? = nil) {
             self.allocatedCapacity = allocatedCapacity
             self.arguments = arguments
@@ -8305,6 +8378,27 @@ extension Glue {
         /// 	          For the Standard worker type, each worker provides 4 vCPU, 16 GB of memory and a 50GB disk, and 2 executors per worker.   For the G.1X worker type, each worker maps to 1 DPU (4 vCPU, 16 GB of memory, 64 GB disk), and provides 1 executor per worker. We recommend this worker type for memory-intensive jobs.   For the G.2X worker type, each worker maps to 2 DPU (8 vCPU, 32 GB of memory, 128 GB disk), and provides 1 executor per worker. We recommend this worker type for memory-intensive jobs.
         public let workerType: WorkerType?
 
+        public init(command: JobCommand? = nil, connections: ConnectionsList? = nil, defaultArguments: [String: String]? = nil, description: String? = nil, executionProperty: ExecutionProperty? = nil, glueVersion: String? = nil, logUri: String? = nil, maxCapacity: Double? = nil, maxRetries: Int? = nil, nonOverridableArguments: [String: String]? = nil, notificationProperty: NotificationProperty? = nil, numberOfWorkers: Int? = nil, role: String? = nil, securityConfiguration: String? = nil, timeout: Int? = nil, workerType: WorkerType? = nil) {
+            self.allocatedCapacity = nil
+            self.command = command
+            self.connections = connections
+            self.defaultArguments = defaultArguments
+            self.description = description
+            self.executionProperty = executionProperty
+            self.glueVersion = glueVersion
+            self.logUri = logUri
+            self.maxCapacity = maxCapacity
+            self.maxRetries = maxRetries
+            self.nonOverridableArguments = nonOverridableArguments
+            self.notificationProperty = notificationProperty
+            self.numberOfWorkers = numberOfWorkers
+            self.role = role
+            self.securityConfiguration = securityConfiguration
+            self.timeout = timeout
+            self.workerType = workerType
+        }
+
+        @available(*, deprecated, message: "Members allocatedCapacity have been deprecated")
         public init(allocatedCapacity: Int? = nil, command: JobCommand? = nil, connections: ConnectionsList? = nil, defaultArguments: [String: String]? = nil, description: String? = nil, executionProperty: ExecutionProperty? = nil, glueVersion: String? = nil, logUri: String? = nil, maxCapacity: Double? = nil, maxRetries: Int? = nil, nonOverridableArguments: [String: String]? = nil, notificationProperty: NotificationProperty? = nil, numberOfWorkers: Int? = nil, role: String? = nil, securityConfiguration: String? = nil, timeout: Int? = nil, workerType: WorkerType? = nil) {
             self.allocatedCapacity = allocatedCapacity
             self.command = command
@@ -10893,6 +10987,20 @@ extension Glue {
         /// The type of predefined worker that is allocated when a job runs. Accepts a value of Standard, G.1X, or G.2X.   For the Standard worker type, each worker provides 4 vCPU, 16 GB of memory and a 50GB disk, and 2 executors per worker.   For the G.1X worker type, each worker provides 4 vCPU, 16 GB of memory and a 64GB disk, and 1 executor per worker.   For the G.2X worker type, each worker provides 8 vCPU, 32 GB of memory and a 128GB disk, and 1 executor per worker.
         public let workerType: WorkerType?
 
+        public init(arguments: [String: String]? = nil, jobName: String, jobRunId: String? = nil, maxCapacity: Double? = nil, notificationProperty: NotificationProperty? = nil, numberOfWorkers: Int? = nil, securityConfiguration: String? = nil, timeout: Int? = nil, workerType: WorkerType? = nil) {
+            self.allocatedCapacity = nil
+            self.arguments = arguments
+            self.jobName = jobName
+            self.jobRunId = jobRunId
+            self.maxCapacity = maxCapacity
+            self.notificationProperty = notificationProperty
+            self.numberOfWorkers = numberOfWorkers
+            self.securityConfiguration = securityConfiguration
+            self.timeout = timeout
+            self.workerType = workerType
+        }
+
+        @available(*, deprecated, message: "Members allocatedCapacity have been deprecated")
         public init(allocatedCapacity: Int? = nil, arguments: [String: String]? = nil, jobName: String, jobRunId: String? = nil, maxCapacity: Double? = nil, notificationProperty: NotificationProperty? = nil, numberOfWorkers: Int? = nil, securityConfiguration: String? = nil, timeout: Int? = nil, workerType: WorkerType? = nil) {
             self.allocatedCapacity = allocatedCapacity
             self.arguments = arguments

--- a/Sources/Soto/Services/GuardDuty/GuardDuty_Shapes.swift
+++ b/Sources/Soto/Services/GuardDuty/GuardDuty_Shapes.swift
@@ -482,6 +482,22 @@ extension GuardDuty {
         /// Represents a not equal condition to be applied to a single field when querying for findings.
         public let notEquals: [String]?
 
+        public init(equals: [String]? = nil, greaterThan: Int64? = nil, greaterThanOrEqual: Int64? = nil, lessThan: Int64? = nil, lessThanOrEqual: Int64? = nil, notEquals: [String]? = nil) {
+            self.eq = nil
+            self.equals = equals
+            self.greaterThan = greaterThan
+            self.greaterThanOrEqual = greaterThanOrEqual
+            self.gt = nil
+            self.gte = nil
+            self.lessThan = lessThan
+            self.lessThanOrEqual = lessThanOrEqual
+            self.lt = nil
+            self.lte = nil
+            self.neq = nil
+            self.notEquals = notEquals
+        }
+
+        @available(*, deprecated, message: "Members eq, gt, gte, lt, lte, neq have been deprecated")
         public init(eq: [String]? = nil, equals: [String]? = nil, greaterThan: Int64? = nil, greaterThanOrEqual: Int64? = nil, gt: Int? = nil, gte: Int? = nil, lessThan: Int64? = nil, lessThanOrEqual: Int64? = nil, lt: Int? = nil, lte: Int? = nil, neq: [String]? = nil, notEquals: [String]? = nil) {
             self.eq = eq
             self.equals = equals

--- a/Sources/Soto/Services/IoT/IoT_Shapes.swift
+++ b/Sources/Soto/Services/IoT/IoT_Shapes.swift
@@ -3992,6 +3992,17 @@ extension IoT {
         /// Metadata that can be used to manage the security profile.
         public let tags: [Tag]?
 
+        public init(additionalMetricsToRetainV2: [MetricToRetain]? = nil, alertTargets: [AlertTargetType: AlertTarget]? = nil, behaviors: [Behavior]? = nil, securityProfileDescription: String? = nil, securityProfileName: String, tags: [Tag]? = nil) {
+            self.additionalMetricsToRetain = nil
+            self.additionalMetricsToRetainV2 = additionalMetricsToRetainV2
+            self.alertTargets = alertTargets
+            self.behaviors = behaviors
+            self.securityProfileDescription = securityProfileDescription
+            self.securityProfileName = securityProfileName
+            self.tags = tags
+        }
+
+        @available(*, deprecated, message: "Members additionalMetricsToRetain have been deprecated")
         public init(additionalMetricsToRetain: [String]? = nil, additionalMetricsToRetainV2: [MetricToRetain]? = nil, alertTargets: [AlertTargetType: AlertTarget]? = nil, behaviors: [Behavior]? = nil, securityProfileDescription: String? = nil, securityProfileName: String, tags: [Tag]? = nil) {
             self.additionalMetricsToRetain = additionalMetricsToRetain
             self.additionalMetricsToRetainV2 = additionalMetricsToRetainV2
@@ -6480,6 +6491,20 @@ extension IoT {
         /// The version of the security profile. A new version is generated whenever the security profile is updated.
         public let version: Int64?
 
+        public init(additionalMetricsToRetainV2: [MetricToRetain]? = nil, alertTargets: [AlertTargetType: AlertTarget]? = nil, behaviors: [Behavior]? = nil, creationDate: Date? = nil, lastModifiedDate: Date? = nil, securityProfileArn: String? = nil, securityProfileDescription: String? = nil, securityProfileName: String? = nil, version: Int64? = nil) {
+            self.additionalMetricsToRetain = nil
+            self.additionalMetricsToRetainV2 = additionalMetricsToRetainV2
+            self.alertTargets = alertTargets
+            self.behaviors = behaviors
+            self.creationDate = creationDate
+            self.lastModifiedDate = lastModifiedDate
+            self.securityProfileArn = securityProfileArn
+            self.securityProfileDescription = securityProfileDescription
+            self.securityProfileName = securityProfileName
+            self.version = version
+        }
+
+        @available(*, deprecated, message: "Members additionalMetricsToRetain have been deprecated")
         public init(additionalMetricsToRetain: [String]? = nil, additionalMetricsToRetainV2: [MetricToRetain]? = nil, alertTargets: [AlertTargetType: AlertTarget]? = nil, behaviors: [Behavior]? = nil, creationDate: Date? = nil, lastModifiedDate: Date? = nil, securityProfileArn: String? = nil, securityProfileDescription: String? = nil, securityProfileName: String? = nil, version: Int64? = nil) {
             self.additionalMetricsToRetain = additionalMetricsToRetain
             self.additionalMetricsToRetainV2 = additionalMetricsToRetainV2
@@ -12370,6 +12395,14 @@ extension IoT {
         /// The status of the register certificate request.
         public let status: CertificateStatus?
 
+        public init(caCertificatePem: String? = nil, certificatePem: String, status: CertificateStatus? = nil) {
+            self.caCertificatePem = caCertificatePem
+            self.certificatePem = certificatePem
+            self.setAsActive = nil
+            self.status = status
+        }
+
+        @available(*, deprecated, message: "Members setAsActive have been deprecated")
         public init(caCertificatePem: String? = nil, certificatePem: String, setAsActive: Bool? = nil, status: CertificateStatus? = nil) {
             self.caCertificatePem = caCertificatePem
             self.certificatePem = certificatePem
@@ -15567,6 +15600,20 @@ extension IoT {
         /// The name of the security profile you want to update.
         public let securityProfileName: String
 
+        public init(additionalMetricsToRetainV2: [MetricToRetain]? = nil, alertTargets: [AlertTargetType: AlertTarget]? = nil, behaviors: [Behavior]? = nil, deleteAdditionalMetricsToRetain: Bool? = nil, deleteAlertTargets: Bool? = nil, deleteBehaviors: Bool? = nil, expectedVersion: Int64? = nil, securityProfileDescription: String? = nil, securityProfileName: String) {
+            self.additionalMetricsToRetain = nil
+            self.additionalMetricsToRetainV2 = additionalMetricsToRetainV2
+            self.alertTargets = alertTargets
+            self.behaviors = behaviors
+            self.deleteAdditionalMetricsToRetain = deleteAdditionalMetricsToRetain
+            self.deleteAlertTargets = deleteAlertTargets
+            self.deleteBehaviors = deleteBehaviors
+            self.expectedVersion = expectedVersion
+            self.securityProfileDescription = securityProfileDescription
+            self.securityProfileName = securityProfileName
+        }
+
+        @available(*, deprecated, message: "Members additionalMetricsToRetain have been deprecated")
         public init(additionalMetricsToRetain: [String]? = nil, additionalMetricsToRetainV2: [MetricToRetain]? = nil, alertTargets: [AlertTargetType: AlertTarget]? = nil, behaviors: [Behavior]? = nil, deleteAdditionalMetricsToRetain: Bool? = nil, deleteAlertTargets: Bool? = nil, deleteBehaviors: Bool? = nil, expectedVersion: Int64? = nil, securityProfileDescription: String? = nil, securityProfileName: String) {
             self.additionalMetricsToRetain = additionalMetricsToRetain
             self.additionalMetricsToRetainV2 = additionalMetricsToRetainV2
@@ -15632,6 +15679,20 @@ extension IoT {
         /// The updated version of the security profile.
         public let version: Int64?
 
+        public init(additionalMetricsToRetainV2: [MetricToRetain]? = nil, alertTargets: [AlertTargetType: AlertTarget]? = nil, behaviors: [Behavior]? = nil, creationDate: Date? = nil, lastModifiedDate: Date? = nil, securityProfileArn: String? = nil, securityProfileDescription: String? = nil, securityProfileName: String? = nil, version: Int64? = nil) {
+            self.additionalMetricsToRetain = nil
+            self.additionalMetricsToRetainV2 = additionalMetricsToRetainV2
+            self.alertTargets = alertTargets
+            self.behaviors = behaviors
+            self.creationDate = creationDate
+            self.lastModifiedDate = lastModifiedDate
+            self.securityProfileArn = securityProfileArn
+            self.securityProfileDescription = securityProfileDescription
+            self.securityProfileName = securityProfileName
+            self.version = version
+        }
+
+        @available(*, deprecated, message: "Members additionalMetricsToRetain have been deprecated")
         public init(additionalMetricsToRetain: [String]? = nil, additionalMetricsToRetainV2: [MetricToRetain]? = nil, alertTargets: [AlertTargetType: AlertTarget]? = nil, behaviors: [Behavior]? = nil, creationDate: Date? = nil, lastModifiedDate: Date? = nil, securityProfileArn: String? = nil, securityProfileDescription: String? = nil, securityProfileName: String? = nil, version: Int64? = nil) {
             self.additionalMetricsToRetain = additionalMetricsToRetain
             self.additionalMetricsToRetainV2 = additionalMetricsToRetainV2

--- a/Sources/Soto/Services/IoTEvents/IoTEvents_Shapes.swift
+++ b/Sources/Soto/Services/IoTEvents/IoTEvents_Shapes.swift
@@ -2316,6 +2316,13 @@ extension IoTEvents {
         /// The name of the timer.
         public let timerName: String
 
+        public init(durationExpression: String? = nil, timerName: String) {
+            self.durationExpression = durationExpression
+            self.seconds = nil
+            self.timerName = timerName
+        }
+
+        @available(*, deprecated, message: "Members seconds have been deprecated")
         public init(durationExpression: String? = nil, seconds: Int? = nil, timerName: String) {
             self.durationExpression = durationExpression
             self.seconds = seconds

--- a/Sources/Soto/Services/KMS/KMS_Shapes.swift
+++ b/Sources/Soto/Services/KMS/KMS_Shapes.swift
@@ -439,6 +439,20 @@ extension KMS {
         /// Assigns one or more tags to the KMS key. Use this parameter to tag the KMS key when it is created. To tag an existing KMS key, use the TagResource operation.  Tagging or untagging a KMS key can allow or deny permission to the KMS key. For details, see Using ABAC in KMS in the Key Management Service Developer Guide.  To use this parameter, you must have kms:TagResource permission in an IAM policy. Each tag consists of a tag key and a tag value. Both the tag key and the tag value are required, but the tag value can be an empty (null) string. You cannot have more than one tag on a KMS key with the same tag key. If you specify an existing tag key with a different tag value, KMS replaces the current tag value with the specified one.  When you add tags to an Amazon Web Services resource, Amazon Web Services generates a cost allocation report with usage and costs aggregated by tags. Tags can also be used to control access to a KMS key. For details, see Tagging Keys.
         public let tags: [Tag]?
 
+        public init(bypassPolicyLockoutSafetyCheck: Bool? = nil, customKeyStoreId: String? = nil, description: String? = nil, keySpec: KeySpec? = nil, keyUsage: KeyUsageType? = nil, multiRegion: Bool? = nil, origin: OriginType? = nil, policy: String? = nil, tags: [Tag]? = nil) {
+            self.bypassPolicyLockoutSafetyCheck = bypassPolicyLockoutSafetyCheck
+            self.customerMasterKeySpec = nil
+            self.customKeyStoreId = customKeyStoreId
+            self.description = description
+            self.keySpec = keySpec
+            self.keyUsage = keyUsage
+            self.multiRegion = multiRegion
+            self.origin = origin
+            self.policy = policy
+            self.tags = tags
+        }
+
+        @available(*, deprecated, message: "Members customerMasterKeySpec have been deprecated")
         public init(bypassPolicyLockoutSafetyCheck: Bool? = nil, customerMasterKeySpec: CustomerMasterKeySpec? = nil, customKeyStoreId: String? = nil, description: String? = nil, keySpec: KeySpec? = nil, keyUsage: KeyUsageType? = nil, multiRegion: Bool? = nil, origin: OriginType? = nil, policy: String? = nil, tags: [Tag]? = nil) {
             self.bypassPolicyLockoutSafetyCheck = bypassPolicyLockoutSafetyCheck
             self.customerMasterKeySpec = customerMasterKeySpec
@@ -1349,6 +1363,17 @@ extension KMS {
         /// The signing algorithms that KMS supports for this key. This field appears in the response only when the KeyUsage of the public key is SIGN_VERIFY.
         public let signingAlgorithms: [SigningAlgorithmSpec]?
 
+        public init(encryptionAlgorithms: [EncryptionAlgorithmSpec]? = nil, keyId: String? = nil, keySpec: KeySpec? = nil, keyUsage: KeyUsageType? = nil, publicKey: Data? = nil, signingAlgorithms: [SigningAlgorithmSpec]? = nil) {
+            self.customerMasterKeySpec = nil
+            self.encryptionAlgorithms = encryptionAlgorithms
+            self.keyId = keyId
+            self.keySpec = keySpec
+            self.keyUsage = keyUsage
+            self.publicKey = publicKey
+            self.signingAlgorithms = signingAlgorithms
+        }
+
+        @available(*, deprecated, message: "Members customerMasterKeySpec have been deprecated")
         public init(customerMasterKeySpec: CustomerMasterKeySpec? = nil, encryptionAlgorithms: [EncryptionAlgorithmSpec]? = nil, keyId: String? = nil, keySpec: KeySpec? = nil, keyUsage: KeyUsageType? = nil, publicKey: Data? = nil, signingAlgorithms: [SigningAlgorithmSpec]? = nil) {
             self.customerMasterKeySpec = customerMasterKeySpec
             self.encryptionAlgorithms = encryptionAlgorithms
@@ -1537,6 +1562,32 @@ extension KMS {
         /// The time at which the imported key material expires. When the key material expires, KMS deletes the key material and the KMS key becomes unusable. This value is present only for KMS keys whose Origin is EXTERNAL and whose ExpirationModel is KEY_MATERIAL_EXPIRES, otherwise this value is omitted.
         public let validTo: Date?
 
+        public init(arn: String? = nil, aWSAccountId: String? = nil, cloudHsmClusterId: String? = nil, creationDate: Date? = nil, customKeyStoreId: String? = nil, deletionDate: Date? = nil, description: String? = nil, enabled: Bool? = nil, encryptionAlgorithms: [EncryptionAlgorithmSpec]? = nil, expirationModel: ExpirationModelType? = nil, keyId: String, keyManager: KeyManagerType? = nil, keySpec: KeySpec? = nil, keyState: KeyState? = nil, keyUsage: KeyUsageType? = nil, multiRegion: Bool? = nil, multiRegionConfiguration: MultiRegionConfiguration? = nil, origin: OriginType? = nil, pendingDeletionWindowInDays: Int? = nil, signingAlgorithms: [SigningAlgorithmSpec]? = nil, validTo: Date? = nil) {
+            self.arn = arn
+            self.aWSAccountId = aWSAccountId
+            self.cloudHsmClusterId = cloudHsmClusterId
+            self.creationDate = creationDate
+            self.customerMasterKeySpec = nil
+            self.customKeyStoreId = customKeyStoreId
+            self.deletionDate = deletionDate
+            self.description = description
+            self.enabled = enabled
+            self.encryptionAlgorithms = encryptionAlgorithms
+            self.expirationModel = expirationModel
+            self.keyId = keyId
+            self.keyManager = keyManager
+            self.keySpec = keySpec
+            self.keyState = keyState
+            self.keyUsage = keyUsage
+            self.multiRegion = multiRegion
+            self.multiRegionConfiguration = multiRegionConfiguration
+            self.origin = origin
+            self.pendingDeletionWindowInDays = pendingDeletionWindowInDays
+            self.signingAlgorithms = signingAlgorithms
+            self.validTo = validTo
+        }
+
+        @available(*, deprecated, message: "Members customerMasterKeySpec have been deprecated")
         public init(arn: String? = nil, aWSAccountId: String? = nil, cloudHsmClusterId: String? = nil, creationDate: Date? = nil, customerMasterKeySpec: CustomerMasterKeySpec? = nil, customKeyStoreId: String? = nil, deletionDate: Date? = nil, description: String? = nil, enabled: Bool? = nil, encryptionAlgorithms: [EncryptionAlgorithmSpec]? = nil, expirationModel: ExpirationModelType? = nil, keyId: String, keyManager: KeyManagerType? = nil, keySpec: KeySpec? = nil, keyState: KeyState? = nil, keyUsage: KeyUsageType? = nil, multiRegion: Bool? = nil, multiRegionConfiguration: MultiRegionConfiguration? = nil, origin: OriginType? = nil, pendingDeletionWindowInDays: Int? = nil, signingAlgorithms: [SigningAlgorithmSpec]? = nil, validTo: Date? = nil) {
             self.arn = arn
             self.aWSAccountId = aWSAccountId

--- a/Sources/Soto/Services/LexRuntimeService/LexRuntimeService_Shapes.swift
+++ b/Sources/Soto/Services/LexRuntimeService/LexRuntimeService_Shapes.swift
@@ -507,6 +507,28 @@ extension LexRuntimeService {
         ///  If the dialogState value is ElicitSlot, returns the name of the slot for which Amazon Lex is eliciting a value.
         public let slotToElicit: String?
 
+        public init(activeContexts: String? = nil, alternativeIntents: String? = nil, audioStream: AWSPayload? = nil, botVersion: String? = nil, contentType: String? = nil, dialogState: DialogState? = nil, encodedInputTranscript: String? = nil, encodedMessage: String? = nil, intentName: String? = nil, messageFormat: MessageFormatType? = nil, nluIntentConfidence: String? = nil, sentimentResponse: String? = nil, sessionAttributes: String? = nil, sessionId: String? = nil, slots: String? = nil, slotToElicit: String? = nil) {
+            self.activeContexts = activeContexts
+            self.alternativeIntents = alternativeIntents
+            self.audioStream = audioStream
+            self.botVersion = botVersion
+            self.contentType = contentType
+            self.dialogState = dialogState
+            self.encodedInputTranscript = encodedInputTranscript
+            self.encodedMessage = encodedMessage
+            self.inputTranscript = nil
+            self.intentName = intentName
+            self.message = nil
+            self.messageFormat = messageFormat
+            self.nluIntentConfidence = nluIntentConfidence
+            self.sentimentResponse = sentimentResponse
+            self.sessionAttributes = sessionAttributes
+            self.sessionId = sessionId
+            self.slots = slots
+            self.slotToElicit = slotToElicit
+        }
+
+        @available(*, deprecated, message: "Members inputTranscript, message have been deprecated")
         public init(activeContexts: String? = nil, alternativeIntents: String? = nil, audioStream: AWSPayload? = nil, botVersion: String? = nil, contentType: String? = nil, dialogState: DialogState? = nil, encodedInputTranscript: String? = nil, encodedMessage: String? = nil, inputTranscript: String? = nil, intentName: String? = nil, message: String? = nil, messageFormat: MessageFormatType? = nil, nluIntentConfidence: String? = nil, sentimentResponse: String? = nil, sessionAttributes: String? = nil, sessionId: String? = nil, slots: String? = nil, slotToElicit: String? = nil) {
             self.activeContexts = activeContexts
             self.alternativeIntents = alternativeIntents
@@ -791,6 +813,22 @@ extension LexRuntimeService {
         /// If the dialogState is ElicitSlot, returns the name of the slot for which Amazon Lex is eliciting a value.
         public let slotToElicit: String?
 
+        public init(activeContexts: String? = nil, audioStream: AWSPayload? = nil, contentType: String? = nil, dialogState: DialogState? = nil, encodedMessage: String? = nil, intentName: String? = nil, messageFormat: MessageFormatType? = nil, sessionAttributes: String? = nil, sessionId: String? = nil, slots: String? = nil, slotToElicit: String? = nil) {
+            self.activeContexts = activeContexts
+            self.audioStream = audioStream
+            self.contentType = contentType
+            self.dialogState = dialogState
+            self.encodedMessage = encodedMessage
+            self.intentName = intentName
+            self.message = nil
+            self.messageFormat = messageFormat
+            self.sessionAttributes = sessionAttributes
+            self.sessionId = sessionId
+            self.slots = slots
+            self.slotToElicit = slotToElicit
+        }
+
+        @available(*, deprecated, message: "Members message have been deprecated")
         public init(activeContexts: String? = nil, audioStream: AWSPayload? = nil, contentType: String? = nil, dialogState: DialogState? = nil, encodedMessage: String? = nil, intentName: String? = nil, message: String? = nil, messageFormat: MessageFormatType? = nil, sessionAttributes: String? = nil, sessionId: String? = nil, slots: String? = nil, slotToElicit: String? = nil) {
             self.activeContexts = activeContexts
             self.audioStream = audioStream

--- a/Sources/Soto/Services/Lightsail/Lightsail_Shapes.swift
+++ b/Sources/Soto/Services/Lightsail/Lightsail_Shapes.swift
@@ -2975,6 +2975,20 @@ extension Lightsail {
         /// A launch script you can create that configures a server with additional user data. For example, you might want to run apt-get -y update.  Depending on the machine image you choose, the command to get software on your instance varies. Amazon Linux and CentOS use yum, Debian and Ubuntu use apt-get, and FreeBSD uses pkg. For a complete list, see the Amazon Lightsail Developer Guide.
         public let userData: String?
 
+        public init(addOns: [AddOnRequest]? = nil, availabilityZone: String, blueprintId: String, bundleId: String, instanceNames: [String], ipAddressType: IpAddressType? = nil, keyPairName: String? = nil, tags: [Tag]? = nil, userData: String? = nil) {
+            self.addOns = addOns
+            self.availabilityZone = availabilityZone
+            self.blueprintId = blueprintId
+            self.bundleId = bundleId
+            self.customImageName = nil
+            self.instanceNames = instanceNames
+            self.ipAddressType = ipAddressType
+            self.keyPairName = keyPairName
+            self.tags = tags
+            self.userData = userData
+        }
+
+        @available(*, deprecated, message: "Members customImageName have been deprecated")
         public init(addOns: [AddOnRequest]? = nil, availabilityZone: String, blueprintId: String, bundleId: String, customImageName: String? = nil, instanceNames: [String], ipAddressType: IpAddressType? = nil, keyPairName: String? = nil, tags: [Tag]? = nil, userData: String? = nil) {
             self.addOns = addOns
             self.availabilityZone = availabilityZone
@@ -4234,6 +4248,27 @@ extension Lightsail {
         /// The tag keys and optional values for the resource. For more information about tags in Lightsail, see the Amazon Lightsail Developer Guide.
         public let tags: [Tag]?
 
+        public init(addOns: [AddOn]? = nil, arn: String? = nil, attachedTo: String? = nil, createdAt: Date? = nil, iops: Int? = nil, isAttached: Bool? = nil, isSystemDisk: Bool? = nil, location: ResourceLocation? = nil, name: String? = nil, path: String? = nil, resourceType: ResourceType? = nil, sizeInGb: Int? = nil, state: DiskState? = nil, supportCode: String? = nil, tags: [Tag]? = nil) {
+            self.addOns = addOns
+            self.arn = arn
+            self.attachedTo = attachedTo
+            self.attachmentState = nil
+            self.createdAt = createdAt
+            self.gbInUse = nil
+            self.iops = iops
+            self.isAttached = isAttached
+            self.isSystemDisk = isSystemDisk
+            self.location = location
+            self.name = name
+            self.path = path
+            self.resourceType = resourceType
+            self.sizeInGb = sizeInGb
+            self.state = state
+            self.supportCode = supportCode
+            self.tags = tags
+        }
+
+        @available(*, deprecated, message: "Members attachmentState, gbInUse have been deprecated")
         public init(addOns: [AddOn]? = nil, arn: String? = nil, attachedTo: String? = nil, attachmentState: String? = nil, createdAt: Date? = nil, gbInUse: Int? = nil, iops: Int? = nil, isAttached: Bool? = nil, isSystemDisk: Bool? = nil, location: ResourceLocation? = nil, name: String? = nil, path: String? = nil, resourceType: ResourceType? = nil, sizeInGb: Int? = nil, state: DiskState? = nil, supportCode: String? = nil, tags: [Tag]? = nil) {
             self.addOns = addOns
             self.arn = arn
@@ -4488,6 +4523,16 @@ extension Lightsail {
         /// The type of domain entry, such as address for IPv4 (A), address for IPv6 (AAAA), canonical name (CNAME), mail exchanger (MX), name server (NS), start of authority (SOA), service locator (SRV), or text (TXT). The following domain entry types can be used:    A     AAAA     CNAME     MX     NS     SOA     SRV     TXT
         public let type: String?
 
+        public init(id: String? = nil, isAlias: Bool? = nil, name: String? = nil, target: String? = nil, type: String? = nil) {
+            self.id = id
+            self.isAlias = isAlias
+            self.name = name
+            self.options = nil
+            self.target = target
+            self.type = type
+        }
+
+        @available(*, deprecated, message: "Members options have been deprecated")
         public init(id: String? = nil, isAlias: Bool? = nil, name: String? = nil, options: [String: String]? = nil, target: String? = nil, type: String? = nil) {
             self.id = id
             self.isAlias = isAlias
@@ -6316,6 +6361,13 @@ extension Lightsail {
         /// An array of objects that describe the result of the action, such as the status of the request, the timestamp of the request, and the resources affected by the request.
         public let operations: [Operation]?
 
+        public init(nextPageToken: String? = nil, operations: [Operation]? = nil) {
+            self.nextPageCount = nil
+            self.nextPageToken = nextPageToken
+            self.operations = operations
+        }
+
+        @available(*, deprecated, message: "Members nextPageCount have been deprecated")
         public init(nextPageCount: String? = nil, nextPageToken: String? = nil, operations: [Operation]? = nil) {
             self.nextPageCount = nextPageCount
             self.nextPageToken = nextPageToken

--- a/Sources/Soto/Services/MTurk/MTurk_Shapes.swift
+++ b/Sources/Soto/Services/MTurk/MTurk_Shapes.swift
@@ -1832,6 +1832,16 @@ extension MTurk {
         ///  DEPRECATED: Use the ActionsGuarded field instead. If RequiredToPreview is true, the question data for the HIT will not be shown when a Worker whose Qualifications do not meet this requirement tries to preview the HIT. That is, a Worker's Qualifications must meet all of the requirements for which RequiredToPreview is true in order to preview the HIT. If a Worker meets all of the requirements where RequiredToPreview is true (or if there are no such requirements), but does not meet all of the requirements for the HIT, the Worker will be allowed to preview the HIT's question data, but will not be allowed to accept and complete the HIT. The default is false. This should not be used in combination with the ActionsGuarded field.
         public let requiredToPreview: Bool?
 
+        public init(actionsGuarded: HITAccessActions? = nil, comparator: Comparator, integerValues: [Int]? = nil, localeValues: [Locale]? = nil, qualificationTypeId: String) {
+            self.actionsGuarded = actionsGuarded
+            self.comparator = comparator
+            self.integerValues = integerValues
+            self.localeValues = localeValues
+            self.qualificationTypeId = qualificationTypeId
+            self.requiredToPreview = nil
+        }
+
+        @available(*, deprecated, message: "Members requiredToPreview have been deprecated")
         public init(actionsGuarded: HITAccessActions? = nil, comparator: Comparator, integerValues: [Int]? = nil, localeValues: [Locale]? = nil, qualificationTypeId: String, requiredToPreview: Bool? = nil) {
             self.actionsGuarded = actionsGuarded
             self.comparator = comparator

--- a/Sources/Soto/Services/MediaLive/MediaLive_Shapes.swift
+++ b/Sources/Soto/Services/MediaLive/MediaLive_Shapes.swift
@@ -3251,6 +3251,23 @@ extension MediaLive {
         /// Settings for the VPC outputs
         public let vpc: VpcOutputSettings?
 
+        public init(cdiInputSpecification: CdiInputSpecification? = nil, channelClass: ChannelClass? = nil, destinations: [OutputDestination]? = nil, encoderSettings: EncoderSettings? = nil, inputAttachments: [InputAttachment]? = nil, inputSpecification: InputSpecification? = nil, logLevel: LogLevel? = nil, name: String? = nil, requestId: String? = CreateChannelRequest.idempotencyToken(), roleArn: String? = nil, tags: [String: String]? = nil, vpc: VpcOutputSettings? = nil) {
+            self.cdiInputSpecification = cdiInputSpecification
+            self.channelClass = channelClass
+            self.destinations = destinations
+            self.encoderSettings = encoderSettings
+            self.inputAttachments = inputAttachments
+            self.inputSpecification = inputSpecification
+            self.logLevel = logLevel
+            self.name = name
+            self.requestId = requestId
+            self.reserved = nil
+            self.roleArn = roleArn
+            self.tags = tags
+            self.vpc = vpc
+        }
+
+        @available(*, deprecated, message: "Members reserved have been deprecated")
         public init(cdiInputSpecification: CdiInputSpecification? = nil, channelClass: ChannelClass? = nil, destinations: [OutputDestination]? = nil, encoderSettings: EncoderSettings? = nil, inputAttachments: [InputAttachment]? = nil, inputSpecification: InputSpecification? = nil, logLevel: LogLevel? = nil, name: String? = nil, requestId: String? = CreateChannelRequest.idempotencyToken(), reserved: String? = nil, roleArn: String? = nil, tags: [String: String]? = nil, vpc: VpcOutputSettings? = nil) {
             self.cdiInputSpecification = cdiInputSpecification
             self.channelClass = channelClass

--- a/Sources/Soto/Services/Neptune/Neptune_Shapes.swift
+++ b/Sources/Soto/Services/Neptune/Neptune_Shapes.swift
@@ -716,6 +716,53 @@ extension Neptune {
         @OptionalCustomCoding<ArrayCoder<_VpcSecurityGroupIdsEncoding, String>>
         public var vpcSecurityGroupIds: [String]?
 
+        public init(allocatedStorage: Int? = nil, autoMinorVersionUpgrade: Bool? = nil, availabilityZone: String? = nil, backupRetentionPeriod: Int? = nil, characterSetName: String? = nil, copyTagsToSnapshot: Bool? = nil, dBClusterIdentifier: String? = nil, dBInstanceClass: String, dBInstanceIdentifier: String, dBName: String? = nil, dBParameterGroupName: String? = nil, dBSecurityGroups: [String]? = nil, dBSubnetGroupName: String? = nil, deletionProtection: Bool? = nil, domain: String? = nil, domainIAMRoleName: String? = nil, enableCloudwatchLogsExports: [String]? = nil, enableIAMDatabaseAuthentication: Bool? = nil, enablePerformanceInsights: Bool? = nil, engine: String, engineVersion: String? = nil, iops: Int? = nil, kmsKeyId: String? = nil, licenseModel: String? = nil, masterUsername: String? = nil, masterUserPassword: String? = nil, monitoringInterval: Int? = nil, monitoringRoleArn: String? = nil, multiAZ: Bool? = nil, optionGroupName: String? = nil, performanceInsightsKMSKeyId: String? = nil, port: Int? = nil, preferredBackupWindow: String? = nil, preferredMaintenanceWindow: String? = nil, promotionTier: Int? = nil, storageEncrypted: Bool? = nil, storageType: String? = nil, tags: [Tag]? = nil, tdeCredentialArn: String? = nil, tdeCredentialPassword: String? = nil, timezone: String? = nil, vpcSecurityGroupIds: [String]? = nil) {
+            self.allocatedStorage = allocatedStorage
+            self.autoMinorVersionUpgrade = autoMinorVersionUpgrade
+            self.availabilityZone = availabilityZone
+            self.backupRetentionPeriod = backupRetentionPeriod
+            self.characterSetName = characterSetName
+            self.copyTagsToSnapshot = copyTagsToSnapshot
+            self.dBClusterIdentifier = dBClusterIdentifier
+            self.dBInstanceClass = dBInstanceClass
+            self.dBInstanceIdentifier = dBInstanceIdentifier
+            self.dBName = dBName
+            self.dBParameterGroupName = dBParameterGroupName
+            self.dBSecurityGroups = dBSecurityGroups
+            self.dBSubnetGroupName = dBSubnetGroupName
+            self.deletionProtection = deletionProtection
+            self.domain = domain
+            self.domainIAMRoleName = domainIAMRoleName
+            self.enableCloudwatchLogsExports = enableCloudwatchLogsExports
+            self.enableIAMDatabaseAuthentication = enableIAMDatabaseAuthentication
+            self.enablePerformanceInsights = enablePerformanceInsights
+            self.engine = engine
+            self.engineVersion = engineVersion
+            self.iops = iops
+            self.kmsKeyId = kmsKeyId
+            self.licenseModel = licenseModel
+            self.masterUsername = masterUsername
+            self.masterUserPassword = masterUserPassword
+            self.monitoringInterval = monitoringInterval
+            self.monitoringRoleArn = monitoringRoleArn
+            self.multiAZ = multiAZ
+            self.optionGroupName = optionGroupName
+            self.performanceInsightsKMSKeyId = performanceInsightsKMSKeyId
+            self.port = port
+            self.preferredBackupWindow = preferredBackupWindow
+            self.preferredMaintenanceWindow = preferredMaintenanceWindow
+            self.promotionTier = promotionTier
+            self.publiclyAccessible = nil
+            self.storageEncrypted = storageEncrypted
+            self.storageType = storageType
+            self.tags = tags
+            self.tdeCredentialArn = tdeCredentialArn
+            self.tdeCredentialPassword = tdeCredentialPassword
+            self.timezone = timezone
+            self.vpcSecurityGroupIds = vpcSecurityGroupIds
+        }
+
+        @available(*, deprecated, message: "Members publiclyAccessible have been deprecated")
         public init(allocatedStorage: Int? = nil, autoMinorVersionUpgrade: Bool? = nil, availabilityZone: String? = nil, backupRetentionPeriod: Int? = nil, characterSetName: String? = nil, copyTagsToSnapshot: Bool? = nil, dBClusterIdentifier: String? = nil, dBInstanceClass: String, dBInstanceIdentifier: String, dBName: String? = nil, dBParameterGroupName: String? = nil, dBSecurityGroups: [String]? = nil, dBSubnetGroupName: String? = nil, deletionProtection: Bool? = nil, domain: String? = nil, domainIAMRoleName: String? = nil, enableCloudwatchLogsExports: [String]? = nil, enableIAMDatabaseAuthentication: Bool? = nil, enablePerformanceInsights: Bool? = nil, engine: String, engineVersion: String? = nil, iops: Int? = nil, kmsKeyId: String? = nil, licenseModel: String? = nil, masterUsername: String? = nil, masterUserPassword: String? = nil, monitoringInterval: Int? = nil, monitoringRoleArn: String? = nil, multiAZ: Bool? = nil, optionGroupName: String? = nil, performanceInsightsKMSKeyId: String? = nil, port: Int? = nil, preferredBackupWindow: String? = nil, preferredMaintenanceWindow: String? = nil, promotionTier: Int? = nil, publiclyAccessible: Bool? = nil, storageEncrypted: Bool? = nil, storageType: String? = nil, tags: [Tag]? = nil, tdeCredentialArn: String? = nil, tdeCredentialPassword: String? = nil, timezone: String? = nil, vpcSecurityGroupIds: [String]? = nil) {
             self.allocatedStorage = allocatedStorage
             self.autoMinorVersionUpgrade = autoMinorVersionUpgrade
@@ -1739,6 +1786,63 @@ extension Neptune {
         @OptionalCustomCoding<ArrayCoder<_VpcSecurityGroupsEncoding, VpcSecurityGroupMembership>>
         public var vpcSecurityGroups: [VpcSecurityGroupMembership]?
 
+        public init(allocatedStorage: Int? = nil, autoMinorVersionUpgrade: Bool? = nil, availabilityZone: String? = nil, backupRetentionPeriod: Int? = nil, cACertificateIdentifier: String? = nil, characterSetName: String? = nil, copyTagsToSnapshot: Bool? = nil, dBClusterIdentifier: String? = nil, dBInstanceArn: String? = nil, dBInstanceClass: String? = nil, dBInstanceIdentifier: String? = nil, dbInstancePort: Int? = nil, dBInstanceStatus: String? = nil, dbiResourceId: String? = nil, dBName: String? = nil, dBParameterGroups: [DBParameterGroupStatus]? = nil, dBSecurityGroups: [DBSecurityGroupMembership]? = nil, dBSubnetGroup: DBSubnetGroup? = nil, deletionProtection: Bool? = nil, domainMemberships: [DomainMembership]? = nil, enabledCloudwatchLogsExports: [String]? = nil, endpoint: Endpoint? = nil, engine: String? = nil, engineVersion: String? = nil, enhancedMonitoringResourceArn: String? = nil, iAMDatabaseAuthenticationEnabled: Bool? = nil, instanceCreateTime: Date? = nil, iops: Int? = nil, kmsKeyId: String? = nil, latestRestorableTime: Date? = nil, licenseModel: String? = nil, masterUsername: String? = nil, monitoringInterval: Int? = nil, monitoringRoleArn: String? = nil, multiAZ: Bool? = nil, optionGroupMemberships: [OptionGroupMembership]? = nil, pendingModifiedValues: PendingModifiedValues? = nil, performanceInsightsEnabled: Bool? = nil, performanceInsightsKMSKeyId: String? = nil, preferredBackupWindow: String? = nil, preferredMaintenanceWindow: String? = nil, promotionTier: Int? = nil, readReplicaDBClusterIdentifiers: [String]? = nil, readReplicaDBInstanceIdentifiers: [String]? = nil, readReplicaSourceDBInstanceIdentifier: String? = nil, secondaryAvailabilityZone: String? = nil, statusInfos: [DBInstanceStatusInfo]? = nil, storageEncrypted: Bool? = nil, storageType: String? = nil, tdeCredentialArn: String? = nil, timezone: String? = nil, vpcSecurityGroups: [VpcSecurityGroupMembership]? = nil) {
+            self.allocatedStorage = allocatedStorage
+            self.autoMinorVersionUpgrade = autoMinorVersionUpgrade
+            self.availabilityZone = availabilityZone
+            self.backupRetentionPeriod = backupRetentionPeriod
+            self.cACertificateIdentifier = cACertificateIdentifier
+            self.characterSetName = characterSetName
+            self.copyTagsToSnapshot = copyTagsToSnapshot
+            self.dBClusterIdentifier = dBClusterIdentifier
+            self.dBInstanceArn = dBInstanceArn
+            self.dBInstanceClass = dBInstanceClass
+            self.dBInstanceIdentifier = dBInstanceIdentifier
+            self.dbInstancePort = dbInstancePort
+            self.dBInstanceStatus = dBInstanceStatus
+            self.dbiResourceId = dbiResourceId
+            self.dBName = dBName
+            self.dBParameterGroups = dBParameterGroups
+            self.dBSecurityGroups = dBSecurityGroups
+            self.dBSubnetGroup = dBSubnetGroup
+            self.deletionProtection = deletionProtection
+            self.domainMemberships = domainMemberships
+            self.enabledCloudwatchLogsExports = enabledCloudwatchLogsExports
+            self.endpoint = endpoint
+            self.engine = engine
+            self.engineVersion = engineVersion
+            self.enhancedMonitoringResourceArn = enhancedMonitoringResourceArn
+            self.iAMDatabaseAuthenticationEnabled = iAMDatabaseAuthenticationEnabled
+            self.instanceCreateTime = instanceCreateTime
+            self.iops = iops
+            self.kmsKeyId = kmsKeyId
+            self.latestRestorableTime = latestRestorableTime
+            self.licenseModel = licenseModel
+            self.masterUsername = masterUsername
+            self.monitoringInterval = monitoringInterval
+            self.monitoringRoleArn = monitoringRoleArn
+            self.multiAZ = multiAZ
+            self.optionGroupMemberships = optionGroupMemberships
+            self.pendingModifiedValues = pendingModifiedValues
+            self.performanceInsightsEnabled = performanceInsightsEnabled
+            self.performanceInsightsKMSKeyId = performanceInsightsKMSKeyId
+            self.preferredBackupWindow = preferredBackupWindow
+            self.preferredMaintenanceWindow = preferredMaintenanceWindow
+            self.promotionTier = promotionTier
+            self.publiclyAccessible = nil
+            self.readReplicaDBClusterIdentifiers = readReplicaDBClusterIdentifiers
+            self.readReplicaDBInstanceIdentifiers = readReplicaDBInstanceIdentifiers
+            self.readReplicaSourceDBInstanceIdentifier = readReplicaSourceDBInstanceIdentifier
+            self.secondaryAvailabilityZone = secondaryAvailabilityZone
+            self.statusInfos = statusInfos
+            self.storageEncrypted = storageEncrypted
+            self.storageType = storageType
+            self.tdeCredentialArn = tdeCredentialArn
+            self.timezone = timezone
+            self.vpcSecurityGroups = vpcSecurityGroups
+        }
+
+        @available(*, deprecated, message: "Members publiclyAccessible have been deprecated")
         public init(allocatedStorage: Int? = nil, autoMinorVersionUpgrade: Bool? = nil, availabilityZone: String? = nil, backupRetentionPeriod: Int? = nil, cACertificateIdentifier: String? = nil, characterSetName: String? = nil, copyTagsToSnapshot: Bool? = nil, dBClusterIdentifier: String? = nil, dBInstanceArn: String? = nil, dBInstanceClass: String? = nil, dBInstanceIdentifier: String? = nil, dbInstancePort: Int? = nil, dBInstanceStatus: String? = nil, dbiResourceId: String? = nil, dBName: String? = nil, dBParameterGroups: [DBParameterGroupStatus]? = nil, dBSecurityGroups: [DBSecurityGroupMembership]? = nil, dBSubnetGroup: DBSubnetGroup? = nil, deletionProtection: Bool? = nil, domainMemberships: [DomainMembership]? = nil, enabledCloudwatchLogsExports: [String]? = nil, endpoint: Endpoint? = nil, engine: String? = nil, engineVersion: String? = nil, enhancedMonitoringResourceArn: String? = nil, iAMDatabaseAuthenticationEnabled: Bool? = nil, instanceCreateTime: Date? = nil, iops: Int? = nil, kmsKeyId: String? = nil, latestRestorableTime: Date? = nil, licenseModel: String? = nil, masterUsername: String? = nil, monitoringInterval: Int? = nil, monitoringRoleArn: String? = nil, multiAZ: Bool? = nil, optionGroupMemberships: [OptionGroupMembership]? = nil, pendingModifiedValues: PendingModifiedValues? = nil, performanceInsightsEnabled: Bool? = nil, performanceInsightsKMSKeyId: String? = nil, preferredBackupWindow: String? = nil, preferredMaintenanceWindow: String? = nil, promotionTier: Int? = nil, publiclyAccessible: Bool? = nil, readReplicaDBClusterIdentifiers: [String]? = nil, readReplicaDBInstanceIdentifiers: [String]? = nil, readReplicaSourceDBInstanceIdentifier: String? = nil, secondaryAvailabilityZone: String? = nil, statusInfos: [DBInstanceStatusInfo]? = nil, storageEncrypted: Bool? = nil, storageType: String? = nil, tdeCredentialArn: String? = nil, timezone: String? = nil, vpcSecurityGroups: [VpcSecurityGroupMembership]? = nil) {
             self.allocatedStorage = allocatedStorage
             self.autoMinorVersionUpgrade = autoMinorVersionUpgrade
@@ -3553,6 +3657,47 @@ extension Neptune {
         @OptionalCustomCoding<ArrayCoder<_VpcSecurityGroupIdsEncoding, String>>
         public var vpcSecurityGroupIds: [String]?
 
+        public init(allocatedStorage: Int? = nil, allowMajorVersionUpgrade: Bool? = nil, applyImmediately: Bool? = nil, autoMinorVersionUpgrade: Bool? = nil, backupRetentionPeriod: Int? = nil, cACertificateIdentifier: String? = nil, cloudwatchLogsExportConfiguration: CloudwatchLogsExportConfiguration? = nil, copyTagsToSnapshot: Bool? = nil, dBInstanceClass: String? = nil, dBInstanceIdentifier: String, dBParameterGroupName: String? = nil, dBPortNumber: Int? = nil, dBSecurityGroups: [String]? = nil, dBSubnetGroupName: String? = nil, deletionProtection: Bool? = nil, domain: String? = nil, domainIAMRoleName: String? = nil, enableIAMDatabaseAuthentication: Bool? = nil, enablePerformanceInsights: Bool? = nil, engineVersion: String? = nil, iops: Int? = nil, licenseModel: String? = nil, masterUserPassword: String? = nil, monitoringInterval: Int? = nil, monitoringRoleArn: String? = nil, multiAZ: Bool? = nil, newDBInstanceIdentifier: String? = nil, optionGroupName: String? = nil, performanceInsightsKMSKeyId: String? = nil, preferredBackupWindow: String? = nil, preferredMaintenanceWindow: String? = nil, promotionTier: Int? = nil, storageType: String? = nil, tdeCredentialArn: String? = nil, tdeCredentialPassword: String? = nil, vpcSecurityGroupIds: [String]? = nil) {
+            self.allocatedStorage = allocatedStorage
+            self.allowMajorVersionUpgrade = allowMajorVersionUpgrade
+            self.applyImmediately = applyImmediately
+            self.autoMinorVersionUpgrade = autoMinorVersionUpgrade
+            self.backupRetentionPeriod = backupRetentionPeriod
+            self.cACertificateIdentifier = cACertificateIdentifier
+            self.cloudwatchLogsExportConfiguration = cloudwatchLogsExportConfiguration
+            self.copyTagsToSnapshot = copyTagsToSnapshot
+            self.dBInstanceClass = dBInstanceClass
+            self.dBInstanceIdentifier = dBInstanceIdentifier
+            self.dBParameterGroupName = dBParameterGroupName
+            self.dBPortNumber = dBPortNumber
+            self.dBSecurityGroups = dBSecurityGroups
+            self.dBSubnetGroupName = dBSubnetGroupName
+            self.deletionProtection = deletionProtection
+            self.domain = domain
+            self.domainIAMRoleName = domainIAMRoleName
+            self.enableIAMDatabaseAuthentication = enableIAMDatabaseAuthentication
+            self.enablePerformanceInsights = enablePerformanceInsights
+            self.engineVersion = engineVersion
+            self.iops = iops
+            self.licenseModel = licenseModel
+            self.masterUserPassword = masterUserPassword
+            self.monitoringInterval = monitoringInterval
+            self.monitoringRoleArn = monitoringRoleArn
+            self.multiAZ = multiAZ
+            self.newDBInstanceIdentifier = newDBInstanceIdentifier
+            self.optionGroupName = optionGroupName
+            self.performanceInsightsKMSKeyId = performanceInsightsKMSKeyId
+            self.preferredBackupWindow = preferredBackupWindow
+            self.preferredMaintenanceWindow = preferredMaintenanceWindow
+            self.promotionTier = promotionTier
+            self.publiclyAccessible = nil
+            self.storageType = storageType
+            self.tdeCredentialArn = tdeCredentialArn
+            self.tdeCredentialPassword = tdeCredentialPassword
+            self.vpcSecurityGroupIds = vpcSecurityGroupIds
+        }
+
+        @available(*, deprecated, message: "Members publiclyAccessible have been deprecated")
         public init(allocatedStorage: Int? = nil, allowMajorVersionUpgrade: Bool? = nil, applyImmediately: Bool? = nil, autoMinorVersionUpgrade: Bool? = nil, backupRetentionPeriod: Int? = nil, cACertificateIdentifier: String? = nil, cloudwatchLogsExportConfiguration: CloudwatchLogsExportConfiguration? = nil, copyTagsToSnapshot: Bool? = nil, dBInstanceClass: String? = nil, dBInstanceIdentifier: String, dBParameterGroupName: String? = nil, dBPortNumber: Int? = nil, dBSecurityGroups: [String]? = nil, dBSubnetGroupName: String? = nil, deletionProtection: Bool? = nil, domain: String? = nil, domainIAMRoleName: String? = nil, enableIAMDatabaseAuthentication: Bool? = nil, enablePerformanceInsights: Bool? = nil, engineVersion: String? = nil, iops: Int? = nil, licenseModel: String? = nil, masterUserPassword: String? = nil, monitoringInterval: Int? = nil, monitoringRoleArn: String? = nil, multiAZ: Bool? = nil, newDBInstanceIdentifier: String? = nil, optionGroupName: String? = nil, performanceInsightsKMSKeyId: String? = nil, preferredBackupWindow: String? = nil, preferredMaintenanceWindow: String? = nil, promotionTier: Int? = nil, publiclyAccessible: Bool? = nil, storageType: String? = nil, tdeCredentialArn: String? = nil, tdeCredentialPassword: String? = nil, vpcSecurityGroupIds: [String]? = nil) {
             self.allocatedStorage = allocatedStorage
             self.allowMajorVersionUpgrade = allowMajorVersionUpgrade

--- a/Sources/Soto/Services/OpsWorksCM/OpsWorksCM_Shapes.swift
+++ b/Sources/Soto/Services/OpsWorksCM/OpsWorksCM_Shapes.swift
@@ -183,6 +183,34 @@ extension OpsWorksCM {
         ///  The IAM user ARN of the requester for manual backups. This field is empty for automated backups.
         public let userArn: String?
 
+        public init(backupArn: String? = nil, backupId: String? = nil, backupType: BackupType? = nil, createdAt: Date? = nil, description: String? = nil, engine: String? = nil, engineModel: String? = nil, engineVersion: String? = nil, instanceProfileArn: String? = nil, instanceType: String? = nil, keyPair: String? = nil, preferredBackupWindow: String? = nil, preferredMaintenanceWindow: String? = nil, s3LogUrl: String? = nil, securityGroupIds: [String]? = nil, serverName: String? = nil, serviceRoleArn: String? = nil, status: BackupStatus? = nil, statusDescription: String? = nil, subnetIds: [String]? = nil, toolsVersion: String? = nil, userArn: String? = nil) {
+            self.backupArn = backupArn
+            self.backupId = backupId
+            self.backupType = backupType
+            self.createdAt = createdAt
+            self.description = description
+            self.engine = engine
+            self.engineModel = engineModel
+            self.engineVersion = engineVersion
+            self.instanceProfileArn = instanceProfileArn
+            self.instanceType = instanceType
+            self.keyPair = keyPair
+            self.preferredBackupWindow = preferredBackupWindow
+            self.preferredMaintenanceWindow = preferredMaintenanceWindow
+            self.s3DataSize = nil
+            self.s3DataUrl = nil
+            self.s3LogUrl = s3LogUrl
+            self.securityGroupIds = securityGroupIds
+            self.serverName = serverName
+            self.serviceRoleArn = serviceRoleArn
+            self.status = status
+            self.statusDescription = statusDescription
+            self.subnetIds = subnetIds
+            self.toolsVersion = toolsVersion
+            self.userArn = userArn
+        }
+
+        @available(*, deprecated, message: "Members s3DataSize, s3DataUrl have been deprecated")
         public init(backupArn: String? = nil, backupId: String? = nil, backupType: BackupType? = nil, createdAt: Date? = nil, description: String? = nil, engine: String? = nil, engineModel: String? = nil, engineVersion: String? = nil, instanceProfileArn: String? = nil, instanceType: String? = nil, keyPair: String? = nil, preferredBackupWindow: String? = nil, preferredMaintenanceWindow: String? = nil, s3DataSize: Int? = nil, s3DataUrl: String? = nil, s3LogUrl: String? = nil, securityGroupIds: [String]? = nil, serverName: String? = nil, serviceRoleArn: String? = nil, status: BackupStatus? = nil, statusDescription: String? = nil, subnetIds: [String]? = nil, toolsVersion: String? = nil, userArn: String? = nil) {
             self.backupArn = backupArn
             self.backupId = backupId

--- a/Sources/Soto/Services/RAM/RAM_Shapes.swift
+++ b/Sources/Soto/Services/RAM/RAM_Shapes.swift
@@ -1164,6 +1164,19 @@ extension RAM {
         /// The status of the invitation.
         public let status: ResourceShareInvitationStatus?
 
+        public init(invitationTimestamp: Date? = nil, receiverAccountId: String? = nil, receiverArn: String? = nil, resourceShareArn: String? = nil, resourceShareInvitationArn: String? = nil, resourceShareName: String? = nil, senderAccountId: String? = nil, status: ResourceShareInvitationStatus? = nil) {
+            self.invitationTimestamp = invitationTimestamp
+            self.receiverAccountId = receiverAccountId
+            self.receiverArn = receiverArn
+            self.resourceShareArn = resourceShareArn
+            self.resourceShareAssociations = nil
+            self.resourceShareInvitationArn = resourceShareInvitationArn
+            self.resourceShareName = resourceShareName
+            self.senderAccountId = senderAccountId
+            self.status = status
+        }
+
+        @available(*, deprecated, message: "Members resourceShareAssociations have been deprecated")
         public init(invitationTimestamp: Date? = nil, receiverAccountId: String? = nil, receiverArn: String? = nil, resourceShareArn: String? = nil, resourceShareAssociations: [ResourceShareAssociation]? = nil, resourceShareInvitationArn: String? = nil, resourceShareName: String? = nil, senderAccountId: String? = nil, status: ResourceShareInvitationStatus? = nil) {
             self.invitationTimestamp = invitationTimestamp
             self.receiverAccountId = receiverAccountId

--- a/Sources/Soto/Services/ResourceGroups/ResourceGroups_Paginator.swift
+++ b/Sources/Soto/Services/ResourceGroups/ResourceGroups_Paginator.swift
@@ -185,7 +185,6 @@ extension ResourceGroups.ListGroupResourcesInput: AWSPaginateToken {
         return .init(
             filters: self.filters,
             group: self.group,
-            groupName: self.groupName,
             maxResults: self.maxResults,
             nextToken: token
         )

--- a/Sources/Soto/Services/ResourceGroups/ResourceGroups_Shapes.swift
+++ b/Sources/Soto/Services/ResourceGroups/ResourceGroups_Shapes.swift
@@ -138,6 +138,12 @@ extension ResourceGroups {
         /// Deprecated - don't use this parameter. Use Group instead.
         public let groupName: String?
 
+        public init(group: String? = nil) {
+            self.group = group
+            self.groupName = nil
+        }
+
+        @available(*, deprecated, message: "Members groupName have been deprecated")
         public init(group: String? = nil, groupName: String? = nil) {
             self.group = group
             self.groupName = groupName
@@ -230,6 +236,12 @@ extension ResourceGroups {
         /// Deprecated - don't use this parameter. Use Group instead.
         public let groupName: String?
 
+        public init(group: String? = nil) {
+            self.group = group
+            self.groupName = nil
+        }
+
+        @available(*, deprecated, message: "Members groupName have been deprecated")
         public init(group: String? = nil, groupName: String? = nil) {
             self.group = group
             self.groupName = groupName
@@ -269,6 +281,12 @@ extension ResourceGroups {
         /// Don't use this parameter. Use Group instead.
         public let groupName: String?
 
+        public init(group: String? = nil) {
+            self.group = group
+            self.groupName = nil
+        }
+
+        @available(*, deprecated, message: "Members groupName have been deprecated")
         public init(group: String? = nil, groupName: String? = nil) {
             self.group = group
             self.groupName = groupName
@@ -571,6 +589,15 @@ extension ResourceGroups {
         /// call's NextToken response to indicate where the output should continue from.
         public let nextToken: String?
 
+        public init(filters: [ResourceFilter]? = nil, group: String? = nil, maxResults: Int? = nil, nextToken: String? = nil) {
+            self.filters = filters
+            self.group = group
+            self.groupName = nil
+            self.maxResults = maxResults
+            self.nextToken = nextToken
+        }
+
+        @available(*, deprecated, message: "Members groupName have been deprecated")
         public init(filters: [ResourceFilter]? = nil, group: String? = nil, groupName: String? = nil, maxResults: Int? = nil, nextToken: String? = nil) {
             self.filters = filters
             self.group = group
@@ -633,6 +660,14 @@ extension ResourceGroups {
         /// An array of resources from which you can determine each resource's identity, type, and group membership status.
         public let resources: [ListGroupResourcesItem]?
 
+        public init(nextToken: String? = nil, queryErrors: [QueryError]? = nil, resources: [ListGroupResourcesItem]? = nil) {
+            self.nextToken = nextToken
+            self.queryErrors = queryErrors
+            self.resourceIdentifiers = nil
+            self.resources = resources
+        }
+
+        @available(*, deprecated, message: "Members resourceIdentifiers have been deprecated")
         public init(nextToken: String? = nil, queryErrors: [QueryError]? = nil, resourceIdentifiers: [ResourceIdentifier]? = nil, resources: [ListGroupResourcesItem]? = nil) {
             self.nextToken = nextToken
             self.queryErrors = queryErrors
@@ -703,6 +738,13 @@ extension ResourceGroups {
         /// until the NextToken response element comes back as null.
         public let nextToken: String?
 
+        public init(groupIdentifiers: [GroupIdentifier]? = nil, nextToken: String? = nil) {
+            self.groupIdentifiers = groupIdentifiers
+            self.groups = nil
+            self.nextToken = nextToken
+        }
+
+        @available(*, deprecated, message: "Members groups have been deprecated")
         public init(groupIdentifiers: [GroupIdentifier]? = nil, groups: [Group]? = nil, nextToken: String? = nil) {
             self.groupIdentifiers = groupIdentifiers
             self.groups = groups
@@ -1074,6 +1116,13 @@ extension ResourceGroups {
         /// Don't use this parameter. Use Group instead.
         public let groupName: String?
 
+        public init(description: String? = nil, group: String? = nil) {
+            self.description = description
+            self.group = group
+            self.groupName = nil
+        }
+
+        @available(*, deprecated, message: "Members groupName have been deprecated")
         public init(description: String? = nil, group: String? = nil, groupName: String? = nil) {
             self.description = description
             self.group = group
@@ -1119,6 +1168,13 @@ extension ResourceGroups {
         /// The resource query to determine which AWS resources are members of this resource group.  A resource group can contain either a Configuration or a ResourceQuery, but not both.
         public let resourceQuery: ResourceQuery
 
+        public init(group: String? = nil, resourceQuery: ResourceQuery) {
+            self.group = group
+            self.groupName = nil
+            self.resourceQuery = resourceQuery
+        }
+
+        @available(*, deprecated, message: "Members groupName have been deprecated")
         public init(group: String? = nil, groupName: String? = nil, resourceQuery: ResourceQuery) {
             self.group = group
             self.groupName = groupName

--- a/Sources/Soto/Services/Route53Domains/Route53Domains_Shapes.swift
+++ b/Sources/Soto/Services/Route53Domains/Route53Domains_Shapes.swift
@@ -1896,6 +1896,13 @@ extension Route53Domains {
         /// A list of new name servers for the domain.
         public let nameservers: [Nameserver]
 
+        public init(domainName: String, nameservers: [Nameserver]) {
+            self.domainName = domainName
+            self.fIAuthKey = nil
+            self.nameservers = nameservers
+        }
+
+        @available(*, deprecated, message: "Members fIAuthKey have been deprecated")
         public init(domainName: String, fIAuthKey: String? = nil, nameservers: [Nameserver]) {
             self.domainName = domainName
             self.fIAuthKey = fIAuthKey

--- a/Sources/Soto/Services/S3/S3_Shapes.swift
+++ b/Sources/Soto/Services/S3/S3_Shapes.swift
@@ -4539,6 +4539,19 @@ extension S3 {
         /// Specifies when an Amazon S3 object transitions to a specified storage class.
         public let transitions: [Transition]?
 
+        public init(abortIncompleteMultipartUpload: AbortIncompleteMultipartUpload? = nil, expiration: LifecycleExpiration? = nil, filter: LifecycleRuleFilter, id: String? = nil, noncurrentVersionExpiration: NoncurrentVersionExpiration? = nil, noncurrentVersionTransitions: [NoncurrentVersionTransition]? = nil, status: ExpirationStatus, transitions: [Transition]? = nil) {
+            self.abortIncompleteMultipartUpload = abortIncompleteMultipartUpload
+            self.expiration = expiration
+            self.filter = filter
+            self.id = id
+            self.noncurrentVersionExpiration = noncurrentVersionExpiration
+            self.noncurrentVersionTransitions = noncurrentVersionTransitions
+            self.prefix = nil
+            self.status = status
+            self.transitions = transitions
+        }
+
+        @available(*, deprecated, message: "Members prefix have been deprecated")
         public init(abortIncompleteMultipartUpload: AbortIncompleteMultipartUpload? = nil, expiration: LifecycleExpiration? = nil, filter: LifecycleRuleFilter, id: String? = nil, noncurrentVersionExpiration: NoncurrentVersionExpiration? = nil, noncurrentVersionTransitions: [NoncurrentVersionTransition]? = nil, prefix: String? = nil, status: ExpirationStatus, transitions: [Transition]? = nil) {
             self.abortIncompleteMultipartUpload = abortIncompleteMultipartUpload
             self.expiration = expiration
@@ -7194,6 +7207,19 @@ extension S3 {
         /// Specifies whether the rule is enabled.
         public let status: ReplicationRuleStatus
 
+        public init(deleteMarkerReplication: DeleteMarkerReplication? = nil, destination: Destination, existingObjectReplication: ExistingObjectReplication? = nil, filter: ReplicationRuleFilter? = nil, id: String? = nil, priority: Int? = nil, sourceSelectionCriteria: SourceSelectionCriteria? = nil, status: ReplicationRuleStatus) {
+            self.deleteMarkerReplication = deleteMarkerReplication
+            self.destination = destination
+            self.existingObjectReplication = existingObjectReplication
+            self.filter = filter
+            self.id = id
+            self.prefix = nil
+            self.priority = priority
+            self.sourceSelectionCriteria = sourceSelectionCriteria
+            self.status = status
+        }
+
+        @available(*, deprecated, message: "Members prefix have been deprecated")
         public init(deleteMarkerReplication: DeleteMarkerReplication? = nil, destination: Destination, existingObjectReplication: ExistingObjectReplication? = nil, filter: ReplicationRuleFilter? = nil, id: String? = nil, prefix: String? = nil, priority: Int? = nil, sourceSelectionCriteria: SourceSelectionCriteria? = nil, status: ReplicationRuleStatus) {
             self.deleteMarkerReplication = deleteMarkerReplication
             self.destination = destination

--- a/Sources/Soto/Services/SageMaker/SageMaker_Shapes.swift
+++ b/Sources/Soto/Services/SageMaker/SageMaker_Shapes.swift
@@ -4331,6 +4331,21 @@ extension SageMaker {
         /// The ID of the Amazon Virtual Private Cloud (VPC) that Studio uses for communication.
         public let vpcId: String
 
+        public init(appNetworkAccessType: AppNetworkAccessType? = nil, appSecurityGroupManagement: AppSecurityGroupManagement? = nil, authMode: AuthMode, defaultUserSettings: UserSettings, domainName: String, domainSettings: DomainSettings? = nil, kmsKeyId: String? = nil, subnetIds: [String], tags: [Tag]? = nil, vpcId: String) {
+            self.appNetworkAccessType = appNetworkAccessType
+            self.appSecurityGroupManagement = appSecurityGroupManagement
+            self.authMode = authMode
+            self.defaultUserSettings = defaultUserSettings
+            self.domainName = domainName
+            self.domainSettings = domainSettings
+            self.homeEfsFileSystemKmsKeyId = nil
+            self.kmsKeyId = kmsKeyId
+            self.subnetIds = subnetIds
+            self.tags = tags
+            self.vpcId = vpcId
+        }
+
+        @available(*, deprecated, message: "Members homeEfsFileSystemKmsKeyId have been deprecated")
         public init(appNetworkAccessType: AppNetworkAccessType? = nil, appSecurityGroupManagement: AppSecurityGroupManagement? = nil, authMode: AuthMode, defaultUserSettings: UserSettings, domainName: String, domainSettings: DomainSettings? = nil, homeEfsFileSystemKmsKeyId: String? = nil, kmsKeyId: String? = nil, subnetIds: [String], tags: [Tag]? = nil, vpcId: String) {
             self.appNetworkAccessType = appNetworkAccessType
             self.appSecurityGroupManagement = appSecurityGroupManagement
@@ -9058,6 +9073,30 @@ extension SageMaker {
         /// The ID of the Amazon Virtual Private Cloud (VPC) that Studio uses for communication.
         public let vpcId: String?
 
+        public init(appNetworkAccessType: AppNetworkAccessType? = nil, appSecurityGroupManagement: AppSecurityGroupManagement? = nil, authMode: AuthMode? = nil, creationTime: Date? = nil, defaultUserSettings: UserSettings? = nil, domainArn: String? = nil, domainId: String? = nil, domainName: String? = nil, domainSettings: DomainSettings? = nil, failureReason: String? = nil, homeEfsFileSystemId: String? = nil, kmsKeyId: String? = nil, lastModifiedTime: Date? = nil, securityGroupIdForDomainBoundary: String? = nil, singleSignOnManagedApplicationInstanceId: String? = nil, status: DomainStatus? = nil, subnetIds: [String]? = nil, url: String? = nil, vpcId: String? = nil) {
+            self.appNetworkAccessType = appNetworkAccessType
+            self.appSecurityGroupManagement = appSecurityGroupManagement
+            self.authMode = authMode
+            self.creationTime = creationTime
+            self.defaultUserSettings = defaultUserSettings
+            self.domainArn = domainArn
+            self.domainId = domainId
+            self.domainName = domainName
+            self.domainSettings = domainSettings
+            self.failureReason = failureReason
+            self.homeEfsFileSystemId = homeEfsFileSystemId
+            self.homeEfsFileSystemKmsKeyId = nil
+            self.kmsKeyId = kmsKeyId
+            self.lastModifiedTime = lastModifiedTime
+            self.securityGroupIdForDomainBoundary = securityGroupIdForDomainBoundary
+            self.singleSignOnManagedApplicationInstanceId = singleSignOnManagedApplicationInstanceId
+            self.status = status
+            self.subnetIds = subnetIds
+            self.url = url
+            self.vpcId = vpcId
+        }
+
+        @available(*, deprecated, message: "Members homeEfsFileSystemKmsKeyId have been deprecated")
         public init(appNetworkAccessType: AppNetworkAccessType? = nil, appSecurityGroupManagement: AppSecurityGroupManagement? = nil, authMode: AuthMode? = nil, creationTime: Date? = nil, defaultUserSettings: UserSettings? = nil, domainArn: String? = nil, domainId: String? = nil, domainName: String? = nil, domainSettings: DomainSettings? = nil, failureReason: String? = nil, homeEfsFileSystemId: String? = nil, homeEfsFileSystemKmsKeyId: String? = nil, kmsKeyId: String? = nil, lastModifiedTime: Date? = nil, securityGroupIdForDomainBoundary: String? = nil, singleSignOnManagedApplicationInstanceId: String? = nil, status: DomainStatus? = nil, subnetIds: [String]? = nil, url: String? = nil, vpcId: String? = nil) {
             self.appNetworkAccessType = appNetworkAccessType
             self.appSecurityGroupManagement = appSecurityGroupManagement

--- a/Sources/Soto/Services/SecurityHub/SecurityHub_Shapes.swift
+++ b/Sources/Soto/Services/SecurityHub/SecurityHub_Shapes.swift
@@ -6891,6 +6891,19 @@ extension SecurityHub {
         /// The user associated with the IAM access key related to a finding. The UserName parameter has been replaced with the PrincipalName parameter because access keys can also be assigned to principals that are not IAM users.
         public let userName: String?
 
+        public init(accessKeyId: String? = nil, accountId: String? = nil, createdAt: String? = nil, principalId: String? = nil, principalName: String? = nil, principalType: String? = nil, sessionContext: AwsIamAccessKeySessionContext? = nil, status: AwsIamAccessKeyStatus? = nil) {
+            self.accessKeyId = accessKeyId
+            self.accountId = accountId
+            self.createdAt = createdAt
+            self.principalId = principalId
+            self.principalName = principalName
+            self.principalType = principalType
+            self.sessionContext = sessionContext
+            self.status = status
+            self.userName = nil
+        }
+
+        @available(*, deprecated, message: "Members userName have been deprecated")
         public init(accessKeyId: String? = nil, accountId: String? = nil, createdAt: String? = nil, principalId: String? = nil, principalName: String? = nil, principalType: String? = nil, sessionContext: AwsIamAccessKeySessionContext? = nil, status: AwsIamAccessKeyStatus? = nil, userName: String? = nil) {
             self.accessKeyId = accessKeyId
             self.accountId = accountId
@@ -11264,6 +11277,104 @@ extension SecurityHub {
         /// The status of the investigation into a finding. Allowed values are the following.    NEW - The initial state of a finding, before it is reviewed. Security Hub also resets the workflow status from NOTIFIED or RESOLVED to NEW in the following cases:   The record state changes from ARCHIVED to ACTIVE.   The compliance status changes from PASSED to either WARNING, FAILED, or NOT_AVAILABLE.      NOTIFIED - Indicates that the resource owner has been notified about the security issue. Used when the initial reviewer is not the resource owner, and needs intervention from the resource owner.    SUPPRESSED - The finding will not be reviewed again and will not be acted upon.    RESOLVED - The finding was reviewed and remediated and is now considered resolved.
         public let workflowStatus: [StringFilter]?
 
+        public init(awsAccountId: [StringFilter]? = nil, companyName: [StringFilter]? = nil, complianceStatus: [StringFilter]? = nil, confidence: [NumberFilter]? = nil, createdAt: [DateFilter]? = nil, criticality: [NumberFilter]? = nil, description: [StringFilter]? = nil, findingProviderFieldsConfidence: [NumberFilter]? = nil, findingProviderFieldsCriticality: [NumberFilter]? = nil, findingProviderFieldsRelatedFindingsId: [StringFilter]? = nil, findingProviderFieldsRelatedFindingsProductArn: [StringFilter]? = nil, findingProviderFieldsSeverityLabel: [StringFilter]? = nil, findingProviderFieldsSeverityOriginal: [StringFilter]? = nil, findingProviderFieldsTypes: [StringFilter]? = nil, firstObservedAt: [DateFilter]? = nil, generatorId: [StringFilter]? = nil, id: [StringFilter]? = nil, lastObservedAt: [DateFilter]? = nil, malwareName: [StringFilter]? = nil, malwarePath: [StringFilter]? = nil, malwareState: [StringFilter]? = nil, malwareType: [StringFilter]? = nil, networkDestinationDomain: [StringFilter]? = nil, networkDestinationIpV4: [IpFilter]? = nil, networkDestinationIpV6: [IpFilter]? = nil, networkDestinationPort: [NumberFilter]? = nil, networkDirection: [StringFilter]? = nil, networkProtocol: [StringFilter]? = nil, networkSourceDomain: [StringFilter]? = nil, networkSourceIpV4: [IpFilter]? = nil, networkSourceIpV6: [IpFilter]? = nil, networkSourceMac: [StringFilter]? = nil, networkSourcePort: [NumberFilter]? = nil, noteText: [StringFilter]? = nil, noteUpdatedAt: [DateFilter]? = nil, noteUpdatedBy: [StringFilter]? = nil, processLaunchedAt: [DateFilter]? = nil, processName: [StringFilter]? = nil, processParentPid: [NumberFilter]? = nil, processPath: [StringFilter]? = nil, processPid: [NumberFilter]? = nil, processTerminatedAt: [DateFilter]? = nil, productArn: [StringFilter]? = nil, productFields: [MapFilter]? = nil, productName: [StringFilter]? = nil, recommendationText: [StringFilter]? = nil, recordState: [StringFilter]? = nil, region: [StringFilter]? = nil, relatedFindingsId: [StringFilter]? = nil, relatedFindingsProductArn: [StringFilter]? = nil, resourceAwsEc2InstanceIamInstanceProfileArn: [StringFilter]? = nil, resourceAwsEc2InstanceImageId: [StringFilter]? = nil, resourceAwsEc2InstanceIpV4Addresses: [IpFilter]? = nil, resourceAwsEc2InstanceIpV6Addresses: [IpFilter]? = nil, resourceAwsEc2InstanceKeyName: [StringFilter]? = nil, resourceAwsEc2InstanceLaunchedAt: [DateFilter]? = nil, resourceAwsEc2InstanceSubnetId: [StringFilter]? = nil, resourceAwsEc2InstanceType: [StringFilter]? = nil, resourceAwsEc2InstanceVpcId: [StringFilter]? = nil, resourceAwsIamAccessKeyCreatedAt: [DateFilter]? = nil, resourceAwsIamAccessKeyPrincipalName: [StringFilter]? = nil, resourceAwsIamAccessKeyStatus: [StringFilter]? = nil, resourceAwsIamUserUserName: [StringFilter]? = nil, resourceAwsS3BucketOwnerId: [StringFilter]? = nil, resourceAwsS3BucketOwnerName: [StringFilter]? = nil, resourceContainerImageId: [StringFilter]? = nil, resourceContainerImageName: [StringFilter]? = nil, resourceContainerLaunchedAt: [DateFilter]? = nil, resourceContainerName: [StringFilter]? = nil, resourceDetailsOther: [MapFilter]? = nil, resourceId: [StringFilter]? = nil, resourcePartition: [StringFilter]? = nil, resourceRegion: [StringFilter]? = nil, resourceTags: [MapFilter]? = nil, resourceType: [StringFilter]? = nil, severityLabel: [StringFilter]? = nil, sourceUrl: [StringFilter]? = nil, threatIntelIndicatorCategory: [StringFilter]? = nil, threatIntelIndicatorLastObservedAt: [DateFilter]? = nil, threatIntelIndicatorSource: [StringFilter]? = nil, threatIntelIndicatorSourceUrl: [StringFilter]? = nil, threatIntelIndicatorType: [StringFilter]? = nil, threatIntelIndicatorValue: [StringFilter]? = nil, title: [StringFilter]? = nil, type: [StringFilter]? = nil, updatedAt: [DateFilter]? = nil, userDefinedFields: [MapFilter]? = nil, verificationState: [StringFilter]? = nil, workflowState: [StringFilter]? = nil, workflowStatus: [StringFilter]? = nil) {
+            self.awsAccountId = awsAccountId
+            self.companyName = companyName
+            self.complianceStatus = complianceStatus
+            self.confidence = confidence
+            self.createdAt = createdAt
+            self.criticality = criticality
+            self.description = description
+            self.findingProviderFieldsConfidence = findingProviderFieldsConfidence
+            self.findingProviderFieldsCriticality = findingProviderFieldsCriticality
+            self.findingProviderFieldsRelatedFindingsId = findingProviderFieldsRelatedFindingsId
+            self.findingProviderFieldsRelatedFindingsProductArn = findingProviderFieldsRelatedFindingsProductArn
+            self.findingProviderFieldsSeverityLabel = findingProviderFieldsSeverityLabel
+            self.findingProviderFieldsSeverityOriginal = findingProviderFieldsSeverityOriginal
+            self.findingProviderFieldsTypes = findingProviderFieldsTypes
+            self.firstObservedAt = firstObservedAt
+            self.generatorId = generatorId
+            self.id = id
+            self.keyword = nil
+            self.lastObservedAt = lastObservedAt
+            self.malwareName = malwareName
+            self.malwarePath = malwarePath
+            self.malwareState = malwareState
+            self.malwareType = malwareType
+            self.networkDestinationDomain = networkDestinationDomain
+            self.networkDestinationIpV4 = networkDestinationIpV4
+            self.networkDestinationIpV6 = networkDestinationIpV6
+            self.networkDestinationPort = networkDestinationPort
+            self.networkDirection = networkDirection
+            self.networkProtocol = networkProtocol
+            self.networkSourceDomain = networkSourceDomain
+            self.networkSourceIpV4 = networkSourceIpV4
+            self.networkSourceIpV6 = networkSourceIpV6
+            self.networkSourceMac = networkSourceMac
+            self.networkSourcePort = networkSourcePort
+            self.noteText = noteText
+            self.noteUpdatedAt = noteUpdatedAt
+            self.noteUpdatedBy = noteUpdatedBy
+            self.processLaunchedAt = processLaunchedAt
+            self.processName = processName
+            self.processParentPid = processParentPid
+            self.processPath = processPath
+            self.processPid = processPid
+            self.processTerminatedAt = processTerminatedAt
+            self.productArn = productArn
+            self.productFields = productFields
+            self.productName = productName
+            self.recommendationText = recommendationText
+            self.recordState = recordState
+            self.region = region
+            self.relatedFindingsId = relatedFindingsId
+            self.relatedFindingsProductArn = relatedFindingsProductArn
+            self.resourceAwsEc2InstanceIamInstanceProfileArn = resourceAwsEc2InstanceIamInstanceProfileArn
+            self.resourceAwsEc2InstanceImageId = resourceAwsEc2InstanceImageId
+            self.resourceAwsEc2InstanceIpV4Addresses = resourceAwsEc2InstanceIpV4Addresses
+            self.resourceAwsEc2InstanceIpV6Addresses = resourceAwsEc2InstanceIpV6Addresses
+            self.resourceAwsEc2InstanceKeyName = resourceAwsEc2InstanceKeyName
+            self.resourceAwsEc2InstanceLaunchedAt = resourceAwsEc2InstanceLaunchedAt
+            self.resourceAwsEc2InstanceSubnetId = resourceAwsEc2InstanceSubnetId
+            self.resourceAwsEc2InstanceType = resourceAwsEc2InstanceType
+            self.resourceAwsEc2InstanceVpcId = resourceAwsEc2InstanceVpcId
+            self.resourceAwsIamAccessKeyCreatedAt = resourceAwsIamAccessKeyCreatedAt
+            self.resourceAwsIamAccessKeyPrincipalName = resourceAwsIamAccessKeyPrincipalName
+            self.resourceAwsIamAccessKeyStatus = resourceAwsIamAccessKeyStatus
+            self.resourceAwsIamAccessKeyUserName = nil
+            self.resourceAwsIamUserUserName = resourceAwsIamUserUserName
+            self.resourceAwsS3BucketOwnerId = resourceAwsS3BucketOwnerId
+            self.resourceAwsS3BucketOwnerName = resourceAwsS3BucketOwnerName
+            self.resourceContainerImageId = resourceContainerImageId
+            self.resourceContainerImageName = resourceContainerImageName
+            self.resourceContainerLaunchedAt = resourceContainerLaunchedAt
+            self.resourceContainerName = resourceContainerName
+            self.resourceDetailsOther = resourceDetailsOther
+            self.resourceId = resourceId
+            self.resourcePartition = resourcePartition
+            self.resourceRegion = resourceRegion
+            self.resourceTags = resourceTags
+            self.resourceType = resourceType
+            self.severityLabel = severityLabel
+            self.severityNormalized = nil
+            self.severityProduct = nil
+            self.sourceUrl = sourceUrl
+            self.threatIntelIndicatorCategory = threatIntelIndicatorCategory
+            self.threatIntelIndicatorLastObservedAt = threatIntelIndicatorLastObservedAt
+            self.threatIntelIndicatorSource = threatIntelIndicatorSource
+            self.threatIntelIndicatorSourceUrl = threatIntelIndicatorSourceUrl
+            self.threatIntelIndicatorType = threatIntelIndicatorType
+            self.threatIntelIndicatorValue = threatIntelIndicatorValue
+            self.title = title
+            self.type = type
+            self.updatedAt = updatedAt
+            self.userDefinedFields = userDefinedFields
+            self.verificationState = verificationState
+            self.workflowState = workflowState
+            self.workflowStatus = workflowStatus
+        }
+
+        @available(*, deprecated, message: "Members keyword, resourceAwsIamAccessKeyUserName, severityNormalized, severityProduct have been deprecated")
         public init(awsAccountId: [StringFilter]? = nil, companyName: [StringFilter]? = nil, complianceStatus: [StringFilter]? = nil, confidence: [NumberFilter]? = nil, createdAt: [DateFilter]? = nil, criticality: [NumberFilter]? = nil, description: [StringFilter]? = nil, findingProviderFieldsConfidence: [NumberFilter]? = nil, findingProviderFieldsCriticality: [NumberFilter]? = nil, findingProviderFieldsRelatedFindingsId: [StringFilter]? = nil, findingProviderFieldsRelatedFindingsProductArn: [StringFilter]? = nil, findingProviderFieldsSeverityLabel: [StringFilter]? = nil, findingProviderFieldsSeverityOriginal: [StringFilter]? = nil, findingProviderFieldsTypes: [StringFilter]? = nil, firstObservedAt: [DateFilter]? = nil, generatorId: [StringFilter]? = nil, id: [StringFilter]? = nil, keyword: [KeywordFilter]? = nil, lastObservedAt: [DateFilter]? = nil, malwareName: [StringFilter]? = nil, malwarePath: [StringFilter]? = nil, malwareState: [StringFilter]? = nil, malwareType: [StringFilter]? = nil, networkDestinationDomain: [StringFilter]? = nil, networkDestinationIpV4: [IpFilter]? = nil, networkDestinationIpV6: [IpFilter]? = nil, networkDestinationPort: [NumberFilter]? = nil, networkDirection: [StringFilter]? = nil, networkProtocol: [StringFilter]? = nil, networkSourceDomain: [StringFilter]? = nil, networkSourceIpV4: [IpFilter]? = nil, networkSourceIpV6: [IpFilter]? = nil, networkSourceMac: [StringFilter]? = nil, networkSourcePort: [NumberFilter]? = nil, noteText: [StringFilter]? = nil, noteUpdatedAt: [DateFilter]? = nil, noteUpdatedBy: [StringFilter]? = nil, processLaunchedAt: [DateFilter]? = nil, processName: [StringFilter]? = nil, processParentPid: [NumberFilter]? = nil, processPath: [StringFilter]? = nil, processPid: [NumberFilter]? = nil, processTerminatedAt: [DateFilter]? = nil, productArn: [StringFilter]? = nil, productFields: [MapFilter]? = nil, productName: [StringFilter]? = nil, recommendationText: [StringFilter]? = nil, recordState: [StringFilter]? = nil, region: [StringFilter]? = nil, relatedFindingsId: [StringFilter]? = nil, relatedFindingsProductArn: [StringFilter]? = nil, resourceAwsEc2InstanceIamInstanceProfileArn: [StringFilter]? = nil, resourceAwsEc2InstanceImageId: [StringFilter]? = nil, resourceAwsEc2InstanceIpV4Addresses: [IpFilter]? = nil, resourceAwsEc2InstanceIpV6Addresses: [IpFilter]? = nil, resourceAwsEc2InstanceKeyName: [StringFilter]? = nil, resourceAwsEc2InstanceLaunchedAt: [DateFilter]? = nil, resourceAwsEc2InstanceSubnetId: [StringFilter]? = nil, resourceAwsEc2InstanceType: [StringFilter]? = nil, resourceAwsEc2InstanceVpcId: [StringFilter]? = nil, resourceAwsIamAccessKeyCreatedAt: [DateFilter]? = nil, resourceAwsIamAccessKeyPrincipalName: [StringFilter]? = nil, resourceAwsIamAccessKeyStatus: [StringFilter]? = nil, resourceAwsIamAccessKeyUserName: [StringFilter]? = nil, resourceAwsIamUserUserName: [StringFilter]? = nil, resourceAwsS3BucketOwnerId: [StringFilter]? = nil, resourceAwsS3BucketOwnerName: [StringFilter]? = nil, resourceContainerImageId: [StringFilter]? = nil, resourceContainerImageName: [StringFilter]? = nil, resourceContainerLaunchedAt: [DateFilter]? = nil, resourceContainerName: [StringFilter]? = nil, resourceDetailsOther: [MapFilter]? = nil, resourceId: [StringFilter]? = nil, resourcePartition: [StringFilter]? = nil, resourceRegion: [StringFilter]? = nil, resourceTags: [MapFilter]? = nil, resourceType: [StringFilter]? = nil, severityLabel: [StringFilter]? = nil, severityNormalized: [NumberFilter]? = nil, severityProduct: [NumberFilter]? = nil, sourceUrl: [StringFilter]? = nil, threatIntelIndicatorCategory: [StringFilter]? = nil, threatIntelIndicatorLastObservedAt: [DateFilter]? = nil, threatIntelIndicatorSource: [StringFilter]? = nil, threatIntelIndicatorSourceUrl: [StringFilter]? = nil, threatIntelIndicatorType: [StringFilter]? = nil, threatIntelIndicatorValue: [StringFilter]? = nil, title: [StringFilter]? = nil, type: [StringFilter]? = nil, updatedAt: [DateFilter]? = nil, userDefinedFields: [MapFilter]? = nil, verificationState: [StringFilter]? = nil, workflowState: [StringFilter]? = nil, workflowStatus: [StringFilter]? = nil) {
             self.awsAccountId = awsAccountId
             self.companyName = companyName
@@ -14559,6 +14670,17 @@ extension SecurityHub {
         @OptionalCustomCoding<ISO8601DateCoder>
         public var updatedAt: Date?
 
+        public init(accountId: String? = nil, administratorId: String? = nil, email: String? = nil, invitedAt: Date? = nil, memberStatus: String? = nil, updatedAt: Date? = nil) {
+            self.accountId = accountId
+            self.administratorId = administratorId
+            self.email = email
+            self.invitedAt = invitedAt
+            self.masterId = nil
+            self.memberStatus = memberStatus
+            self.updatedAt = updatedAt
+        }
+
+        @available(*, deprecated, message: "Members masterId have been deprecated")
         public init(accountId: String? = nil, administratorId: String? = nil, email: String? = nil, invitedAt: Date? = nil, masterId: String? = nil, memberStatus: String? = nil, updatedAt: Date? = nil) {
             self.accountId = accountId
             self.administratorId = administratorId

--- a/Sources/Soto/Services/ServiceDiscovery/ServiceDiscovery_Shapes.swift
+++ b/Sources/Soto/Services/ServiceDiscovery/ServiceDiscovery_Shapes.swift
@@ -528,6 +528,13 @@ extension ServiceDiscovery {
         /// The routing policy that you want to apply to all Route 53 DNS records that Cloud Map creates when you register an instance and specify this service.  If you want to use this service to register instances that create alias records, specify WEIGHTED for the routing policy.  You can specify the following values:  MULTIVALUE  If you define a health check for the service and the health check is healthy, Route 53 returns the applicable value for up to eight instances. For example, suppose that the service includes configurations for one A record and a health check. You use the service to register 10 instances. Route 53 responds to DNS queries with IP addresses for up to eight healthy instances. If fewer than eight instances are healthy, Route 53 responds to every DNS query with the IP addresses for all of the healthy instances. If you don't define a health check for the service, Route 53 assumes that all instances are healthy and returns the values for up to eight instances. For more information about the multivalue routing policy, see Multivalue Answer Routing in the Route 53 Developer Guide.  WEIGHTED  Route 53 returns the applicable value from one randomly selected instance from among the instances that you registered using the same service. Currently, all records have the same weight, so you can't route more or less traffic to any instances. For example, suppose that the service includes configurations for one A record and a health check. You use the service to register 10 instances. Route 53 responds to DNS queries with the IP address for one randomly selected instance from among the healthy instances. If no instances are healthy, Route 53 responds to DNS queries as if all of the instances were healthy. If you don't define a health check for the service, Route 53 assumes that all instances are healthy and returns the applicable value for one randomly selected instance. For more information about the weighted routing policy, see Weighted Routing in the Route 53 Developer Guide.
         public let routingPolicy: RoutingPolicy?
 
+        public init(dnsRecords: [DnsRecord], routingPolicy: RoutingPolicy? = nil) {
+            self.dnsRecords = dnsRecords
+            self.namespaceId = nil
+            self.routingPolicy = routingPolicy
+        }
+
+        @available(*, deprecated, message: "Members namespaceId have been deprecated")
         public init(dnsRecords: [DnsRecord], namespaceId: String? = nil, routingPolicy: RoutingPolicy? = nil) {
             self.dnsRecords = dnsRecords
             self.namespaceId = namespaceId
@@ -815,6 +822,11 @@ extension ServiceDiscovery {
         ///  This parameter is no longer supported and is always set to 1. Cloud Map waits for approximately 30 seconds after receiving an UpdateInstanceCustomHealthStatus request before changing the status of the service instance.  The number of 30-second intervals that you want Cloud Map to wait after receiving an UpdateInstanceCustomHealthStatus request before it changes the health status of a service instance. Sending a second or subsequent UpdateInstanceCustomHealthStatus request with the same value before 30 seconds has passed doesn't accelerate the change. Cloud Map still waits 30 seconds after the first request to make the change.
         public let failureThreshold: Int?
 
+        public init() {
+            self.failureThreshold = nil
+        }
+
+        @available(*, deprecated, message: "Members failureThreshold have been deprecated")
         public init(failureThreshold: Int? = nil) {
             self.failureThreshold = failureThreshold
         }

--- a/Sources/Soto/Services/WorkDocs/WorkDocs_Shapes.swift
+++ b/Sources/Soto/Services/WorkDocs/WorkDocs_Shapes.swift
@@ -1740,6 +1740,13 @@ extension WorkDocs {
         /// The users.
         public let users: [User]?
 
+        public init(marker: String? = nil, users: [User]? = nil) {
+            self.marker = marker
+            self.totalNumberOfUsers = nil
+            self.users = users
+        }
+
+        @available(*, deprecated, message: "Members totalNumberOfUsers have been deprecated")
         public init(marker: String? = nil, totalNumberOfUsers: Int64? = nil, users: [User]? = nil) {
             self.marker = marker
             self.totalNumberOfUsers = totalNumberOfUsers


### PR DESCRIPTION
For shapes with deprecated member variables 
- Remove deprecated variables from standard `init` function
- Add an additional `init` which is flagged as deprecated which includes deprecated variables

Soto Code generator PR is https://github.com/soto-project/soto-codegenerator/pull/34
This resolves #352 