### PR TITLE
Swift Concurrency Availability macOS 10.15, iOS 13, tvOS 13, ...

### DIFF
--- a/CodeGenerator/mustache/api+async.mustache
+++ b/CodeGenerator/mustache/api+async.mustache
@@ -5,7 +5,7 @@
 
 import SotoCore
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension {{ name }} {
 
     // MARK: Async API Calls

--- a/CodeGenerator/mustache/paginator+async.mustache
+++ b/CodeGenerator/mustache/paginator+async.mustache
@@ -7,7 +7,7 @@ import SotoCore
 
 // MARK: Paginators
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension {{name}} {
 {{#paginators}}
 {{#operation.comment}}

--- a/CodeGenerator/mustache/waiter+async.mustache
+++ b/CodeGenerator/mustache/waiter+async.mustache
@@ -7,7 +7,7 @@ import SotoCore
 
 // MARK: Waiters
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension {{name}} {
 {{#waiters}}
     public func waitUntil{{waiterName}}(


### PR DESCRIPTION
Edit mustache templates to update swift concurrency availability.

The code will be updated the next time I do a model update