### PR TITLE
Test fixes

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+    "name": "Soto Swift 5.6",
+    "dockerComposeFile": "docker-compose.yml",
+    "service": "app",
+    "workspaceFolder": "/workspace",
+    "extensions": [
+      "sswg.swift-lang"
+    ],
+    "settings": {
+      "lldb.library": "/usr/lib/liblldb.so",
+      "terminal.integrated.env.linux": {
+        "LOCALSTACK_ENDPOINT": "http://localstack:4566"
+      }
+    }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,18 @@
+# run this with docker-compose -f docker/docker-compose.yml run test
+version: "3.3"
+
+services:
+  app:
+    image: swift:5.6-focal
+    volumes:
+      - ..:/workspace
+    depends_on:
+      - localstack
+    environment:
+      - LOCALSTACK_ENDPOINT=http://localstack:4566
+    command: sleep infinity
+
+  localstack:
+    image: localstack/localstack
+    ports:
+      - "4566:4566"

--- a/Tests/SotoTests/Services/APIGateway/APIGatewayTests.swift
+++ b/Tests/SotoTests/Services/APIGateway/APIGatewayTests.swift
@@ -161,7 +161,10 @@ class APIGatewayTests: XCTestCase {
             case let error as AWSClientError where error == .invalidSignature:
                 XCTFail()
             case let error as APIGatewayErrorType where error == .notFoundException:
-                XCTAssertEqual(error.message, "Invalid API identifier specified 931875313149:Test+%/*%25")
+                // Localstack produces a different error message to AWS
+                if !TestEnvironment.isUsingLocalstack {
+                    XCTAssertEqual(error.message, "Invalid API identifier specified 931875313149:Test+%/*%25")
+                }
             default:
                 break
             }


### PR DESCRIPTION
- Add a devcontainer which includes localstack for testing
- Latest localstack returns an error for `APIGateway.GetResourcesRequest` but the error message is different from AWS so we cannot compare the error messages