### PR TITLE
Fix a bug where empty files can't be uploaded with multipart.

### DIFF
--- a/Sources/Soto/Extensions/S3/S3+multipart_API.swift
+++ b/Sources/Soto/Extensions/S3/S3+multipart_API.swift
@@ -694,8 +694,10 @@ extension S3 {
             } else {
                 // supply payload data
                 inputStream(eventLoop).flatMap { payload -> EventLoopFuture<Bool> in
-                    // if no data returned then return success
-                    guard let size = payload.size, size > 0 else {
+                    // if no data returned then return success. If this is the first part
+                    // and it is empty then that means the entire file is empty. In that
+                    // case, we do still "upload" this first empty part.
+                    guard let size = payload.size, size > 0 || partNumber == 1 else {
                         return eventLoop.makeSucceededFuture(true)
                     }
                     // upload payload


### PR DESCRIPTION
This fixes a bug when upload a zero-length file via multipart upload. 

Previously, this would result in the error: `MultipartUploadError(error: MalformedXML: The XML you provided was not well-formed or did not validate against our published schema, completedParts: [])`

The root of this bug was that an empty file would have 0 parts. This fix makes sure there is at least 1 part uploaded, even if that part is 0 bytes in length.