### PR TITLE
Fix additionalAttributeNames in UpdateItemCodableInput by mapping key array

### DIFF
--- a/Sources/Soto/Extensions/DynamoDB/DynamoDB+Codable.swift
+++ b/Sources/Soto/Extensions/DynamoDB/DynamoDB+Codable.swift
@@ -365,7 +365,7 @@ extension DynamoDB {
 
         public init<AdditionalAttributes: Encodable>(additionalAttributes: AdditionalAttributes, conditionExpression: String? = nil, key: [String], returnConsumedCapacity: ReturnConsumedCapacity? = nil, returnItemCollectionMetrics: ReturnItemCollectionMetrics? = nil, returnValues: ReturnValue? = nil, tableName: String, updateItem: T) throws {
             let attributes = try DynamoDBEncoder().encode(additionalAttributes)
-            self.additionalAttributeNames = .init(attributes.keys.map { ("#\($0)", $0) }) { first, _ in return first }
+            self.additionalAttributeNames = .init(key.map { ("#\($0)", $0) }) { first, _ in return first }
             self.additionalAttributeValues = .init(attributes.map { (":\($0.key)", $0.value) }) { first, _ in return first }
             self.conditionExpression = conditionExpression
             self.expressionAttributeNames = nil

--- a/Tests/SotoTests/Services/DynamoDB/DynamoDBCodableTests+async.swift
+++ b/Tests/SotoTests/Services/DynamoDB/DynamoDBCodableTests+async.swift
@@ -108,23 +108,18 @@ final class DynamoDBCodableAsyncTests: XCTestCase {
         let id = UUID().uuidString
         let test = TestObject(id: id, name: "John", surname: "Smith", age: 32, address: "1 Park Lane", pets: ["cat", "dog"])
         let nameUpdate = NameUpdate(id: id, name: "David", surname: "Jones")
-
         let tableName = TestEnvironment.generateResourceName()
         do {
             _ = try await self.createTable(name: tableName)
-
             let putRequest = DynamoDB.PutItemCodableInput(item: test, tableName: tableName)
             _ = try await Self.dynamoDB.putItem(putRequest, logger: TestEnvironment.logger)
-
             let updateRequest = DynamoDB.UpdateItemCodableInput(key: ["id"], tableName: tableName, updateItem: nameUpdate)
             _ = try await Self.dynamoDB.updateItem(updateRequest, logger: TestEnvironment.logger)
-
             let additionalAttributes1 = AdditionalAttributes(oldAge: 32)
             let conditionExpression1 = "attribute_exists(#id) AND #age = :oldAge"
             let nameUpdateWithAge1 = NameUpdateWithAge(id: id, name: "David", surname: "Jones", age: 33)
             let updateRequest1 = try DynamoDB.UpdateItemCodableInput(additionalAttributes: additionalAttributes1, conditionExpression: conditionExpression1, key: ["id"], tableName: tableName, updateItem: nameUpdateWithAge1)
             _ = try await Self.dynamoDB.updateItem(updateRequest1, logger: TestEnvironment.logger)
-    
             do {
                 let additionalAttributes = AdditionalAttributes(oldAge: 34)
                 let conditionExpression = "attribute_exists(#id) AND #age = :oldAge"

--- a/Tests/SotoTests/Services/DynamoDB/DynamoDBCodableTests+async.swift
+++ b/Tests/SotoTests/Services/DynamoDB/DynamoDBCodableTests+async.swift
@@ -135,7 +135,7 @@ final class DynamoDBCodableAsyncTests: XCTestCase {
 
             XCTAssertEqual("David", response.item?.name)
             XCTAssertEqual("Jones", response.item?.surname)
-            XCTAssertEqual(32, response.item?.age)
+            XCTAssertEqual(33, response.item?.age)
             XCTAssertEqual("1 Park Lane", response.item?.address)
             XCTAssertEqual(["cat", "dog"], response.item?.pets)
         } catch {

--- a/Tests/SotoTests/Services/DynamoDB/DynamoDBCodableTests+async.swift
+++ b/Tests/SotoTests/Services/DynamoDB/DynamoDBCodableTests+async.swift
@@ -96,8 +96,14 @@ final class DynamoDBCodableAsyncTests: XCTestCase {
             let name: String
             let surname: String
         }
-        struct AdditionalAttributes: Codable {
+        struct NameUpdateWithAge: Codable {
+            let id: String
+            let name: String
+            let surname: String
             let age: Int
+        }
+        struct AdditionalAttributes: Codable {
+            let oldAge: Int
         }
         let id = UUID().uuidString
         let test = TestObject(id: id, name: "John", surname: "Smith", age: 32, address: "1 Park Lane", pets: ["cat", "dog"])
@@ -113,10 +119,17 @@ final class DynamoDBCodableAsyncTests: XCTestCase {
             let updateRequest = DynamoDB.UpdateItemCodableInput(key: ["id"], tableName: tableName, updateItem: nameUpdate)
             _ = try await Self.dynamoDB.updateItem(updateRequest, logger: TestEnvironment.logger)
 
+            let additionalAttributes1 = AdditionalAttributes(oldAge: 32)
+            let conditionExpression1 = "attribute_exists(#id) AND #age = :oldAge"
+            let nameUpdateWithAge1 = NameUpdateWithAge(id: id, name: "David", surname: "Jones", age: 33)
+            let updateRequest1 = try DynamoDB.UpdateItemCodableInput(additionalAttributes: additionalAttributes1, conditionExpression: conditionExpression1, key: ["id"], tableName: tableName, updateItem: nameUpdateWithAge1)
+            _ = try await Self.dynamoDB.updateItem(updateRequest1, logger: TestEnvironment.logger)
+    
             do {
-                let additionalAttributes = AdditionalAttributes(age: 33)
-                let conditionExpression = "#age = :age"
-                let updateRequest = try DynamoDB.UpdateItemCodableInput(additionalAttributes: additionalAttributes, conditionExpression: conditionExpression, key: ["id"], tableName: tableName, updateItem: nameUpdate)
+                let additionalAttributes = AdditionalAttributes(oldAge: 34)
+                let conditionExpression = "attribute_exists(#id) AND #age = :oldAge"
+                let nameUpdateWithAge = NameUpdateWithAge(id: id, name: "David", surname: "Jones", age: 35)
+                let updateRequest = try DynamoDB.UpdateItemCodableInput(additionalAttributes: additionalAttributes, conditionExpression: conditionExpression, key: ["id"], tableName: tableName, updateItem: nameUpdateWithAge)
                 _ = try await Self.dynamoDB.updateItem(updateRequest, logger: TestEnvironment.logger)
                 XCTFail("Should have thrown error because conditionExpression is not met")
             } catch {


### PR DESCRIPTION
#671 has introduced a new method to initialize UpdateItemCodableInput, but it has introduced an issue.

Consider the following code:
```swift 
private struct AdditionalAttributes: Encodable {
        let keyName: String
        let oldUpdatedAt: String
}
    
func updateItem<T: BreezeCodable>(item: T) async throws -> T {
        var item = item
        let oldUpdatedAt = item.updatedAt ?? ""
        let date = Date()
        item.updatedAt = date.iso8601
        let attributes = AdditionalAttributes(keyName: keyName, oldUpdatedAt: oldUpdatedAt)
        let input = try DynamoDB.UpdateItemCodableInput(
            additionalAttributes: attributes,
            conditionExpression: "attribute_exists(#keyName) AND #updatedAt = :oldUpdatedAt AND #createdAt = :createdAt",
            key: [keyName],
            tableName: tableName,
            updateItem: item
        )
        let _ = try await db.updateItem(input)
        return try await readItem(key: item.key)
}
```

The intention of the previous code is to update the item only when the key exists and when the record to update has the same createdAt and updatedAt data stored in DynamoDB. The update will change updatedAt with a new timestamp. In this way a client that doesn't have the same item cannot update the DynamoDB table and is forced to read the item before an update. (Optimistic locking)

But it leads to the following exception:

```
test_updateItem(): failed: caught error: "ValidationException: Value provided in ExpressionAttributeNames unused in expressions: keys: {#oldUpdatedAt}"
```

To fix the issue the code has be changed to include only the key in additionalAttributeNames and avoiding to add attributes that are not used.

The client code can be fixed by using:
```swift
private struct AdditionalAttributes: Encodable {
        let oldUpdatedAt: String
}
    
func updateItem<T: BreezeCodable>(item: T) async throws -> T {
        var item = item
        let oldUpdatedAt = item.updatedAt ?? ""
        let date = Date()
        item.updatedAt = date.iso8601
        let attributes = AdditionalAttributes(oldUpdatedAt: oldUpdatedAt)
        let input = try DynamoDB.UpdateItemCodableInput(
            additionalAttributes: attributes,
            conditionExpression: "attribute_exists(#\(keyName)) AND #updatedAt = :oldUpdatedAt AND #createdAt = :createdAt",
            key: [keyName],
            tableName: tableName,
            updateItem: item
        )
        let _ = try await db.updateItem(input)
        return try await readItem(key: item.key)
}
```

In the Unit Tests, the optimistic locking has been tested using `id` as key and `age` as condition to validate the record.

An alternative solution could be to add an explicit parameter to additionalAttributeNames.
