### PR TITLE
Remove chars "@()" from s3PathAllowedCharacters

### DIFF
--- a/Sources/Soto/Extensions/S3/S3RequestMiddleware.swift
+++ b/Sources/Soto/Extensions/S3/S3RequestMiddleware.swift
@@ -101,7 +101,7 @@ public struct S3RequestMiddleware: AWSServiceMiddleware {
         }
     }
 
-    static let s3PathAllowedCharacters = CharacterSet.urlPathAllowed.subtracting(.init(charactersIn: "+@()&$=;:,?"))
+    static let s3PathAllowedCharacters = CharacterSet.urlPathAllowed.subtracting(.init(charactersIn: "+@()&$=:,'!*"))
     /// percent encode path value.
     private static func urlEncodePath(_ value: String) -> String {
         return value.addingPercentEncoding(withAllowedCharacters: Self.s3PathAllowedCharacters) ?? value

--- a/Sources/Soto/Extensions/S3/S3RequestMiddleware.swift
+++ b/Sources/Soto/Extensions/S3/S3RequestMiddleware.swift
@@ -101,7 +101,7 @@ public struct S3RequestMiddleware: AWSServiceMiddleware {
         }
     }
 
-    static let s3PathAllowedCharacters = CharacterSet.urlPathAllowed.subtracting(.init(charactersIn: "+@()"))
+    static let s3PathAllowedCharacters = CharacterSet.urlPathAllowed.subtracting(.init(charactersIn: "+@()&$=;:,?"))
     /// percent encode path value.
     private static func urlEncodePath(_ value: String) -> String {
         return value.addingPercentEncoding(withAllowedCharacters: Self.s3PathAllowedCharacters) ?? value

--- a/Sources/Soto/Extensions/S3/S3RequestMiddleware.swift
+++ b/Sources/Soto/Extensions/S3/S3RequestMiddleware.swift
@@ -101,10 +101,10 @@ public struct S3RequestMiddleware: AWSServiceMiddleware {
         }
     }
 
-    static let pathAllowedCharacters = CharacterSet.urlPathAllowed.subtracting(.init(charactersIn: "+"))
+    static let s3PathAllowedCharacters = CharacterSet.urlPathAllowed.subtracting(.init(charactersIn: "+@()"))
     /// percent encode path value.
     private static func urlEncodePath(_ value: String) -> String {
-        return value.addingPercentEncoding(withAllowedCharacters: Self.pathAllowedCharacters) ?? value
+        return value.addingPercentEncoding(withAllowedCharacters: Self.s3PathAllowedCharacters) ?? value
     }
 
     func createBucketFixup(request: inout AWSRequest) {

--- a/Tests/SotoTests/Services/S3/S3Tests.swift
+++ b/Tests/SotoTests/Services/S3/S3Tests.swift
@@ -165,6 +165,13 @@ class S3Tests: XCTestCase {
                 XCTAssertEqual(response.body?.asString(), contents)
                 XCTAssertNotNil(response.lastModified)
             }
+            .flatMap { _ -> EventLoopFuture<S3.ListObjectsV2Output> in
+                return Self.s3.listObjectsV2(.init(bucket: name))
+            }
+            .map { result in
+                let contents = result.contents
+                XCTAssertNotNil(contents?.first(where: { $0.key == filename }))
+            }
             .flatAlways { _ in
                 return Self.deleteBucket(name: name, s3: Self.s3)
             }


### PR DESCRIPTION
Some non AWS S3 systems do not cope with non percent encoded version of these characters