### PR TITLE
Allow more complex ConditionExpressions using UpdateItemCodableInput

### DIFF
--- a/Sources/Soto/Extensions/DynamoDB/DynamoDB+Codable.swift
+++ b/Sources/Soto/Extensions/DynamoDB/DynamoDB+Codable.swift
@@ -377,7 +377,7 @@ extension DynamoDB {
             let expressionAttributeNames: [String: String]
             if let names = self.expressionAttributeNames, self.updateExpression != nil {
                 expressionAttributeNames = names
-            } else if let additionalAttributeNames {
+            } else if let additionalAttributeNames = additionalAttributeNames {
                 let tmpAttributeNames: [String: String] = .init(item.keys.map { ("#\($0)", $0) }) { first, _ in return first }
                 expressionAttributeNames = tmpAttributeNames.merging(additionalAttributeNames, uniquingKeysWith: { _, new in new })
             } else {
@@ -385,7 +385,7 @@ extension DynamoDB {
             }
 
             let expressionAttributeValues: [String: AttributeValue]
-            if let additionalAttributeValues {
+            if let additionalAttributeValues = additionalAttributeValues {
                 let tmpExpressionAttributeValues: [String: AttributeValue] = .init(item.map { (":\($0.key)", $0.value) }) { first, _ in return first }
                 expressionAttributeValues = tmpExpressionAttributeValues.merging(additionalAttributeValues, uniquingKeysWith: { _, new in new })
             } else {

--- a/Sources/Soto/Extensions/DynamoDB/DynamoDB+Codable.swift
+++ b/Sources/Soto/Extensions/DynamoDB/DynamoDB+Codable.swift
@@ -349,9 +349,9 @@ extension DynamoDB {
         /// Object containing item key and attributes to update
         public let updateItem: T
 
-        public init(additionalAttributeNames: [String: String]? = nil, additionalAttributeValues: [String: AttributeValue]? = nil, conditionExpression: String? = nil, expressionAttributeNames: [String: String]? = nil, key: [String], returnConsumedCapacity: ReturnConsumedCapacity? = nil, returnItemCollectionMetrics: ReturnItemCollectionMetrics? = nil, returnValues: ReturnValue? = nil, tableName: String, updateExpression: String? = nil, updateItem: T) {
-            self.additionalAttributeNames = additionalAttributeNames
-            self.additionalAttributeValues = additionalAttributeValues
+        public init(conditionExpression: String? = nil, expressionAttributeNames: [String: String]? = nil, key: [String], returnConsumedCapacity: ReturnConsumedCapacity? = nil, returnItemCollectionMetrics: ReturnItemCollectionMetrics? = nil, returnValues: ReturnValue? = nil, tableName: String, updateExpression: String? = nil, updateItem: T) {
+            self.additionalAttributeNames = nil
+            self.additionalAttributeValues = nil
             self.conditionExpression = conditionExpression
             self.expressionAttributeNames = expressionAttributeNames
             self.key = key
@@ -360,6 +360,20 @@ extension DynamoDB {
             self.returnValues = returnValues
             self.tableName = tableName
             self.updateExpression = updateExpression
+            self.updateItem = updateItem
+        }
+
+        public init(additionalAttributeNames: [String: String]?, additionalAttributeValues: [String: AttributeValue]?, conditionExpression: String? = nil, key: [String], returnConsumedCapacity: ReturnConsumedCapacity? = nil, returnItemCollectionMetrics: ReturnItemCollectionMetrics? = nil, returnValues: ReturnValue? = nil, tableName: String, updateItem: T) {
+            self.additionalAttributeNames = additionalAttributeNames
+            self.additionalAttributeValues = additionalAttributeValues
+            self.conditionExpression = conditionExpression
+            self.expressionAttributeNames = nil
+            self.key = key
+            self.returnConsumedCapacity = returnConsumedCapacity
+            self.returnItemCollectionMetrics = returnItemCollectionMetrics
+            self.returnValues = returnValues
+            self.tableName = tableName
+            self.updateExpression = nil
             self.updateItem = updateItem
         }
 

--- a/Sources/Soto/Extensions/DynamoDB/DynamoDB+Codable.swift
+++ b/Sources/Soto/Extensions/DynamoDB/DynamoDB+Codable.swift
@@ -327,9 +327,9 @@ extension DynamoDB {
     }
 
     public struct UpdateItemCodableInput<T: Encodable & Sendable>: AWSEncodableShape {
-        /// In case expressionAttributeNames is nil, the content of additionalAttributeNames is merged with the generated expressionAttributeNames dictionary and will override existing values. This can be used to specify complex condtionExpression with not auto-generated attribute names.
+        /// In case expressionAttributeNames is nil, the content of additionalAttributeNames is merged with the generated expressionAttributeNames dictionary and will override existing values. This can be used to specify complex conditionExpression with not auto-generated attribute names.
         public let additionalAttributeNames: [String: String]?
-        /// The content of additionalAttributeValues is merged with expressionAttributeValues dictionary and will override existing values. This can be used to specify complex condtionExpression with not auto-generated attribute values.
+        /// The content of additionalAttributeValues is merged with expressionAttributeValues dictionary and will override existing values. This can be used to specify complex conditionExpression with not auto-generated attribute values.
         public let additionalAttributeValues: [String: AttributeValue]?
         /// A condition that must be satisfied in order for a conditional update to succeed. An expression can contain any of the following:   Functions: attribute_exists | attribute_not_exists | attribute_type | contains | begins_with | size  These function names are case-sensitive.   Comparison operators: = | &lt;&gt; | &lt; | &gt; | &lt;= | &gt;= | BETWEEN | IN      Logical operators: AND | OR | NOT    For more information about condition expressions, see Specifying Conditions in the Amazon DynamoDB Developer Guide.
         public let conditionExpression: String?

--- a/Sources/Soto/Extensions/DynamoDB/DynamoDB+Codable.swift
+++ b/Sources/Soto/Extensions/DynamoDB/DynamoDB+Codable.swift
@@ -363,9 +363,10 @@ extension DynamoDB {
             self.updateItem = updateItem
         }
 
-        public init(additionalAttributeNames: [String: String]?, additionalAttributeValues: [String: AttributeValue]?, conditionExpression: String? = nil, key: [String], returnConsumedCapacity: ReturnConsumedCapacity? = nil, returnItemCollectionMetrics: ReturnItemCollectionMetrics? = nil, returnValues: ReturnValue? = nil, tableName: String, updateItem: T) {
-            self.additionalAttributeNames = additionalAttributeNames
-            self.additionalAttributeValues = additionalAttributeValues
+        public init<AdditionalAttributes: Encodable>(additionalAttributes: AdditionalAttributes, conditionExpression: String? = nil, key: [String], returnConsumedCapacity: ReturnConsumedCapacity? = nil, returnItemCollectionMetrics: ReturnItemCollectionMetrics? = nil, returnValues: ReturnValue? = nil, tableName: String, updateItem: T) throws {
+            let attributes = try DynamoDBEncoder().encode(additionalAttributes)
+            self.additionalAttributeNames = .init(attributes.keys.map { ("#\($0)", $0) }) { first, _ in return first }
+            self.additionalAttributeValues = .init(attributes.map { (":\($0.key)", $0.value) }) { first, _ in return first }
             self.conditionExpression = conditionExpression
             self.expressionAttributeNames = nil
             self.key = key

--- a/Tests/SotoTests/Services/DynamoDB/DynamoDBCodableTests+async.swift
+++ b/Tests/SotoTests/Services/DynamoDB/DynamoDBCodableTests+async.swift
@@ -116,7 +116,7 @@ final class DynamoDBCodableAsyncTests: XCTestCase {
             do {
                 let additionalAttributes = AdditionalAttributes(age: 33)
                 let conditionExpression = "#age = :age"
-                let updateRequest = try DynamoDB.UpdateItemCodableInput(additionalAttributes: additionalAttributes, key: ["id"], tableName: tableName, updateItem: nameUpdate)
+                let updateRequest = try DynamoDB.UpdateItemCodableInput(additionalAttributes: additionalAttributes, conditionExpression: conditionExpression, key: ["id"], tableName: tableName, updateItem: nameUpdate)
                 _ = try await Self.dynamoDB.updateItem(updateRequest, logger: TestEnvironment.logger)
                 XCTFail("Should have thrown error because conditionExpression is not met")
             } catch {

--- a/Tests/SotoTests/Services/DynamoDB/DynamoDBCodableTests+async.swift
+++ b/Tests/SotoTests/Services/DynamoDB/DynamoDBCodableTests+async.swift
@@ -110,6 +110,16 @@ final class DynamoDBCodableAsyncTests: XCTestCase {
             let updateRequest = DynamoDB.UpdateItemCodableInput(key: ["id"], tableName: tableName, updateItem: nameUpdate)
             _ = try await Self.dynamoDB.updateItem(updateRequest, logger: TestEnvironment.logger)
 
+            do {
+                let additionalAttributeNames: [String: String] = ["#age": "age"]
+                let additionalAttributeValues: [String: DynamoDB.AttributeValue] = [":age": .n("33")]
+                let conditionExpression = "#age = :age"
+                let updateRequest = DynamoDB.UpdateItemCodableInput(additionalAttributeNames: additionalAttributeNames, additionalAttributeValues: additionalAttributeValues, key: ["id"], tableName: tableName, updateItem: nameUpdate)
+                _ = try await Self.dynamoDB.updateItem(updateRequest, logger: TestEnvironment.logger)
+                XCTFail("Should have thrown error because conditionExpression is not met")
+            } catch {
+                XCTAssertNotNil(error)
+            }
             let getRequest = DynamoDB.GetItemInput(consistentRead: true, key: ["id": .s(id)], tableName: tableName)
             let response = try await Self.dynamoDB.getItem(getRequest, type: TestObject.self, logger: TestEnvironment.logger)
 

--- a/Tests/SotoTests/Services/DynamoDB/DynamoDBCodableTests+async.swift
+++ b/Tests/SotoTests/Services/DynamoDB/DynamoDBCodableTests+async.swift
@@ -96,11 +96,9 @@ final class DynamoDBCodableAsyncTests: XCTestCase {
             let name: String
             let surname: String
         }
-        
         struct AdditionalAttributes: Codable {
             let age: Int
         }
-        
         let id = UUID().uuidString
         let test = TestObject(id: id, name: "John", surname: "Smith", age: 32, address: "1 Park Lane", pets: ["cat", "dog"])
         let nameUpdate = NameUpdate(id: id, name: "David", surname: "Jones")

--- a/Tests/SotoTests/Services/DynamoDB/DynamoDBCodableTests+async.swift
+++ b/Tests/SotoTests/Services/DynamoDB/DynamoDBCodableTests+async.swift
@@ -96,6 +96,11 @@ final class DynamoDBCodableAsyncTests: XCTestCase {
             let name: String
             let surname: String
         }
+        
+        struct AdditionalAttributes: Codable {
+            let age: Int
+        }
+        
         let id = UUID().uuidString
         let test = TestObject(id: id, name: "John", surname: "Smith", age: 32, address: "1 Park Lane", pets: ["cat", "dog"])
         let nameUpdate = NameUpdate(id: id, name: "David", surname: "Jones")
@@ -111,10 +116,9 @@ final class DynamoDBCodableAsyncTests: XCTestCase {
             _ = try await Self.dynamoDB.updateItem(updateRequest, logger: TestEnvironment.logger)
 
             do {
-                let additionalAttributeNames: [String: String] = ["#age": "age"]
-                let additionalAttributeValues: [String: DynamoDB.AttributeValue] = [":age": .n("33")]
+                let additionalAttributes = AdditionalAttributes(age: 33)
                 let conditionExpression = "#age = :age"
-                let updateRequest = DynamoDB.UpdateItemCodableInput(additionalAttributeNames: additionalAttributeNames, additionalAttributeValues: additionalAttributeValues, key: ["id"], tableName: tableName, updateItem: nameUpdate)
+                let updateRequest = try DynamoDB.UpdateItemCodableInput(additionalAttributes: additionalAttributes, key: ["id"], tableName: tableName, updateItem: nameUpdate)
                 _ = try await Self.dynamoDB.updateItem(updateRequest, logger: TestEnvironment.logger)
                 XCTFail("Should have thrown error because conditionExpression is not met")
             } catch {


### PR DESCRIPTION
# Description

The current implementation of `DynamoDB.UpdateItemCodableInput` doesn't not allow to implement optimistic locking.
In fact, ConditionExpressions in that struct can compare the current value of a single attribute with a known value.
However, many applications require more complex condition expressions that involve multiple attributes and operators. 
For example, consider the following case:

```
struct Item: Codable {
   let key: String
   let name: String
   let createdAt: String
   let updatedAt: String
}
```

with the current implementation we can update the DynamoDB table in this way:
```
let item = Item(
   key: "9D1DC963-411A-486F-BE26-ADF473F00B80",
   name: "MyItem"
   createdAt: "2023-05-08T18:17:34.972Z",
   updatedAt: "2023-05-11T12:18:41.699Z"
)
let item = try DynamoDB.UpdateItemCodableInput(
            conditionExpression: "attribute_exists(#createdAt)",
            key: [keyName],
            tableName: tableName,
            updateItem: item
        ).createUpdateItemInput()
let _ = try await db.updateItem(input)
```

The previous command has a problem though, there is no way to add a condition on the key and, in a concurrent scenario there is no way to prevent an update if updatedAt field doesn't match with the current value on the DynamoDB table.

Having additionalAttributeNames and additionalAttributeValues as parameter of the `DynamoDB.UpdateItemCodableInput` will allow to write more complex `conditionExpression ` without loosing the flexibility introduced by the generated `expressionAttributeValues` and `expressionAttributeNames`.

```
let item = Item(
   key: "9D1DC963-411A-486F-BE26-ADF473F00B80",
   name: "MyItem"
   createdAt: "2023-05-08T18:17:34.972Z",
   updatedAt: "2023-05-12T12:18:41.699Z"
)
let oldUpdatedAt = "2023-05-11T12:18:41.699Z"
let item = try DynamoDB.UpdateItemCodableInput(
            additionalAttributeNames: ["#keyName": keyName],
            additionalAttributeValues: [":oldUpdatedAt" : .s(oldUpdatedAt)],
            conditionExpression: "attribute_exists(#keyName) AND #updatedAt = :oldUpdatedAt",
            key: [keyName],
            tableName: tableName,
            updateItem: item
        )
let _ = try await db.updateItem(input)
```
The previous update will update the table only if the key exists and the `updateAt` value in the table match the value `oldUpdatedAt` of the request, while the new value is set to `Item.updatedAt`.

In the previous example the `additionalAttributeNames` dictionary will be merged to `expressionAttributeNames` and `additionalAttributeValues` to `expressionAttributeValues`.

# Implementation

- The implementation introduces a non breaking change
- Add `additionalAttributeNames` and `additionalAttributeValues` as nullable in the init method of `DynamoDB.ConditionalUpdateItemCodableInput`.
- In case `expressionAttributeNames` or `updateExpression` are `nil` and  `additionalAttributeNames` is not `nil`, the content of `additionalAttributeNames` will be merged to `expressionAttributeNames` overriding existing keys.
- If `additionalAttributeValues` is not `nil`, the content of `additionalAttributeValues` will be merged to `expressionAttributeValues` overriding existing keys.


