### PR TITLE
DynamoDB Codable date encoding strategy

### DIFF
--- a/Sources/Soto/Extensions/DynamoDB/DynamoDB+Codable.swift
+++ b/Sources/Soto/Extensions/DynamoDB/DynamoDB+Codable.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2021 the Soto project authors
+// Copyright (c) 2017-2025 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/Soto/Extensions/DynamoDB/DynamoDBDecoder.swift
+++ b/Sources/Soto/Extensions/DynamoDB/DynamoDBDecoder.swift
@@ -15,12 +15,53 @@
 import Foundation
 
 public class DynamoDBDecoder {
-    public var userInfo: [CodingUserInfoKey: Any] = [:]
+    /// The strategy to use for decoding `Date` values.
+    public enum DateDecodingStrategy: Sendable {
+        /// Defer to `Date` for decoding. This is the default strategy.
+        case deferredToDate
+
+        /// Decode the `Date` as a UNIX timestamp from a JSON number.
+        case secondsSince1970
+
+        /// Decode the `Date` as UNIX millisecond timestamp from a JSON number.
+        case millisecondsSince1970
+
+        /// Decode the `Date` as an ISO-8601-formatted string (in RFC 3339 format).
+        @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+        case iso8601
+
+        /// Decode the `Date` as a custom value decoded by the given closure.
+        @preconcurrency
+        case custom(@Sendable (_ decoder: Decoder) throws -> Date)
+    }
+
+    /// Options set on the top-level encoder to pass down the decoding hierarchy.
+    fileprivate struct Options {
+        var dateDecodingStrategy: DateDecodingStrategy = .deferredToDate
+        var userInfo: [CodingUserInfoKey: any Sendable] = [:]
+    }
+    fileprivate var options: Options = .init()
+
+    public var dateDecodingStrategy: DateDecodingStrategy {
+        get { self.options.dateDecodingStrategy }
+        set { self.options.dateDecodingStrategy = newValue }
+    }
+    public var userInfo: [CodingUserInfoKey: any Sendable] {
+        get { self.options.userInfo }
+        _modify {
+            var value = self.options.userInfo
+            defer {
+                options.userInfo = value
+            }
+            yield &value
+        }
+        set { self.options.userInfo = newValue }
+    }
 
     public init() {}
 
     public func decode<T: Decodable>(_ type: T.Type, from attributes: [String: DynamoDB.AttributeValue]) throws -> T {
-        let decoder = _DynamoDBDecoder(referencing: attributes, userInfo: userInfo)
+        let decoder = _DynamoDBDecoder(referencing: attributes, options: options)
         let value = try T(from: decoder)
         return value
     }
@@ -52,13 +93,15 @@ private struct _DecoderStorage {
 
 private class _DynamoDBDecoder: Decoder {
     var codingPath: [CodingKey]
-    var userInfo: [CodingUserInfoKey: Any]
+    var options: DynamoDBDecoder.Options
     let attributes: [String: DynamoDB.AttributeValue]
     var storage: _DecoderStorage
-
-    init(referencing: [String: DynamoDB.AttributeValue], userInfo: [CodingUserInfoKey: Any], codingPath: [CodingKey] = []) {
+    var userInfo: [CodingUserInfoKey: Any] {
+        options.userInfo
+    }
+    init(referencing: [String: DynamoDB.AttributeValue], options: DynamoDBDecoder.Options, codingPath: [CodingKey] = []) {
         self.codingPath = codingPath
-        self.userInfo = userInfo
+        self.options = options
         self.attributes = referencing
         self.storage = _DecoderStorage(.m(self.attributes))
     }
@@ -197,7 +240,7 @@ private class _DynamoDBDecoder: Decoder {
             guard case .m(let attributes) = value else {
                 throw DecodingError.dataCorrupted(.init(codingPath: self.codingPath, debugDescription: "Expected a map attribute"))
             }
-            return _DynamoDBDecoder(referencing: attributes, userInfo: self.decoder.userInfo, codingPath: self.decoder.codingPath)
+            return _DynamoDBDecoder(referencing: attributes, options: self.decoder.options, codingPath: self.decoder.codingPath)
         }
 
         func superDecoder() throws -> Decoder {
@@ -647,6 +690,41 @@ extension _DynamoDBDecoder {
         return value
     }
 
+    func unbox(_ attribute: DynamoDB.AttributeValue, as type: Date.Type) throws -> Date {
+        switch self.options.dateDecodingStrategy {
+        case .deferredToDate:
+            self.storage.pushAttribute(attribute)
+            defer { self.storage.popAttribute() }
+            return try Date(from: self)
+        case .millisecondsSince1970:
+            let value = try self.unbox(attribute, as: Double.self)
+            return Date(timeIntervalSince1970: value / 1000)
+        case .secondsSince1970:
+            let value = try self.unbox(attribute, as: Double.self)
+            return Date(timeIntervalSince1970: value)
+        case .iso8601:
+            let string = try self.unbox(attribute, as: String.self)
+            let date: Date?
+            #if compiler(<6.0)
+            date = _iso8601DateFormatter.date(from: string)
+            #else
+            if #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) {
+                date = try? Date(string, strategy: .iso8601)
+            } else {
+                date = _iso8601DateFormatter.date(from: string)
+            }
+            #endif
+            guard let date else {
+                throw DecodingError.dataCorrupted(
+                    DecodingError.Context(codingPath: self.codingPath, debugDescription: "Expected date string to be ISO8601-formatted.")
+                )
+            }
+            return date
+        case .custom(let closure):
+            return try closure(self)
+        }
+    }
+
     func unbox<T>(_ attribute: DynamoDB.AttributeValue, as type: T.Type) throws -> T where T: Decodable {
         try self.unbox_(attribute, as: T.self) as! T
     }
@@ -654,6 +732,8 @@ extension _DynamoDBDecoder {
     func unbox_(_ attribute: DynamoDB.AttributeValue, as type: Decodable.Type) throws -> Any {
         if type == AWSBase64Data.self {
             return try self.unbox(attribute, as: AWSBase64Data.self)
+        } else if type == Date.self {
+            return try self.unbox(attribute, as: Date.self)
         } else {
             self.storage.pushAttribute(attribute)
             defer { self.storage.popAttribute() }
@@ -661,3 +741,17 @@ extension _DynamoDBDecoder {
         }
     }
 }
+
+#if compiler(>=5.10)
+nonisolated(unsafe) let _iso8601DateFormatter: ISO8601DateFormatter = {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = .withInternetDateTime
+    return formatter
+}()
+#else
+let _iso8601DateFormatter: ISO8601DateFormatter = {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = .withInternetDateTime
+    return formatter
+}()
+#endif

--- a/Sources/Soto/Extensions/DynamoDB/DynamoDBDecoder.swift
+++ b/Sources/Soto/Extensions/DynamoDB/DynamoDBDecoder.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2020 the Soto project authors
+// Copyright (c) 2017-2025 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/Soto/Extensions/DynamoDB/DynamoDBEncoder.swift
+++ b/Sources/Soto/Extensions/DynamoDB/DynamoDBEncoder.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2020 the Soto project authors
+// Copyright (c) 2017-2025 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/Soto/Extensions/DynamoDB/DynamoDBEncoder.swift
+++ b/Sources/Soto/Extensions/DynamoDB/DynamoDBEncoder.swift
@@ -15,12 +15,53 @@
 import Foundation
 
 public class DynamoDBEncoder {
-    public var userInfo: [CodingUserInfoKey: Any] = [:]
+    /// The strategy to use for encoding `Date` values.
+    public enum DateEncodingStrategy: Sendable {
+        /// Defer to `Date` for encoding. This is the default strategy.
+        case deferredToDate
+
+        /// Decode the `Date` as a UNIX timestamp from a JSON number.
+        case secondsSince1970
+
+        /// Decode the `Date` as UNIX millisecond timestamp from a JSON number.
+        case millisecondsSince1970
+
+        /// Decode the `Date` as an ISO-8601-formatted string (in RFC 3339 format).
+        @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+        case iso8601
+
+        /// Decode the `Date` as a custom value decoded by the given closure.
+        @preconcurrency
+        case custom(@Sendable (Date, Encoder) -> DynamoDB.AttributeValue)
+    }
+
+    /// Options set on the top-level encoder to pass down the encoding hierarchy.
+    fileprivate struct Options {
+        var dateEncodingStrategy: DateEncodingStrategy = .deferredToDate
+        var userInfo: [CodingUserInfoKey: any Sendable] = [:]
+    }
+    fileprivate var options: Options = .init()
+
+    public var dateEncodingStrategy: DateEncodingStrategy {
+        get { self.options.dateEncodingStrategy }
+        set { self.options.dateEncodingStrategy = newValue }
+    }
+    public var userInfo: [CodingUserInfoKey: any Sendable] {
+        get { self.options.userInfo }
+        _modify {
+            var value = self.options.userInfo
+            defer {
+                options.userInfo = value
+            }
+            yield &value
+        }
+        set { self.options.userInfo = newValue }
+    }
 
     public init() {}
 
     public func encode(_ value: some Encodable) throws -> [String: DynamoDB.AttributeValue] {
-        let encoder = _DynamoDBEncoder(userInfo: userInfo)
+        let encoder = _DynamoDBEncoder(options: options)
         try value.encode(to: encoder)
         return try encoder.storage.collapse()
     }
@@ -121,14 +162,17 @@ private struct _EncoderStorage {
     }
 }
 
-class _DynamoDBEncoder: Encoder {
+private class _DynamoDBEncoder: Encoder {
     var codingPath: [CodingKey]
-    var userInfo: [CodingUserInfoKey: Any]
     fileprivate var storage: _EncoderStorage
+    fileprivate let options: DynamoDBEncoder.Options
+    var userInfo: [CodingUserInfoKey: Any] {
+        self.options.userInfo
+    }
 
-    init(userInfo: [CodingUserInfoKey: Any], codingPath: [CodingKey] = []) {
+    fileprivate init(options: DynamoDBEncoder.Options, codingPath: [CodingKey] = []) {
         self.codingPath = codingPath
-        self.userInfo = userInfo
+        self.options = options
         self.storage = _EncoderStorage()
     }
 
@@ -458,10 +502,36 @@ extension _DynamoDBEncoder {
         .b(data)
     }
 
+    func box(_ date: Date) throws -> DynamoDB.AttributeValue {
+        switch self.options.dateEncodingStrategy {
+        case .deferredToDate:
+            try date.encode(to: self)
+            return self.storage.popContainer().attribute
+        case .millisecondsSince1970:
+            return .n((date.timeIntervalSince1970 * 1000).description)
+        case .secondsSince1970:
+            return .n(date.timeIntervalSince1970.description)
+        case .iso8601:
+            #if compiler(<6.0)
+            return .s(_iso8601DateFormatter.string(from: date))
+            #else
+            if #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) {
+                return .s(date.formatted(.iso8601))
+            } else {
+                return .s(_iso8601DateFormatter.string(from: date))
+            }
+            #endif
+        case .custom(let closure):
+            return closure(date, self)
+        }
+    }
+
     func box(_ value: Encodable) throws -> DynamoDB.AttributeValue {
         let type = Swift.type(of: value)
         if type == AWSBase64Data.self {
             return try self.box(value as! AWSBase64Data)
+        } else if type == Date.self {
+            return try self.box(value as! Date)
         } else {
             try value.encode(to: self)
             return self.storage.popContainer().attribute
@@ -482,7 +552,7 @@ private class _DynamoDBReferencingEncoder: _DynamoDBEncoder {
 
     init(encoder: _DynamoDBEncoder, container: _EncoderKeyedContainer) {
         self.container = container
-        super.init(userInfo: encoder.userInfo, codingPath: encoder.codingPath)
+        super.init(options: encoder.options, codingPath: encoder.codingPath)
     }
 
     deinit {

--- a/Tests/SotoTests/Services/DynamoDB/DynamoDBCodableTests.swift
+++ b/Tests/SotoTests/Services/DynamoDB/DynamoDBCodableTests.swift
@@ -27,15 +27,39 @@ extension DynamoDBTests {
             let age: Int
             let address: String
             let pets: [String]?
+            let date: Date
         }
         let id = UUID().uuidString
-        let test = TestObject(id: id, name: "John", surname: "Smith", age: 32, address: "1 Park Lane", pets: ["zebra", "cat", "dog", "cat"])
-
+        let test = TestObject(id: id, name: "John", surname: "Smith", age: 32, address: "1 Park Lane", pets: ["zebra", "cat", "dog", "cat"], date: Date(timeIntervalSinceReferenceDate: 134500.5))
+        let decoder = DynamoDBDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        let encoder = DynamoDBEncoder()
+        encoder.dateEncodingStrategy = .secondsSince1970
         let putRequest = DynamoDB.PutItemCodableInput(item: test, tableName: Self.tableName)
-        _ = try await Self.dynamoDB.putItem(putRequest, logger: TestEnvironment.logger)
+        _ = try await Self.dynamoDB.putItem(putRequest, encoder: encoder, logger: TestEnvironment.logger)
 
         let getRequest = DynamoDB.GetItemInput(consistentRead: true, key: ["id": .s(id)], tableName: Self.tableName)
-        let response = try await Self.dynamoDB.getItem(getRequest, type: TestObject.self, logger: TestEnvironment.logger)
+        let response = try await Self.dynamoDB.getItem(getRequest, type: TestObject.self, decoder: decoder, logger: TestEnvironment.logger)
+
+        XCTAssertEqual(test, response.item)
+    }
+
+    func testCodablePutGetWithISO8601Date() async throws {
+        struct TestObject: Codable, Equatable {
+            let id: String
+            let date: Date
+        }
+        let id = UUID().uuidString
+        let test = TestObject(id: id, date: Date(timeIntervalSinceReferenceDate: 134500))
+        let decoder = DynamoDBDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let encoder = DynamoDBEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let putRequest = DynamoDB.PutItemCodableInput(item: test, tableName: Self.tableName)
+        _ = try await Self.dynamoDB.putItem(putRequest, encoder: encoder, logger: TestEnvironment.logger)
+
+        let getRequest = DynamoDB.GetItemInput(consistentRead: true, key: ["id": .s(id)], tableName: Self.tableName)
+        let response = try await Self.dynamoDB.getItem(getRequest, type: TestObject.self, decoder: decoder, logger: TestEnvironment.logger)
 
         XCTAssertEqual(test, response.item)
     }

--- a/Tests/SotoTests/Services/DynamoDB/DynamoDBCodableTests.swift
+++ b/Tests/SotoTests/Services/DynamoDB/DynamoDBCodableTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2020 the Soto project authors
+// Copyright (c) 2017-2025 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -30,7 +30,15 @@ extension DynamoDBTests {
             let date: Date
         }
         let id = UUID().uuidString
-        let test = TestObject(id: id, name: "John", surname: "Smith", age: 32, address: "1 Park Lane", pets: ["zebra", "cat", "dog", "cat"], date: Date(timeIntervalSinceReferenceDate: 134500.5))
+        let test = TestObject(
+            id: id,
+            name: "John",
+            surname: "Smith",
+            age: 32,
+            address: "1 Park Lane",
+            pets: ["zebra", "cat", "dog", "cat"],
+            date: Date(timeIntervalSinceReferenceDate: 134500.5)
+        )
         let decoder = DynamoDBDecoder()
         decoder.dateDecodingStrategy = .secondsSince1970
         let encoder = DynamoDBEncoder()


### PR DESCRIPTION
- Add encoding/decoding strategy to DynamoDBEncoder/Decoder
- Add encoder/decoder parameter to DynamoDB codable calls
- BREAKING CHANGE: Move encoding of additionalAttributes in `UpdateItemCodableInput` to `updateItem` call instead of `init`. This means `UpdateItemCodableInput` has an additional generic parameter  