### PR TITLE
Add S3.generatePresignedPost for HTML form based uploads

### DIFF
--- a/Sources/Soto/Extensions/S3/S3+presignedPost.swift
+++ b/Sources/Soto/Extensions/S3/S3+presignedPost.swift
@@ -12,8 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Logging
 import Foundation
+import Logging
 
 import Crypto
 @_spi(SotoInternal) import SotoSignerV4
@@ -48,15 +48,15 @@ extension S3 {
 
         public func encode(to encoder: Encoder) throws {
             switch self {
-                case let .match(field, value):
-                    let condition = [field: value]
-                    var container = encoder.singleValueContainer()
-                    try container.encode(condition)
+            case .match(let field, let value):
+                let condition = [field: value]
+                var container = encoder.singleValueContainer()
+                try container.encode(condition)
 
-                case let .rule(rule, field, value):
-                    let condition = [rule, field, value]
-                    var container = encoder.singleValueContainer()
-                    try container.encode(condition)
+            case .rule(let rule, let field, let value):
+                let condition = [rule, field, value]
+                var container = encoder.singleValueContainer()
+                try container.encode(condition)
             }
         }
     }
@@ -67,15 +67,15 @@ extension S3 {
         let fields: [String: String]
     }
 
-    ///  Builds the url and the form fields used for a presigned s3 post 
+    ///  Builds the url and the form fields used for a presigned s3 post
     /// - Parameters:
-    ///   - key: Key name, optionally add ${filename} to the end to attach the submitted filename. Note that key related conditions and fields are filled out for you and should not be included in the Fields or Conditions parameter. 
+    ///   - key: Key name, optionally add ${filename} to the end to attach the submitted filename. Note that key related conditions and fields are filled out for you and should not be included in the Fields or Conditions parameter.
     ///   - bucket: The name of the bucket to presign the post to. Note that bucket related conditions should not be included in the conditions parameter.
     ///   - fields: A dictionary of prefilled form fields to build on top of. Elements that may be included are acl, Cache-Control, Content-Type, Content-Disposition, Content-Encoding, Expires, success_action_redirect, redirect, success_action_status, and x-amz-meta-.
-    /// 
+    ///
     ///     Note that if a particular element is included in the fields dictionary it will not be automatically added to the conditions list. You must specify a condition for the element as well.
     ///   - conditions: A list of conditions to include in the policy. Each element can be either a match or a rule. For example:
-    /// 
+    ///
     ///     ```
     ///     [
     ///         .match("acl", "public-read"), .rule("content-length-range", "2", "5"), .rule("starts-with", "$success_action_redirect", "")
@@ -125,8 +125,8 @@ extension S3 {
         // Gather canonical values
         let algorithm = "AWS4-HMAC-SHA256" // Get signature version from client?
 
-        let longDate = longDateFormat(date: date)
-        let shortDate = shortDateFormat(date: date)
+        let longDate = self.longDateFormat(date: date)
+        let shortDate = self.shortDateFormat(date: date)
 
         let clientCredentials = try await client.getCredential()
         let presignedPostCredential = try await getPresignedPostCredential(date: shortDate, accessKeyId: clientCredentials.accessKeyId)
@@ -160,7 +160,7 @@ extension S3 {
         fields["Policy"] = stringToSign
 
         // Create the signature and add to fields
-        let signingKey = try await signingKey(date: shortDate, secretAccessKey: clientCredentials.secretAccessKey))
+        let signingKey = try await signingKey(date: shortDate, secretAccessKey: clientCredentials.secretAccessKey)
         let signature = try await getSignature(policy: stringToSign, signingKey: signingKey)
         fields["x-amz-signature"] = signature
 
@@ -212,5 +212,4 @@ extension S3 {
 
         return dateFormatter.string(from: date)
     }
-
 }

--- a/Sources/Soto/Extensions/S3/S3+presignedPost.swift
+++ b/Sources/Soto/Extensions/S3/S3+presignedPost.swift
@@ -50,8 +50,26 @@ extension S3 {
         let fields: [String: String]
     }
 
+    ///  Builds the url and the form fields used for a presigned s3 post 
+    /// - Parameters:
+    ///   - key: Key name, optionally add ${filename} to the end to attach the submitted filename. Note that key related conditions and fields are filled out for you and should not be included in the Fields or Conditions parameter. 
+    ///   - bucket: The name of the bucket to presign the post to. Note that bucket related conditions should not be included in the conditions parameter.
+    ///   - fields: A dictionary of prefilled form fields to build on top of. Elements that may be included are acl, Cache-Control, Content-Type, Content-Disposition, Content-Encoding, Expires, success_action_redirect, redirect, success_action_status, and x-amz-meta-.
     /// 
