### PR TITLE
Add spi yml to fix SPI compatibility test matrix

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -2,3 +2,4 @@ version: 1
 builder:
   configs:
   - target: SotoS3
+    scheme: SotoS3

--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,4 @@
+version: 1
+builder:
+  configs:
+  - target: SotoS3


### PR DESCRIPTION
@adam-fowler as you know we've been unable to complete compatibility tests in SPI from the start, because the builds exceed our 10 min time limit, which leads to this unfortunate display on the package page:

![CleanShot_2024-01-10_at_16 38 362x](https://github.com/soto-project/soto/assets/65520/610360dd-e7bd-4e7d-b1eb-6e691f35f666)

The problem is the large number of targets that are built when we run `swift build` or `xcodebuild build`. I've had the idea that instead of compiling all products, we should instead picking one to represent all. This might not be perfect but should be good enough, particularly if it's a representative target. I've picked `SotoS3` here - would that make sense?