### PR TITLE
Fix uploading empty files with multipart

### DIFF
--- a/Sources/Soto/Extensions/S3/S3+multipart+async.swift
+++ b/Sources/Soto/Extensions/S3/S3+multipart+async.swift
@@ -637,7 +637,10 @@ extension S3 {
                 }
 
                 let payload = try await inputStream(eventLoop)
-                guard let size = payload.size, size > 0 else {
+                // if no data returned then break out of loop. If this is the first part
+                // and it is empty then that means the entire file is empty. In that
+                // case, we do still "upload" this first empty part.
+                guard let size = payload.size, size > 0 || partNumber == 1 else {
                     break
                 }
 

--- a/Sources/Soto/Extensions/S3/S3+multipart.swift
+++ b/Sources/Soto/Extensions/S3/S3+multipart.swift
@@ -694,8 +694,10 @@ extension S3 {
             } else {
                 // supply payload data
                 inputStream(eventLoop).flatMap { payload -> EventLoopFuture<Bool> in
-                    // if no data returned then return success
-                    guard let size = payload.size, size > 0 else {
+                    // if no data returned then return success. If this is the first part
+                    // and it is empty then that means the entire file is empty. In that
+                    // case, we do still "upload" this first empty part.
+                    guard let size = payload.size, size > 0 || partNumber == 1 else {
                         return eventLoop.makeSucceededFuture(true)
                     }
                     // upload payload


### PR DESCRIPTION
This is a copy of the PR #649 from @bridger that fixed this on the 5.x.x branch
I also copied the fix across to the async version of multipart upload