### PR TITLE
fix: handle session tokens in generatePresignedPost

### DIFF
--- a/Sources/Soto/Extensions/S3/S3+presignedPost.swift
+++ b/Sources/Soto/Extensions/S3/S3+presignedPost.swift
@@ -189,6 +189,11 @@ extension S3 {
         fields["x-amz-date"] = longDate
         fields["x-amz-credential"] = presignedPostCredential
 
+        if let sessionToken = clientCredentials.sessionToken {
+            conditions.append(.match("x-amz-security-token", sessionToken))
+            fields["x-amz-security-token"] = sessionToken
+        }
+
         // Create the policy and add to fields
         let policy = PostPolicy(expiration: date.addingTimeInterval(expiresIn), conditions: conditions)
         let stringToSign = try policy.stringToSign()

--- a/Tests/SotoTests/Services/S3/S3ExtensionTests.swift
+++ b/Tests/SotoTests/Services/S3/S3ExtensionTests.swift
@@ -509,7 +509,7 @@ extension S3Tests {
         )
 
         let s3 = S3(client: client, region: .useast1)
-        
+
         defer { try? client.syncShutdown() }
 
         let fields = [

--- a/Tests/SotoTests/Services/S3/S3ExtensionTests.swift
+++ b/Tests/SotoTests/Services/S3/S3ExtensionTests.swift
@@ -499,8 +499,8 @@ extension S3Tests {
         XCTAssertEqual(credential, expectedCredential)
     }
 
-    func testSessionToken() {
-        let clent = AWSClient(
+    func testGeneratePresignedPostWithSessionToken() async throws {
+        let client = AWSClient(
             credentialProvider: .static(
                 accessKeyId: "AKIAIOSFODNN7EXAMPLE",
                 secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
@@ -546,6 +546,6 @@ extension S3Tests {
             date: date
         )
 
-        XCTAssertEqual(presignedPost.fields["x-amz-session-token"], "EXAMPLESESSIONTOKEN")
+        XCTAssertEqual(presignedPost.fields["x-amz-security-token"], "EXAMPLESESSIONTOKEN")
     }
 }

--- a/Tests/SotoTests/Services/S3/S3ExtensionTests.swift
+++ b/Tests/SotoTests/Services/S3/S3ExtensionTests.swift
@@ -498,4 +498,54 @@ extension S3Tests {
 
         XCTAssertEqual(credential, expectedCredential)
     }
+
+    func testSessionToken() {
+        let clent = AWSClient(
+            credentialProvider: .static(
+                accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+                secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                sessionToken: "EXAMPLESESSIONTOKEN"
+            )
+        )
+
+        let s3 = S3(client: client, region: .useast1)
+        
+        defer { try? client.syncShutdown() }
+
+        let fields = [
+            "acl": "public-read",
+            "success_action_redirect": "http://sigv4examplebucket.s3.amazonaws.com/successful_upload.html",
+            "x-amz-meta-uuid": "14365123651274",
+            "x-amz-server-side-encryption": "AES256",
+        ]
+
+        let conditions: [S3.PostPolicyCondition] = [
+            .match("acl", "public-read"),
+            .match("success_action_redirect", "http://sigv4examplebucket.s3.amazonaws.com/successful_upload.html"),
+            .match("x-amz-meta-uuid", "14365123651274"),
+            .match("x-amz-server-side-encryption", "AES256"),
+            .rule("starts-with", "$Content-Type", "image/"),
+            .rule("starts-with", "$x-amz-meta-tag", "")
+        ]
+
+        let expiresIn = 36.0 * 60.0 * 60.0
+        var dateComponents = DateComponents()
+        dateComponents.year = 2015
+        dateComponents.month = 12
+        dateComponents.day = 29
+        dateComponents.timeZone = TimeZone(secondsFromGMT: 0)!
+
+        let date = Calendar(identifier: .gregorian).date(from: dateComponents)!
+
+        let presignedPost = try await s3.generatePresignedPost(
+            key: "user/user1/${filename}",
+            bucket: "sigv4examplebucket",
+            fields: fields,
+            conditions: conditions,
+            expiresIn: expiresIn,
+            date: date
+        )
+
+        XCTAssertEqual(presignedPost.fields["x-amz-session-token"], "EXAMPLESESSIONTOKEN")
+    }
 }


### PR DESCRIPTION
Checks for the presence of a session token, and adds it to the presigned-POST request if it exists.