-    @Sendable
+    ///     Note that if a particular element is included in the fields dictionary it will not be automatically added to the conditions list. You must specify a condition for the element as well.
+    ///   - conditions: A list of conditions to include in the policy. Each element can be either a match or a rule. For example:
+    /// 
+    ///     ```
+    ///     [
+    ///         .match("acl", "public-read"), .rule("content-length-range", "2", "5"), .rule("starts-with", "$success_action_redirect", "")
+    ///     ]
+    ///     ```
+    ///
+    ///     Conditions that are included may pertain to acl, content-length-range, Cache-Control, Content-Type, Content-Disposition, Content-Encoding, Expires, success_action_redirect, redirect, success_action_status, and/or x-amz-meta-.
+    ///
+    ///     Note that if you include a condition, you must specify the a valid value in the fields dictionary as well. A value will not be added automatically to the fields dictionary based on the conditions.
+    ///   - expiresIn: The number of seconds the presigned post is valid for.
+    /// - Returns: An encodable PresignedPostResponse with two properties: url and fields. Url is the url to post to. Fields is a dictionary filled with the form fields and respective values to use when submitting the post.
     public func generatePresignedPost(key: String, bucket: String, fields: [String: String] = [:], conditions: [PostPolicyCondition] = [], expiresIn: TimeInterval) async throws -> PresignedPostResponse {
         // Copy the fields and conditions to a variable
         var fields = fields

--- a/Sources/Soto/Extensions/S3/S3+presignedPost.swift
+++ b/Sources/Soto/Extensions/S3/S3+presignedPost.swift
@@ -1,0 +1,96 @@
+import Crypto
+
+extension S3 {
+    public struct PostPolicy: Encodable {
+        let expiration: Date
+        let conditions: [PostPolicyCondition]
+
+        func stringToSign() -> String {
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            let policyData = try? encoder.encode(self)
+            guard let base64encoded = policyData?.base64EncodedString() else {
+                // Couldn't make a string to sign
+            }
+
+            return base64encoded
+        }
+    }
+
+    public enum PostPolicyCondition: Encodable {
+        case match(String, String)
+        case rule(String, String, String)
+
+        public func encode(to encoder: Encoder) throws {
+            switch self {
+                case let .match(field, value):
+                    let condition = [field: value]
+                    var container = encoder.singleValueContainer()
+                    try container.encode(condition)
+
+                case let .rule(rule, field, value):
+                    let condition = [rule, field, value]
+                    var container = encoder.singleValueContainer()
+                    try container.encode(condition)
+            }
+        }
+    }
+
+    public struct PresignedPostResponse: Encodable {
+        let url: URL
+        let fields: [String: String]
+    }
+
+    /// 
+    @Sendable
+    public func generatePresignedPost(key: String, bucket: String, fields: [String: String] = [:], conditions: [PostPolicyCondition] = []) -> PresignedPostResponse {
+        // Copy the fields and conditions to a variable
+        var fields = fields
+        var conditions = conditions
+
+        // Gather canonical values
+        let url = URL(from: self.config.endpoint)
+        let algorithm = "AWS4-HMAC-SHA256" // Get signature version from client?
+        let date = Date.now
+
+        // Add required conditions
+        conditions.append(.match("bucket", bucket))
+        conditions.append(.match("key", key))
+        conditions.append(.match("x-amz-algorithm", algorithm))
+        conditions.append(.match("x-amz-date", "")) // TODO
+        conditions.append(.match("x-amz-credential", "")) // TODO
+
+        // Add required fields
+        fields["key"] = key
+        fields["x-amz-algorithm"] = algorithm
+        fields["x-amz-date"] = "" // TODO
+        fields["x-amz-credential"] = "" // TODO
+
+        // Create the policy and add to fields
+        let policy = PostPolicy(expiration: Date(), conditions: conditions)
+        let stringToSign = policy.stringToSign()
+        fields["Policy"] = stringToSign
+
+        // Create the signature and add to fields
+        let signature = getSignature(policy: stringToSign)
+        fields["x-amz-signature"] = signature
+
+        // Create the response
+        let presignedPostResponse = PresignedPostResponse(url: url, fields: fields)
+
+        return presignedPostResponse
+    }
+
+    private func getSigningKey() -> SymmetricKey {
+
+    }
+
+    private func getSignature(policy: String) -> String {
+        return ""
+    }
+
+    private func getCredential() -> String {
+        return ""
+    }
+
+}

--- a/Sources/Soto/Extensions/S3/S3+presignedPost.swift
+++ b/Sources/Soto/Extensions/S3/S3+presignedPost.swift
@@ -128,7 +128,7 @@ extension S3 {
     }
 
     // Private API adds date argument for testing
-    private func generatePresignedPost(
+    func generatePresignedPost(
         key: String,
         bucket: String,
         fields: [String: String] = [:],
@@ -206,7 +206,7 @@ extension S3 {
         return presignedPostResponse
     }
 
-    private func signingKey(date: String, secretAccessKey: String) async throws -> SymmetricKey {
+    func signingKey(date: String, secretAccessKey: String) async throws -> SymmetricKey {
         let credentials = try await client.getCredential()
         let name = config.signingName
         let region = config.region.rawValue
@@ -218,12 +218,12 @@ extension S3 {
         return SymmetricKey(data: kSigning)
     }
 
-    private func getSignature(policy: String, signingKey key: SymmetricKey) async throws -> String {
+    func getSignature(policy: String, signingKey key: SymmetricKey) async throws -> String {
         let signature = HMAC<SHA256>.authenticationCode(for: [UInt8](policy.utf8), using: key).hexDigest()
         return signature
     }
 
-    private func getPresignedPostCredential(date: String, accessKeyId: String) async throws -> String {
+    func getPresignedPostCredential(date: String, accessKeyId: String) async throws -> String {
         let region = config.region.rawValue
         let service = config.signingName
 

--- a/Sources/Soto/Extensions/S3/S3+presignedPost.swift
+++ b/Sources/Soto/Extensions/S3/S3+presignedPost.swift
@@ -1,3 +1,16 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Soto for AWS open source project
+//
+// Copyright (c) 2017-2021 the Soto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Soto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
 
 import Logging
 import Foundation

--- a/Sources/Soto/Extensions/S3/S3+presignedPost.swift
+++ b/Sources/Soto/Extensions/S3/S3+presignedPost.swift
@@ -166,7 +166,7 @@ extension S3 {
         let shortDate = self.shortDateFormat(date: date)
 
         let clientCredentials = try await client.getCredential()
-        let presignedPostCredential = getPresignedPostCredential(date: shortDate, accessKeyId: clientCredentials.accessKeyId)
+        let presignedPostCredential = self.getPresignedPostCredential(date: shortDate, accessKeyId: clientCredentials.accessKeyId)
 
         var keyCondition: PostPolicyCondition
         let suffix = "${filename}"
@@ -197,7 +197,7 @@ extension S3 {
 
         // Create the signature and add to fields
         let signingKey = signingKey(date: shortDate, secretAccessKey: clientCredentials.secretAccessKey)
-        let signature = getSignature(policy: stringToSign, signingKey: signingKey)
+        let signature = self.getSignature(policy: stringToSign, signingKey: signingKey)
         fields["x-amz-signature"] = signature
 
         // Create the response

--- a/Sources/Soto/Extensions/S3/S3+presignedPost.swift
+++ b/Sources/Soto/Extensions/S3/S3+presignedPost.swift
@@ -123,7 +123,7 @@ extension S3 {
             fields: fields,
             conditions: conditions,
             expiresIn: expiresIn,
-            date: Date.now
+            date: Date()
         )
     }
 
@@ -134,7 +134,7 @@ extension S3 {
         fields: [String: String] = [:],
         conditions: [PostPolicyCondition] = [],
         expiresIn: TimeInterval,
-        date: Date = Date.now
+        date: Date = Date()
     ) async throws -> PresignedPostResponse {
         // Copy the fields and conditions to a variable
         var fields = fields

--- a/Sources/Soto/Extensions/S3/S3+presignedPost.swift
+++ b/Sources/Soto/Extensions/S3/S3+presignedPost.swift
@@ -43,31 +43,35 @@ extension S3 {
 
     /// 
     @Sendable
-    public func generatePresignedPost(key: String, bucket: String, fields: [String: String] = [:], conditions: [PostPolicyCondition] = []) -> PresignedPostResponse {
+    public func generatePresignedPost(key: String, bucket: String, fields: [String: String] = [:], conditions: [PostPolicyCondition] = [], expiresIn: TimeInterval) -> PresignedPostResponse {
         // Copy the fields and conditions to a variable
         var fields = fields
         var conditions = conditions
 
+        // Update endpoint URL to include the bucket
+        var url = URL(from: self.config.endpoint)
+        url.host = [bucket, url.host].joined(separator: ".")
+
         // Gather canonical values
-        let url = URL(from: self.config.endpoint)
         let algorithm = "AWS4-HMAC-SHA256" // Get signature version from client?
         let date = Date.now
+        let region = self.config.region
 
         // Add required conditions
         conditions.append(.match("bucket", bucket))
         conditions.append(.match("key", key))
         conditions.append(.match("x-amz-algorithm", algorithm))
         conditions.append(.match("x-amz-date", "")) // TODO
-        conditions.append(.match("x-amz-credential", "")) // TODO
+        conditions.append(.match("x-amz-credential", getCredential()))
 
         // Add required fields
         fields["key"] = key
         fields["x-amz-algorithm"] = algorithm
         fields["x-amz-date"] = "" // TODO
-        fields["x-amz-credential"] = "" // TODO
+        fields["x-amz-credential"] = getCredential()
 
         // Create the policy and add to fields
-        let policy = PostPolicy(expiration: Date(), conditions: conditions)
+        let policy = PostPolicy(expiration: date.adding(expiresIn), conditions: conditions)
         let stringToSign = policy.stringToSign()
         fields["Policy"] = stringToSign
 
@@ -81,16 +85,34 @@ extension S3 {
         return presignedPostResponse
     }
 
-    private func getSigningKey() -> SymmetricKey {
+    private func signingKey(date: String) -> SymmetricKey {
+        let credentials = await client.credentialProvider.getCredential()
+        let name = client.config.name
+        let region = client.config.region
 
+        let kDate = HMAC<SHA256>.authenticationCode(for: [UInt8](date.utf8), using: SymmetricKey(data: Array("AWS4\(credentials.secretAccessKey)".utf8)))
+        let kRegion = HMAC<SHA256>.authenticationCode(for: [UInt8](region.utf8), using: SymmetricKey(data: kDate))
+        let kService = HMAC<SHA256>.authenticationCode(for: [UInt8](name.utf8), using: SymmetricKey(data: kRegion))
+        let kSigning = HMAC<SHA256>.authenticationCode(for: [UInt8]("aws4_request".utf8), using: SymmetricKey(data: kService))
+        return SymmetricKey(data: kSigning)
     }
 
-    private func getSignature(policy: String) -> String {
-        return ""
+    private func getSignature(policy: String, date: String) -> String {
+        let key = signingKey(date: date)
+        let signature = HMAC<SHA256>.authenticationCode(for: Data(stringToSign.utf8), using: key)
+        return signature
     }
 
     private func getCredential() -> String {
-        return ""
+        let credentials = await client.credentialProvider.getCredential()
+
+        let accessKeyID = credentials.accessKeyID
+        let date = date
+        let region = config.region
+        let service = config.name
+
+        let credential = "\(accessKeyID)/\(date)/\(region)/\(service)"
+        return credential
     }
 
 }

--- a/Sources/Soto/Extensions/S3/S3+presignedPost.swift
+++ b/Sources/Soto/Extensions/S3/S3+presignedPost.swift
@@ -231,20 +231,31 @@ extension S3 {
     }
 
     private func shortDateFormat(date: Date) -> String {
-        let dateFormatter = DateFormatter()
-        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
-        dateFormatter.dateFormat = "yyyyMMdd"
-        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions.insert(.withYear)
+        formatter.formatOptions.insert(.withMonth)
+        formatter.formatOptions.insert(.withDay)
+        formatter.formatOptions.remove(.withTime)
+        formatter.formatOptions.remove(.withTimeZone)
+        formatter.formatOptions.remove(.withDashSeparatorInDate)
 
-        return dateFormatter.string(from: date)
+        let formattedDate = formatter.string(from: date)
+
+        return formattedDate
     }
 
     private func longDateFormat(date: Date) -> String {
-        let dateFormatter = DateFormatter()
-        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
-        dateFormatter.dateFormat = "yyyyMMdd'T'HHmmss'Z'"
-        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions.insert(.withYear)
+        formatter.formatOptions.insert(.withMonth)
+        formatter.formatOptions.insert(.withDay)
+        formatter.formatOptions.insert(.withTime)
+        formatter.formatOptions.insert(.withTimeZone)
+        formatter.formatOptions.remove(.withDashSeparatorInDate)
+        formatter.formatOptions.remove(.withColonSeparatorInTime)
 
-        return dateFormatter.string(from: date)
+        let formattedDate = formatter.string(from: date)
+
+        return formattedDate
     }
 }

--- a/Sources/Soto/Extensions/S3/S3+presignedPost.swift
+++ b/Sources/Soto/Extensions/S3/S3+presignedPost.swift
@@ -12,6 +12,7 @@ extension S3ErrorType {
 }
 
 extension S3 {
+    /// An encodable struct that represents acceptable values for the fields supplied in a presigned POST request
     public struct PostPolicy: Encodable {
         let expiration: Date
         let conditions: [PostPolicyCondition]
@@ -26,6 +27,7 @@ extension S3 {
         }
     }
 
+    /// A condition for use in a PostPolicy, which can represent an exact match on the value for a particular field, or a rule that allows for other types of matches, eg. "starts-with"
     public enum PostPolicyCondition: Encodable {
         case match(String, String)
         case rule(String, String, String)
@@ -45,6 +47,7 @@ extension S3 {
         }
     }
 
+    /// An encodable struct that represents the URL and form fields to use in a presigned POST request to S3
     public struct PresignedPostResponse: Encodable {
         let url: URL
         let fields: [String: String]

--- a/Sources/Soto/Services/S3/S3_api.swift
+++ b/Sources/Soto/Services/S3/S3_api.swift
@@ -513,6 +513,35 @@ public struct S3: AWSService {
         )
     }
 
+    enum S3PostCondition: Encodable {
+        case match(String, String)
+        case rule(String, String, String)
+
+        public func encode(to encoder: Encoder) throws {
+            switch self {
+                case let .rule(rule, field, value):
+                    let condition = [rule, field, value]
+                    var container = encoder.singleValueContainer()
+                    try container.encode(condition)
+
+                case let .match(field, value):
+                    let condition = [field: value]
+                    var container = encoder.singleValueContainer()
+                    try container.encode(condition)
+            }
+        }
+    }
+
+    public struct S3PresignedPost: Encodable {
+        let expiration: Date
+        let conditions: [S3PostCondition]
+    }
+
+    @Sendable
+    public func generatePresignedPost(key: String, bucket: String, fields: [String: String] = [:], conditions: [S3PostCondition]) -> S3PresignedPost {
+       // TODO: Implement the function 
+    }
+
     ///  This operation is not supported by directory buckets.  This implementation of the GET action uses the accelerate subresource to return the Transfer Acceleration state of a bucket, which is either Enabled or Suspended. Amazon S3 Transfer Acceleration is a bucket-level feature that enables you to perform faster data transfers to and from Amazon S3. To use this operation, you must have permission to perform the s3:GetAccelerateConfiguration action. The bucket owner has this permission by default. The bucket owner can grant this permission to others. For more information about permissions, see Permissions Related to Bucket Subresource Operations and Managing Access Permissions to your Amazon S3 Resources in the Amazon S3 User Guide. You set the Transfer Acceleration state of an existing bucket to Enabled or Suspended by using the PutBucketAccelerateConfiguration operation.  A GET accelerate request does not return a state value for a bucket that has no transfer acceleration state. A bucket has no Transfer Acceleration state if a state has never been set on the bucket.  For more information about transfer acceleration, see Transfer Acceleration in the Amazon S3 User Guide. The following operations are related to GetBucketAccelerateConfiguration:    PutBucketAccelerateConfiguration
     @Sendable
     public func getBucketAccelerateConfiguration(_ input: GetBucketAccelerateConfigurationRequest, logger: Logger = AWSClient.loggingDisabled) async throws -> GetBucketAccelerateConfigurationOutput {

--- a/Sources/Soto/Services/S3/S3_api.swift
+++ b/Sources/Soto/Services/S3/S3_api.swift
@@ -513,35 +513,6 @@ public struct S3: AWSService {
         )
     }
 
-    enum S3PostCondition: Encodable {
-        case match(String, String)
-        case rule(String, String, String)
-
-        public func encode(to encoder: Encoder) throws {
-            switch self {
-                case let .rule(rule, field, value):
-                    let condition = [rule, field, value]
-                    var container = encoder.singleValueContainer()
-                    try container.encode(condition)
-
-                case let .match(field, value):
-                    let condition = [field: value]
-                    var container = encoder.singleValueContainer()
-                    try container.encode(condition)
-            }
-        }
-    }
-
-    public struct S3PresignedPost: Encodable {
-        let expiration: Date
-        let conditions: [S3PostCondition]
-    }
-
-    @Sendable
-    public func generatePresignedPost(key: String, bucket: String, fields: [String: String] = [:], conditions: [S3PostCondition]) -> S3PresignedPost {
-       // TODO: Implement the function 
-    }
-
     ///  This operation is not supported by directory buckets.  This implementation of the GET action uses the accelerate subresource to return the Transfer Acceleration state of a bucket, which is either Enabled or Suspended. Amazon S3 Transfer Acceleration is a bucket-level feature that enables you to perform faster data transfers to and from Amazon S3. To use this operation, you must have permission to perform the s3:GetAccelerateConfiguration action. The bucket owner has this permission by default. The bucket owner can grant this permission to others. For more information about permissions, see Permissions Related to Bucket Subresource Operations and Managing Access Permissions to your Amazon S3 Resources in the Amazon S3 User Guide. You set the Transfer Acceleration state of an existing bucket to Enabled or Suspended by using the PutBucketAccelerateConfiguration operation.  A GET accelerate request does not return a state value for a bucket that has no transfer acceleration state. A bucket has no Transfer Acceleration state if a state has never been set on the bucket.  For more information about transfer acceleration, see Transfer Acceleration in the Amazon S3 User Guide. The following operations are related to GetBucketAccelerateConfiguration:    PutBucketAccelerateConfiguration
     @Sendable
     public func getBucketAccelerateConfiguration(_ input: GetBucketAccelerateConfigurationRequest, logger: Logger = AWSClient.loggingDisabled) async throws -> GetBucketAccelerateConfigurationOutput {

--- a/Tests/SotoTests/Services/S3/S3ExtensionTests.swift
+++ b/Tests/SotoTests/Services/S3/S3ExtensionTests.swift
@@ -420,22 +420,52 @@ extension S3Tests {
 
         let presignedPost = try await s3.generatePresignedPost(key: "user/user1/${filename}", bucket: "sigv4examplebucket", fields: fields, conditions: conditions, expiresIn: expiresIn, date: date)
 
-        let expectedPolicy = "eyAiZXhwaXJhdGlvbiI6ICIyMDE1LTEyLTMwVDEyOjAwOjAwLjAwMFoiLA0KICAiY29uZGl0aW9ucyI6IFsNCiAgICB7ImJ1Y2tldCI6ICJzaWd2NGV4YW1wbGVidWNrZXQifSwNCiAgICBbInN0YXJ0cy13aXRoIiwgIiRrZXkiLCAidXNlci91c2VyMS8iXSwNCiAgICB7ImFjbCI6ICJwdWJsaWMtcmVhZCJ9LA0KICAgIHsic3VjY2Vzc19hY3Rpb25fcmVkaXJlY3QiOiAiaHR0cDovL3NpZ3Y0ZXhhbXBsZWJ1Y2tldC5zMy5hbWF6b25hd3MuY29tL3N1Y2Nlc3NmdWxfdXBsb2FkLmh0bWwifSwNCiAgICBbInN0YXJ0cy13aXRoIiwgIiRDb250ZW50LVR5cGUiLCAiaW1hZ2UvIl0sDQogICAgeyJ4LWFtei1tZXRhLXV1aWQiOiAiMTQzNjUxMjM2NTEyNzQifSwNCiAgICB7IngtYW16LXNlcnZlci1zaWRlLWVuY3J5cHRpb24iOiAiQUVTMjU2In0sDQogICAgWyJzdGFydHMtd2l0aCIsICIkeC1hbXotbWV0YS10YWciLCAiIl0sDQoNCiAgICB7IngtYW16LWNyZWRlbnRpYWwiOiAiQUtJQUlPU0ZPRE5ON0VYQU1QTEUvMjAxNTEyMjkvdXMtZWFzdC0xL3MzL2F3czRfcmVxdWVzdCJ9LA0KICAgIHsieC1hbXotYWxnb3JpdGhtIjogIkFXUzQtSE1BQy1TSEEyNTYifSwNCiAgICB7IngtYW16LWRhdGUiOiAiMjAxNTEyMjlUMDAwMDAwWiIgfQ0KICBdDQp9"
-        let expectedSignature = "8afdbf4008c03f22c2cd3cdb72e4afbb1f6a588f3255ac628749a66d7f09699e"
         let expectedURL = "https://sigv4examplebucket.s3.us-east-1.amazonaws.com"
         let expectedCredential = "AKIAIOSFODNN7EXAMPLE/20151229/us-east-1/s3/aws4_request"
         let expectedAlgorithm = "AWS4-HMAC-SHA256"
         let expectedDate = "20151229T000000Z"
 
         XCTAssertEqual(presignedPost.url, URL(string: expectedURL))
-        XCTAssertEqual(presignedPost.fields["x-amz-signature"], expectedSignature)
-        XCTAssertEqual(presignedPost.fields["Policy"], expectedPolicy)
         XCTAssertEqual(presignedPost.fields["x-amz-credential"], expectedCredential)
         XCTAssertEqual(presignedPost.fields["x-amz-algorithm"], expectedAlgorithm)
         XCTAssertEqual(presignedPost.fields["x-amz-date"], expectedDate)
 
-        // Boto3 Output
-        // {'url': 'https://sigv4examplebucket.s3.amazonaws.com/', 'fields': {'acl': 'public-read', 'success_action_redirect': 'http://sigv4examplebucket.s3.amazonaws.com/successful_upload.html', 'x-amz-meta-uuid': '14365123651274', 'x-amz-server-side-encryption': 'AES256', 'key': 'user/user1/${filename}', 'AWSAccessKeyId': 'AKIAIOSFODNN7EXAMPLE', 'policy': 'eyJleHBpcmF0aW9uIjogIjIwMjQtMDQtMDJUMDM6NTE6MDBaIiwgImNvbmRpdGlvbnMiOiBbeyJhY2wiOiAicHVibGljLXJlYWQifSwgeyJzdWNjZXNzX2FjdGlvbl9yZWRpcmVjdCI6ICJodHRwOi8vc2lndjRleGFtcGxlYnVja2V0LnMzLmFtYXpvbmF3cy5jb20vc3VjY2Vzc2Z1bF91cGxvYWQuaHRtbCJ9LCB7IngtYW16LW1ldGEtdXVpZCI6ICIxNDM2NTEyMzY1MTI3NCJ9LCB7IngtYW16LXNlcnZlci1zaWRlLWVuY3J5cHRpb24iOiAiQUVTMjU2In0sIFsic3RhcnRzLXdpdGgiLCAiJENvbnRlbnQtVHlwZSIsICJpbWFnZS8iXSwgWyJzdGFydHMtd2l0aCIsICIkeC1hbXotbWV0YS10YWciLCAiIl0sIHsiYnVja2V0IjogInNpZ3Y0ZXhhbXBsZWJ1Y2tldCJ9LCBbInN0YXJ0cy13aXRoIiwgIiRrZXkiLCAidXNlci91c2VyMS8iXV19', 'signature': 'sSXUD8RpSI7x/Vo/SJ0vTtc98Qo='}
+        XCTAssertNotNil(presignedPost.fields["x-amz-signature"])
+        XCTAssertNotNil(presignedPost.fields["Policy"])
+    }
+
+    func testGetSignature() async throws {
+        // Based on the example here: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-post-example.html
+
+        // Credentials are example only, from the above documentation
+        let client = AWSClient(credentialProvider: .static(accessKeyId: "AKIAIOSFODNN7EXAMPLE", secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"), httpClientProvider: .createNew)
+        let s3 = S3(client: client, region: .useast1)
+
+        defer { try? client.syncShutdown() }
+
+        let policy = "eyAiZXhwaXJhdGlvbiI6ICIyMDE1LTEyLTMwVDEyOjAwOjAwLjAwMFoiLA0KICAiY29uZGl0aW9ucyI6IFsNCiAgICB7ImJ1Y2tldCI6ICJzaWd2NGV4YW1wbGVidWNrZXQifSwNCiAgICBbInN0YXJ0cy13aXRoIiwgIiRrZXkiLCAidXNlci91c2VyMS8iXSwNCiAgICB7ImFjbCI6ICJwdWJsaWMtcmVhZCJ9LA0KICAgIHsic3VjY2Vzc19hY3Rpb25fcmVkaXJlY3QiOiAiaHR0cDovL3NpZ3Y0ZXhhbXBsZWJ1Y2tldC5zMy5hbWF6b25hd3MuY29tL3N1Y2Nlc3NmdWxfdXBsb2FkLmh0bWwifSwNCiAgICBbInN0YXJ0cy13aXRoIiwgIiRDb250ZW50LVR5cGUiLCAiaW1hZ2UvIl0sDQogICAgeyJ4LWFtei1tZXRhLXV1aWQiOiAiMTQzNjUxMjM2NTEyNzQifSwNCiAgICB7IngtYW16LXNlcnZlci1zaWRlLWVuY3J5cHRpb24iOiAiQUVTMjU2In0sDQogICAgWyJzdGFydHMtd2l0aCIsICIkeC1hbXotbWV0YS10YWciLCAiIl0sDQoNCiAgICB7IngtYW16LWNyZWRlbnRpYWwiOiAiQUtJQUlPU0ZPRE5ON0VYQU1QTEUvMjAxNTEyMjkvdXMtZWFzdC0xL3MzL2F3czRfcmVxdWVzdCJ9LA0KICAgIHsieC1hbXotYWxnb3JpdGhtIjogIkFXUzQtSE1BQy1TSEEyNTYifSwNCiAgICB7IngtYW16LWRhdGUiOiAiMjAxNTEyMjlUMDAwMDAwWiIgfQ0KICBdDQp9"
+        let signingKey = try await s3.signingKey(date: "20151229", secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+        let signature = try await s3.getSignature(policy: policy, signingKey: signingKey)
+        
+        let expectedSignature = "8afdbf4008c03f22c2cd3cdb72e4afbb1f6a588f3255ac628749a66d7f09699e"
+
+        XCTAssertEqual(signature, expectedSignature)
+    }
+
+    func testGetPresignedPostCredential() async throws {
+        // Based on the example here: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-post-example.html
+
+        // Credentials are example only, from the above documentation
+        let client = AWSClient(credentialProvider: .static(accessKeyId: "AKIAIOSFODNN7EXAMPLE", secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"), httpClientProvider: .createNew)
+        let s3 = S3(client: client, region: .useast1)
+
+        defer { try? client.syncShutdown() }
+
+        let credential = try await s3.getPresignedPostCredential(date: "20151229", accessKeyId: "AKIAIOSFODNN7EXAMPLE")
+        
+        let expectedCredential = "AKIAIOSFODNN7EXAMPLE/20151229/us-east-1/s3/aws4_request"
+
+        XCTAssertEqual(credential, expectedCredential)
     }
 
 }

--- a/Tests/SotoTests/Services/S3/S3ExtensionTests.swift
+++ b/Tests/SotoTests/Services/S3/S3ExtensionTests.swift
@@ -420,19 +420,21 @@ extension S3Tests {
 
         let expectedPolicy = "eyAiZXhwaXJhdGlvbiI6ICIyMDE1LTEyLTMwVDEyOjAwOjAwLjAwMFoiLA0KICAiY29uZGl0aW9ucyI6IFsNCiAgICB7ImJ1Y2tldCI6ICJzaWd2NGV4YW1wbGVidWNrZXQifSwNCiAgICBbInN0YXJ0cy13aXRoIiwgIiRrZXkiLCAidXNlci91c2VyMS8iXSwNCiAgICB7ImFjbCI6ICJwdWJsaWMtcmVhZCJ9LA0KICAgIHsic3VjY2Vzc19hY3Rpb25fcmVkaXJlY3QiOiAiaHR0cDovL3NpZ3Y0ZXhhbXBsZWJ1Y2tldC5zMy5hbWF6b25hd3MuY29tL3N1Y2Nlc3NmdWxfdXBsb2FkLmh0bWwifSwNCiAgICBbInN0YXJ0cy13aXRoIiwgIiRDb250ZW50LVR5cGUiLCAiaW1hZ2UvIl0sDQogICAgeyJ4LWFtei1tZXRhLXV1aWQiOiAiMTQzNjUxMjM2NTEyNzQifSwNCiAgICB7IngtYW16LXNlcnZlci1zaWRlLWVuY3J5cHRpb24iOiAiQUVTMjU2In0sDQogICAgWyJzdGFydHMtd2l0aCIsICIkeC1hbXotbWV0YS10YWciLCAiIl0sDQoNCiAgICB7IngtYW16LWNyZWRlbnRpYWwiOiAiQUtJQUlPU0ZPRE5ON0VYQU1QTEUvMjAxNTEyMjkvdXMtZWFzdC0xL3MzL2F3czRfcmVxdWVzdCJ9LA0KICAgIHsieC1hbXotYWxnb3JpdGhtIjogIkFXUzQtSE1BQy1TSEEyNTYifSwNCiAgICB7IngtYW16LWRhdGUiOiAiMjAxNTEyMjlUMDAwMDAwWiIgfQ0KICBdDQp9"
         let expectedSignature = "8afdbf4008c03f22c2cd3cdb72e4afbb1f6a588f3255ac628749a66d7f09699e"
-        let expectedURL = "https://sigv4examplebucket.s3.us-east-1.amazonaws.com/"
+        let expectedURL = "https://sigv4examplebucket.s3.us-east-1.amazonaws.com"
         let expectedCredential = "AKIAIOSFODNN7EXAMPLE/20151229/us-east-1/s3/aws4_request"
         let expectedAlgorithm = "AWS4-HMAC-SHA256"
         let expectedDate = "20151229T000000Z"
 
         XCTAssertEqual(presignedPost.url, URL(string: expectedURL))
-        XCTAssertEqual(presignedPost.fields["Policy"], expectedPolicy)
         XCTAssertEqual(presignedPost.fields["x-amz-signature"], expectedSignature)
+        XCTAssertEqual(presignedPost.fields["Policy"], expectedPolicy)
         XCTAssertEqual(presignedPost.fields["x-amz-credential"], expectedCredential)
         XCTAssertEqual(presignedPost.fields["x-amz-algorithm"], expectedAlgorithm)
         XCTAssertEqual(presignedPost.fields["x-amz-date"], expectedDate)
 
         try? await client.shutdown()
+        // Boto3 Output
+        // {'url': 'https://sigv4examplebucket.s3.amazonaws.com/', 'fields': {'acl': 'public-read', 'success_action_redirect': 'http://sigv4examplebucket.s3.amazonaws.com/successful_upload.html', 'x-amz-meta-uuid': '14365123651274', 'x-amz-server-side-encryption': 'AES256', 'key': 'user/user1/${filename}', 'AWSAccessKeyId': 'AKIAIOSFODNN7EXAMPLE', 'policy': 'eyJleHBpcmF0aW9uIjogIjIwMjQtMDQtMDJUMDM6NTE6MDBaIiwgImNvbmRpdGlvbnMiOiBbeyJhY2wiOiAicHVibGljLXJlYWQifSwgeyJzdWNjZXNzX2FjdGlvbl9yZWRpcmVjdCI6ICJodHRwOi8vc2lndjRleGFtcGxlYnVja2V0LnMzLmFtYXpvbmF3cy5jb20vc3VjY2Vzc2Z1bF91cGxvYWQuaHRtbCJ9LCB7IngtYW16LW1ldGEtdXVpZCI6ICIxNDM2NTEyMzY1MTI3NCJ9LCB7IngtYW16LXNlcnZlci1zaWRlLWVuY3J5cHRpb24iOiAiQUVTMjU2In0sIFsic3RhcnRzLXdpdGgiLCAiJENvbnRlbnQtVHlwZSIsICJpbWFnZS8iXSwgWyJzdGFydHMtd2l0aCIsICIkeC1hbXotbWV0YS10YWciLCAiIl0sIHsiYnVja2V0IjogInNpZ3Y0ZXhhbXBsZWJ1Y2tldCJ9LCBbInN0YXJ0cy13aXRoIiwgIiRrZXkiLCAidXNlci91c2VyMS8iXV19', 'signature': 'sSXUD8RpSI7x/Vo/SJ0vTtc98Qo='}
     }
 
 }

--- a/Tests/SotoTests/Services/S3/S3ExtensionTests.swift
+++ b/Tests/SotoTests/Services/S3/S3ExtensionTests.swift
@@ -418,7 +418,7 @@ extension S3Tests {
 
         let date = Calendar(identifier: .gregorian).date(from: dateComponents)!
 
-        let presignedPost = try await s3.generatePresignedPost(key: "user/user1/${filename}", bucket: "sigv4examplebucket", fields: fields, conditions: conditions, expiresIn: expiresIn, now: date)
+        let presignedPost = try await s3.generatePresignedPost(key: "user/user1/${filename}", bucket: "sigv4examplebucket", fields: fields, conditions: conditions, expiresIn: expiresIn, date: date)
 
         let expectedPolicy = "eyAiZXhwaXJhdGlvbiI6ICIyMDE1LTEyLTMwVDEyOjAwOjAwLjAwMFoiLA0KICAiY29uZGl0aW9ucyI6IFsNCiAgICB7ImJ1Y2tldCI6ICJzaWd2NGV4YW1wbGVidWNrZXQifSwNCiAgICBbInN0YXJ0cy13aXRoIiwgIiRrZXkiLCAidXNlci91c2VyMS8iXSwNCiAgICB7ImFjbCI6ICJwdWJsaWMtcmVhZCJ9LA0KICAgIHsic3VjY2Vzc19hY3Rpb25fcmVkaXJlY3QiOiAiaHR0cDovL3NpZ3Y0ZXhhbXBsZWJ1Y2tldC5zMy5hbWF6b25hd3MuY29tL3N1Y2Nlc3NmdWxfdXBsb2FkLmh0bWwifSwNCiAgICBbInN0YXJ0cy13aXRoIiwgIiRDb250ZW50LVR5cGUiLCAiaW1hZ2UvIl0sDQogICAgeyJ4LWFtei1tZXRhLXV1aWQiOiAiMTQzNjUxMjM2NTEyNzQifSwNCiAgICB7IngtYW16LXNlcnZlci1zaWRlLWVuY3J5cHRpb24iOiAiQUVTMjU2In0sDQogICAgWyJzdGFydHMtd2l0aCIsICIkeC1hbXotbWV0YS10YWciLCAiIl0sDQoNCiAgICB7IngtYW16LWNyZWRlbnRpYWwiOiAiQUtJQUlPU0ZPRE5ON0VYQU1QTEUvMjAxNTEyMjkvdXMtZWFzdC0xL3MzL2F3czRfcmVxdWVzdCJ9LA0KICAgIHsieC1hbXotYWxnb3JpdGhtIjogIkFXUzQtSE1BQy1TSEEyNTYifSwNCiAgICB7IngtYW16LWRhdGUiOiAiMjAxNTEyMjlUMDAwMDAwWiIgfQ0KICBdDQp9"
         let expectedSignature = "8afdbf4008c03f22c2cd3cdb72e4afbb1f6a588f3255ac628749a66d7f09699e"

--- a/Tests/SotoTests/Services/S3/S3ExtensionTests.swift
+++ b/Tests/SotoTests/Services/S3/S3ExtensionTests.swift
@@ -383,12 +383,18 @@ extension S3Tests {
         let request2 = try AWSHTTPRequest(operation: "PutObject", path: "/{Bucket}/{Key+}?x-id=PutObject", method: .PUT, input: input2, configuration: s3.config)
         XCTAssertEqual(request2.headers["Content-MD5"].first, "JhF7IaLE189bvT4/iv/iqg==")
     }
-    
+
     func testGeneratePresignedPost() async throws {
         // Based on the example here: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-post-example.html
 
         // Credentials are example only, from the above documentation
-        let client = AWSClient(credentialProvider: .static(accessKeyId: "AKIAIOSFODNN7EXAMPLE", secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"), httpClientProvider: .createNew)
+        let client = AWSClient(
+            credentialProvider: .static(
+                accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+                secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+            ),
+            httpClientProvider: .createNew
+        )
         let s3 = S3(client: client, region: .useast1)
 
         defer { try? client.syncShutdown() }
@@ -418,7 +424,14 @@ extension S3Tests {
 
         let date = Calendar(identifier: .gregorian).date(from: dateComponents)!
 
-        let presignedPost = try await s3.generatePresignedPost(key: "user/user1/${filename}", bucket: "sigv4examplebucket", fields: fields, conditions: conditions, expiresIn: expiresIn, date: date)
+        let presignedPost = try await s3.generatePresignedPost(
+            key: "user/user1/${filename}",
+            bucket: "sigv4examplebucket",
+            fields: fields,
+            conditions: conditions,
+            expiresIn: expiresIn,
+            date: date
+        )
 
         let expectedURL = "https://sigv4examplebucket.s3.us-east-1.amazonaws.com"
         let expectedCredential = "AKIAIOSFODNN7EXAMPLE/20151229/us-east-1/s3/aws4_request"
@@ -438,15 +451,27 @@ extension S3Tests {
         // Based on the example here: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-post-example.html
 
         // Credentials are example only, from the above documentation
-        let client = AWSClient(credentialProvider: .static(accessKeyId: "AKIAIOSFODNN7EXAMPLE", secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"), httpClientProvider: .createNew)
+        let client = AWSClient(
+            credentialProvider: .static(
+                accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+                secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+            ),
+            httpClientProvider: .createNew
+        )
         let s3 = S3(client: client, region: .useast1)
 
         defer { try? client.syncShutdown() }
 
         let policy = "eyAiZXhwaXJhdGlvbiI6ICIyMDE1LTEyLTMwVDEyOjAwOjAwLjAwMFoiLA0KICAiY29uZGl0aW9ucyI6IFsNCiAgICB7ImJ1Y2tldCI6ICJzaWd2NGV4YW1wbGVidWNrZXQifSwNCiAgICBbInN0YXJ0cy13aXRoIiwgIiRrZXkiLCAidXNlci91c2VyMS8iXSwNCiAgICB7ImFjbCI6ICJwdWJsaWMtcmVhZCJ9LA0KICAgIHsic3VjY2Vzc19hY3Rpb25fcmVkaXJlY3QiOiAiaHR0cDovL3NpZ3Y0ZXhhbXBsZWJ1Y2tldC5zMy5hbWF6b25hd3MuY29tL3N1Y2Nlc3NmdWxfdXBsb2FkLmh0bWwifSwNCiAgICBbInN0YXJ0cy13aXRoIiwgIiRDb250ZW50LVR5cGUiLCAiaW1hZ2UvIl0sDQogICAgeyJ4LWFtei1tZXRhLXV1aWQiOiAiMTQzNjUxMjM2NTEyNzQifSwNCiAgICB7IngtYW16LXNlcnZlci1zaWRlLWVuY3J5cHRpb24iOiAiQUVTMjU2In0sDQogICAgWyJzdGFydHMtd2l0aCIsICIkeC1hbXotbWV0YS10YWciLCAiIl0sDQoNCiAgICB7IngtYW16LWNyZWRlbnRpYWwiOiAiQUtJQUlPU0ZPRE5ON0VYQU1QTEUvMjAxNTEyMjkvdXMtZWFzdC0xL3MzL2F3czRfcmVxdWVzdCJ9LA0KICAgIHsieC1hbXotYWxnb3JpdGhtIjogIkFXUzQtSE1BQy1TSEEyNTYifSwNCiAgICB7IngtYW16LWRhdGUiOiAiMjAxNTEyMjlUMDAwMDAwWiIgfQ0KICBdDQp9"
-        let signingKey = try await s3.signingKey(date: "20151229", secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
-        let signature = try await s3.getSignature(policy: policy, signingKey: signingKey)
-        
+        let signingKey = try await s3.signingKey(
+            date: "20151229",
+            secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        )
+        let signature = try await s3.getSignature(
+            policy: policy,
+            signingKey: signingKey
+        )
+
         let expectedSignature = "8afdbf4008c03f22c2cd3cdb72e4afbb1f6a588f3255ac628749a66d7f09699e"
 
         XCTAssertEqual(signature, expectedSignature)
@@ -456,16 +481,24 @@ extension S3Tests {
         // Based on the example here: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-post-example.html
 
         // Credentials are example only, from the above documentation
-        let client = AWSClient(credentialProvider: .static(accessKeyId: "AKIAIOSFODNN7EXAMPLE", secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"), httpClientProvider: .createNew)
+        let client = AWSClient(
+            credentialProvider: .static(
+                accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+                secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+            ),
+            httpClientProvider: .createNew
+        )
         let s3 = S3(client: client, region: .useast1)
 
         defer { try? client.syncShutdown() }
 
-        let credential = try await s3.getPresignedPostCredential(date: "20151229", accessKeyId: "AKIAIOSFODNN7EXAMPLE")
-        
+        let credential = try await s3.getPresignedPostCredential(
+            date: "20151229",
+            accessKeyId: "AKIAIOSFODNN7EXAMPLE"
+        )
+
         let expectedCredential = "AKIAIOSFODNN7EXAMPLE/20151229/us-east-1/s3/aws4_request"
 
         XCTAssertEqual(credential, expectedCredential)
     }
-
 }

--- a/Tests/SotoTests/Services/S3/S3ExtensionTests.swift
+++ b/Tests/SotoTests/Services/S3/S3ExtensionTests.swift
@@ -447,7 +447,7 @@ extension S3Tests {
         XCTAssertNotNil(presignedPost.fields["Policy"])
     }
 
-    func testGetSignature() async throws {
+    func testGetSignature() {
         // Based on the example here: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-post-example.html
 
         // Credentials are example only, from the above documentation
@@ -463,11 +463,11 @@ extension S3Tests {
         defer { try? client.syncShutdown() }
 
         let policy = "eyAiZXhwaXJhdGlvbiI6ICIyMDE1LTEyLTMwVDEyOjAwOjAwLjAwMFoiLA0KICAiY29uZGl0aW9ucyI6IFsNCiAgICB7ImJ1Y2tldCI6ICJzaWd2NGV4YW1wbGVidWNrZXQifSwNCiAgICBbInN0YXJ0cy13aXRoIiwgIiRrZXkiLCAidXNlci91c2VyMS8iXSwNCiAgICB7ImFjbCI6ICJwdWJsaWMtcmVhZCJ9LA0KICAgIHsic3VjY2Vzc19hY3Rpb25fcmVkaXJlY3QiOiAiaHR0cDovL3NpZ3Y0ZXhhbXBsZWJ1Y2tldC5zMy5hbWF6b25hd3MuY29tL3N1Y2Nlc3NmdWxfdXBsb2FkLmh0bWwifSwNCiAgICBbInN0YXJ0cy13aXRoIiwgIiRDb250ZW50LVR5cGUiLCAiaW1hZ2UvIl0sDQogICAgeyJ4LWFtei1tZXRhLXV1aWQiOiAiMTQzNjUxMjM2NTEyNzQifSwNCiAgICB7IngtYW16LXNlcnZlci1zaWRlLWVuY3J5cHRpb24iOiAiQUVTMjU2In0sDQogICAgWyJzdGFydHMtd2l0aCIsICIkeC1hbXotbWV0YS10YWciLCAiIl0sDQoNCiAgICB7IngtYW16LWNyZWRlbnRpYWwiOiAiQUtJQUlPU0ZPRE5ON0VYQU1QTEUvMjAxNTEyMjkvdXMtZWFzdC0xL3MzL2F3czRfcmVxdWVzdCJ9LA0KICAgIHsieC1hbXotYWxnb3JpdGhtIjogIkFXUzQtSE1BQy1TSEEyNTYifSwNCiAgICB7IngtYW16LWRhdGUiOiAiMjAxNTEyMjlUMDAwMDAwWiIgfQ0KICBdDQp9"
-        let signingKey = try await s3.signingKey(
+        let signingKey = s3.signingKey(
             date: "20151229",
             secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
         )
-        let signature = try await s3.getSignature(
+        let signature = s3.getSignature(
             policy: policy,
             signingKey: signingKey
         )
@@ -477,7 +477,7 @@ extension S3Tests {
         XCTAssertEqual(signature, expectedSignature)
     }
 
-    func testGetPresignedPostCredential() async throws {
+    func testGetPresignedPostCredential() {
         // Based on the example here: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-post-example.html
 
         // Credentials are example only, from the above documentation
@@ -492,7 +492,7 @@ extension S3Tests {
 
         defer { try? client.syncShutdown() }
 
-        let credential = try await s3.getPresignedPostCredential(
+        let credential = s3.getPresignedPostCredential(
             date: "20151229",
             accessKeyId: "AKIAIOSFODNN7EXAMPLE"
         )

--- a/Tests/SotoTests/Services/S3/S3ExtensionTests.swift
+++ b/Tests/SotoTests/Services/S3/S3ExtensionTests.swift
@@ -391,6 +391,8 @@ extension S3Tests {
         let client = AWSClient(credentialProvider: .static(accessKeyId: "AKIAIOSFODNN7EXAMPLE", secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"), httpClientProvider: .createNew)
         let s3 = S3(client: client, region: .useast1)
 
+        defer { try? client.syncShutdown() }
+
         let fields = [
             "acl": "public-read",
             "success_action_redirect": "http://sigv4examplebucket.s3.amazonaws.com/successful_upload.html",
@@ -432,7 +434,6 @@ extension S3Tests {
         XCTAssertEqual(presignedPost.fields["x-amz-algorithm"], expectedAlgorithm)
         XCTAssertEqual(presignedPost.fields["x-amz-date"], expectedDate)
 
-        try? await client.shutdown()
         // Boto3 Output
         // {'url': 'https://sigv4examplebucket.s3.amazonaws.com/', 'fields': {'acl': 'public-read', 'success_action_redirect': 'http://sigv4examplebucket.s3.amazonaws.com/successful_upload.html', 'x-amz-meta-uuid': '14365123651274', 'x-amz-server-side-encryption': 'AES256', 'key': 'user/user1/${filename}', 'AWSAccessKeyId': 'AKIAIOSFODNN7EXAMPLE', 'policy': 'eyJleHBpcmF0aW9uIjogIjIwMjQtMDQtMDJUMDM6NTE6MDBaIiwgImNvbmRpdGlvbnMiOiBbeyJhY2wiOiAicHVibGljLXJlYWQifSwgeyJzdWNjZXNzX2FjdGlvbl9yZWRpcmVjdCI6ICJodHRwOi8vc2lndjRleGFtcGxlYnVja2V0LnMzLmFtYXpvbmF3cy5jb20vc3VjY2Vzc2Z1bF91cGxvYWQuaHRtbCJ9LCB7IngtYW16LW1ldGEtdXVpZCI6ICIxNDM2NTEyMzY1MTI3NCJ9LCB7IngtYW16LXNlcnZlci1zaWRlLWVuY3J5cHRpb24iOiAiQUVTMjU2In0sIFsic3RhcnRzLXdpdGgiLCAiJENvbnRlbnQtVHlwZSIsICJpbWFnZS8iXSwgWyJzdGFydHMtd2l0aCIsICIkeC1hbXotbWV0YS10YWciLCAiIl0sIHsiYnVja2V0IjogInNpZ3Y0ZXhhbXBsZWJ1Y2tldCJ9LCBbInN0YXJ0cy13aXRoIiwgIiRrZXkiLCAidXNlci91c2VyMS8iXV19', 'signature': 'sSXUD8RpSI7x/Vo/SJ0vTtc98Qo='}
     }

--- a/Tests/SotoTests/Services/S3/S3ExtensionTests.swift
+++ b/Tests/SotoTests/Services/S3/S3ExtensionTests.swift
@@ -383,4 +383,6 @@ extension S3Tests {
         let request2 = try AWSHTTPRequest(operation: "PutObject", path: "/{Bucket}/{Key+}?x-id=PutObject", method: .PUT, input: input2, configuration: s3.config)
         XCTAssertEqual(request2.headers["Content-MD5"].first, "JhF7IaLE189bvT4/iv/iqg==")
     }
+
+
 }


### PR DESCRIPTION
Adds a generatePresignedPost method to the S3 service, similar to [what is available in Boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/generate_presigned_post.html).

Amazon docs for this type of request live [here](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-UsingHTTPPOST.html).

Remaining work:
- [x] Add error handling
- [x] Add documentation
- [x] Add tests