### PR TITLE
Function does not preserve the trailing / if present

### DIFF
--- a/Sources/Soto/Extensions/S3/S3RequestMiddleware.swift
+++ b/Sources/Soto/Extensions/S3/S3RequestMiddleware.swift
@@ -87,6 +87,10 @@ public struct S3RequestMiddleware: AWSServiceMiddleware {
                 urlPath = paths.joined(separator: "/")
                 urlHost = host
             }
+            // add trailing "/" back if it was present
+            if request.url.pathWithSlash.hasSuffix("/") {
+                urlPath += "/"
+            }
             // add percent encoding back into path as converting from URL to String has removed it
             let percentEncodedUrlPath = Self.urlEncodePath(urlPath)
             var urlString = "\(request.url.scheme ?? "https")://\(urlHost)/\(percentEncodedUrlPath)"


### PR DESCRIPTION
virtualAddressFixup does not preserve, or more precisely restore, the trailing / if it was present. That results in everything being considered as a files where the original intent was to define a folder.