### PR TITLE
Add support for disabling s3 100-continue

### DIFF
--- a/Sources/Soto/Extensions/S3/S3RequestMiddleware.swift
+++ b/Sources/Soto/Extensions/S3/S3RequestMiddleware.swift
@@ -26,7 +26,9 @@ public struct S3RequestMiddleware: AWSServiceMiddleware {
 
         self.virtualAddressFixup(request: &request, context: context)
         self.createBucketFixup(request: &request)
-        self.expect100Continue(request: &request)
+        if !context.options.contains(.s3Disable100Continue) {
+            self.expect100Continue(request: &request)
+        }
 
         return request
     }


### PR DESCRIPTION
Use `.s3disable100continue` service flag to disable the `Expect: 100-continue` header