### PR TITLE
fix: make PresignedPostResponse fields public

### DIFF
--- a/Sources/Soto/Extensions/S3/S3+presignedPost.swift
+++ b/Sources/Soto/Extensions/S3/S3+presignedPost.swift
@@ -67,8 +67,8 @@ extension S3 {
     /// An encodable struct that represents the URL and form fields to use in a
     /// presigned POST request to S3
     public struct PresignedPostResponse: Encodable {
-        let url: URL
-        let fields: [String: String]
+        public let url: URL
+        public let fields: [String: String]
     }
 
     ///  Builds the url and the form fields used for a presigned s3 post


### PR DESCRIPTION
While reviewing the 7.x.x branch with my own project, I realized that the url and fields properties of the PresignedPostResponse struct were declared internal, but they need to be public to be useful outside of Soto.